### PR TITLE
feat: adds initial content for CIS Fedora and CCC

### DIFF
--- a/bundles/ampel-branch-protection.yaml
+++ b/bundles/ampel-branch-protection.yaml
@@ -1,0 +1,3 @@
+layers:
+  - governance/catalogs/ampel-branch-protection-catalog.yaml
+  - governance/policies/ampel-branch-protection-policy.yaml

--- a/bundles/cis-fedora-l1-server.yaml
+++ b/bundles/cis-fedora-l1-server.yaml
@@ -1,0 +1,4 @@
+layers:
+  - governance/guidance/cis-fedora-l1-guidance.yaml
+  - governance/catalogs/cis-fedora-l1-server-catalog.yaml
+  - governance/policies/cis-fedora-l1-server-policy.yaml

--- a/bundles/cis-fedora-l1-workstation.yaml
+++ b/bundles/cis-fedora-l1-workstation.yaml
@@ -1,0 +1,4 @@
+layers:
+  - governance/guidance/cis-fedora-l1-guidance.yaml
+  - governance/catalogs/cis-fedora-l1-workstation-catalog.yaml
+  - governance/policies/cis-fedora-l1-workstation-policy.yaml

--- a/governance/catalogs/cis-fedora-l1-server-catalog.yaml
+++ b/governance/catalogs/cis-fedora-l1-server-catalog.yaml
@@ -1,0 +1,2221 @@
+title: CIS Fedora Linux - Level 1 Server
+metadata:
+  id: cis-fedora-l1-server
+  type: ControlCatalog
+  gemara-version: 0.24.0
+  description: Control catalog derived from the CIS Fedora Linux Level 1 Server Benchmark
+  author:
+    id: complytime
+    name: ComplyTime
+    type: Software
+  applicability-groups:
+    - id: fedora-linux
+      title: Fedora Linux
+      description: Fedora Linux operating system
+groups:
+  - id: initial-setup
+    title: Initial Setup
+    description: Filesystem, software updates, SELinux, boot, kernel, crypto, and banner configuration
+  - id: services
+    title: Services
+    description: Network services, client packages, and time synchronization configuration
+  - id: network
+    title: Network Configuration
+    description: Kernel modules, IPv4, and IPv6 network stack configuration
+  - id: firewall
+    title: Host-Based Firewall
+    description: Firewall package installation and traffic filtering configuration
+  - id: access-auth
+    title: Access, Authentication, and Authorization
+    description: SSH, sudo, PAM, password, user account, and shell configuration
+  - id: logging
+    title: Logging and Auditing
+    description: System logging, journald, and file integrity monitoring configuration
+  - id: maintenance
+    title: System Maintenance
+    description: File permissions, user/group integrity, and home directory configuration
+  - id: operations
+    title: Operations
+    description: Operational tasks required for configuration application
+controls:
+  - id: cis_fedora_1-1.1.1
+    title: Ensure Cramfs Kernel Module Is Not Available
+    objective: Ensure Cramfs Kernel Module Is Not Available
+    group: initial-setup
+    assessment-requirements:
+      - id: kernel_module_cramfs_disabled
+        text: Cramfs Kernel Module Is Not Available MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-1.1.1.9
+    title: Ensure IEEE 1394 (FireWire) Kernel Module Is Not Available
+    objective: Ensure IEEE 1394 (FireWire) Kernel Module Is Not Available
+    group: initial-setup
+    assessment-requirements:
+      - id: kernel_module_firewire-core_disabled
+        text: IEEE 1394 (FireWire) Kernel Module Is Not Available MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-1.1.1.10
+    title: Ensure USB Storage Driver Is Not Available
+    objective: Ensure USB Storage Driver Is Not Available
+    group: initial-setup
+    assessment-requirements:
+      - id: kernel_module_usb-storage_disabled
+        text: USB Storage Driver Is Not Available MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-1.1.2
+    title: Ensure Freevxfs Kernel Module Is Not Available
+    objective: Ensure Freevxfs Kernel Module Is Not Available
+    group: initial-setup
+    assessment-requirements:
+      - id: kernel_module_freevxfs_disabled
+        text: Freevxfs Kernel Module Is Not Available MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-1.1.3
+    title: Ensure Hfs Kernel Module Is Not Available
+    objective: Ensure Hfs Kernel Module Is Not Available
+    group: initial-setup
+    assessment-requirements:
+      - id: kernel_module_hfs_disabled
+        text: Hfs Kernel Module Is Not Available MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-1.1.4
+    title: Ensure Hfsplus Kernel Module Is Not Available
+    objective: Ensure Hfsplus Kernel Module Is Not Available
+    group: initial-setup
+    assessment-requirements:
+      - id: kernel_module_hfsplus_disabled
+        text: Hfsplus Kernel Module Is Not Available MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-1.1.5
+    title: Ensure Jffs2 Kernel Module Is Not Available
+    objective: Ensure Jffs2 Kernel Module Is Not Available
+    group: initial-setup
+    assessment-requirements:
+      - id: kernel_module_jffs2_disabled
+        text: Jffs2 Kernel Module Is Not Available MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-1.2.1.1
+    title: CIS Fedora 1 - 1.2.1.1
+    objective: CIS Fedora 1 - 1.2.1.1
+    group: initial-setup
+    assessment-requirements:
+      - id: partition_for_tmp
+        text: CIS Fedora 1 - 1.2.1.1 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-1.2.1.2
+    title: CIS Fedora 1 - 1.2.1.2
+    objective: CIS Fedora 1 - 1.2.1.2
+    group: initial-setup
+    assessment-requirements:
+      - id: mount_option_tmp_nodev
+        text: CIS Fedora 1 - 1.2.1.2 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-1.2.1.3
+    title: CIS Fedora 1 - 1.2.1.3
+    objective: CIS Fedora 1 - 1.2.1.3
+    group: initial-setup
+    assessment-requirements:
+      - id: mount_option_tmp_nosuid
+        text: CIS Fedora 1 - 1.2.1.3 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-1.2.1.4
+    title: CIS Fedora 1 - 1.2.1.4
+    objective: CIS Fedora 1 - 1.2.1.4
+    group: initial-setup
+    assessment-requirements:
+      - id: mount_option_tmp_noexec
+        text: CIS Fedora 1 - 1.2.1.4 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-1.2.2.1
+    title: CIS Fedora 1 - 1.2.2.1
+    objective: CIS Fedora 1 - 1.2.2.1
+    group: initial-setup
+    assessment-requirements:
+      - id: partition_for_dev_shm
+        text: CIS Fedora 1 - 1.2.2.1 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-1.2.2.2
+    title: CIS Fedora 1 - 1.2.2.2
+    objective: CIS Fedora 1 - 1.2.2.2
+    group: initial-setup
+    assessment-requirements:
+      - id: mount_option_dev_shm_nodev
+        text: CIS Fedora 1 - 1.2.2.2 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-1.2.2.3
+    title: CIS Fedora 1 - 1.2.2.3
+    objective: CIS Fedora 1 - 1.2.2.3
+    group: initial-setup
+    assessment-requirements:
+      - id: mount_option_dev_shm_nosuid
+        text: CIS Fedora 1 - 1.2.2.3 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-1.2.2.4
+    title: CIS Fedora 1 - 1.2.2.4
+    objective: CIS Fedora 1 - 1.2.2.4
+    group: initial-setup
+    assessment-requirements:
+      - id: mount_option_dev_shm_noexec
+        text: CIS Fedora 1 - 1.2.2.4 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-1.2.3.2
+    title: CIS Fedora 1 - 1.2.3.2
+    objective: CIS Fedora 1 - 1.2.3.2
+    group: initial-setup
+    assessment-requirements:
+      - id: mount_option_home_nodev
+        text: CIS Fedora 1 - 1.2.3.2 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-1.2.3.3
+    title: CIS Fedora 1 - 1.2.3.3
+    objective: CIS Fedora 1 - 1.2.3.3
+    group: initial-setup
+    assessment-requirements:
+      - id: mount_option_home_nosuid
+        text: CIS Fedora 1 - 1.2.3.3 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-1.2.4.2
+    title: CIS Fedora 1 - 1.2.4.2
+    objective: CIS Fedora 1 - 1.2.4.2
+    group: initial-setup
+    assessment-requirements:
+      - id: mount_option_var_nodev
+        text: CIS Fedora 1 - 1.2.4.2 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-1.2.4.3
+    title: CIS Fedora 1 - 1.2.4.3
+    objective: CIS Fedora 1 - 1.2.4.3
+    group: initial-setup
+    assessment-requirements:
+      - id: mount_option_var_nosuid
+        text: CIS Fedora 1 - 1.2.4.3 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-1.2.5.2
+    title: CIS Fedora 1 - 1.2.5.2
+    objective: CIS Fedora 1 - 1.2.5.2
+    group: initial-setup
+    assessment-requirements:
+      - id: mount_option_var_tmp_nodev
+        text: CIS Fedora 1 - 1.2.5.2 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-1.2.5.3
+    title: CIS Fedora 1 - 1.2.5.3
+    objective: CIS Fedora 1 - 1.2.5.3
+    group: initial-setup
+    assessment-requirements:
+      - id: mount_option_var_tmp_nosuid
+        text: CIS Fedora 1 - 1.2.5.3 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-1.2.5.4
+    title: CIS Fedora 1 - 1.2.5.4
+    objective: CIS Fedora 1 - 1.2.5.4
+    group: initial-setup
+    assessment-requirements:
+      - id: mount_option_var_tmp_noexec
+        text: CIS Fedora 1 - 1.2.5.4 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-1.2.6.2
+    title: CIS Fedora 1 - 1.2.6.2
+    objective: CIS Fedora 1 - 1.2.6.2
+    group: initial-setup
+    assessment-requirements:
+      - id: mount_option_var_log_nodev
+        text: CIS Fedora 1 - 1.2.6.2 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-1.2.6.3
+    title: CIS Fedora 1 - 1.2.6.3
+    objective: CIS Fedora 1 - 1.2.6.3
+    group: initial-setup
+    assessment-requirements:
+      - id: mount_option_var_log_nosuid
+        text: CIS Fedora 1 - 1.2.6.3 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-1.2.6.4
+    title: CIS Fedora 1 - 1.2.6.4
+    objective: CIS Fedora 1 - 1.2.6.4
+    group: initial-setup
+    assessment-requirements:
+      - id: mount_option_var_log_noexec
+        text: CIS Fedora 1 - 1.2.6.4 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-1.2.7.2
+    title: CIS Fedora 1 - 1.2.7.2
+    objective: CIS Fedora 1 - 1.2.7.2
+    group: initial-setup
+    assessment-requirements:
+      - id: mount_option_var_log_audit_nodev
+        text: CIS Fedora 1 - 1.2.7.2 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-1.2.7.3
+    title: CIS Fedora 1 - 1.2.7.3
+    objective: CIS Fedora 1 - 1.2.7.3
+    group: initial-setup
+    assessment-requirements:
+      - id: mount_option_var_log_audit_nosuid
+        text: CIS Fedora 1 - 1.2.7.3 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-1.2.7.4
+    title: CIS Fedora 1 - 1.2.7.4
+    objective: CIS Fedora 1 - 1.2.7.4
+    group: initial-setup
+    assessment-requirements:
+      - id: mount_option_var_log_audit_noexec
+        text: CIS Fedora 1 - 1.2.7.4 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-2.1.2
+    title: Ensure Gpgcheck Is Configured
+    objective: Ensure Gpgcheck Is Configured
+    group: initial-setup
+    assessment-requirements:
+      - id: ensure_gpgcheck_globally_activated
+        text: Gpgcheck Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-3.1.1
+    title: Ensure Selinux Is Installed
+    objective: Ensure Selinux Is Installed
+    group: initial-setup
+    assessment-requirements:
+      - id: package_libselinux_installed
+        text: Selinux Is Installed MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-3.1.2
+    title: Ensure Selinux Is Not Disabled In Bootloader Configuration
+    objective: Ensure Selinux Is Not Disabled In Bootloader Configuration
+    group: initial-setup
+    assessment-requirements:
+      - id: grub2_enable_selinux
+        text: Selinux Is Not Disabled In Bootloader Configuration MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-3.1.3
+    title: Ensure Selinux Policy Is Configured
+    objective: Ensure Selinux Policy Is Configured
+    group: initial-setup
+    assessment-requirements:
+      - id: selinux_policytype
+        text: Selinux Policy Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-3.1.4
+    title: Ensure The Selinux Mode Is Not Disabled
+    objective: Ensure The Selinux Mode Is Not Disabled
+    group: initial-setup
+    assessment-requirements:
+      - id: selinux_not_disabled
+        text: The Selinux Mode Is Not Disabled MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-3.1.6
+    title: Ensure The Setroubleshoot Package Is Not Installed
+    objective: Ensure The Setroubleshoot Package Is Not Installed
+    group: initial-setup
+    assessment-requirements:
+      - id: package_setroubleshoot_removed
+        text: The Setroubleshoot Package Is Not Installed MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-3.1.7
+    title: Ensure The Mcs Translation Service (Mcstrans) Is Not Installed
+    objective: Ensure The Mcs Translation Service (Mcstrans) Is Not Installed
+    group: initial-setup
+    assessment-requirements:
+      - id: package_mcstrans_removed
+        text: The Mcs Translation Service (Mcstrans) Is Not Installed MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-4.1
+    title: Ensure Bootloader Password Is Set
+    objective: Ensure Bootloader Password Is Set
+    group: initial-setup
+    assessment-requirements:
+      - id: grub2_password
+        text: Bootloader Password Is Set MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-5.1
+    title: Ensure Core File Size Is Configured
+    objective: Ensure Core File Size Is Configured
+    group: initial-setup
+    assessment-requirements:
+      - id: disable_users_coredumps
+        text: Core File Size Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-5.2
+    title: Ensure Fs.Protected_Hardlinks Is Configured
+    objective: Ensure Fs.Protected_Hardlinks Is Configured
+    group: initial-setup
+    assessment-requirements:
+      - id: sysctl_fs_protected_hardlinks
+        text: Fs.Protected_Hardlinks Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-5.3
+    title: Ensure Fs.Protected_Symlinks Is Configured
+    objective: Ensure Fs.Protected_Symlinks Is Configured
+    group: initial-setup
+    assessment-requirements:
+      - id: sysctl_fs_protected_symlinks
+        text: Fs.Protected_Symlinks Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-5.4
+    title: Ensure Fs.Suid_Dumpable Is Configured
+    objective: Ensure Fs.Suid_Dumpable Is Configured
+    group: initial-setup
+    assessment-requirements:
+      - id: sysctl_fs_suid_dumpable
+        text: Fs.Suid_Dumpable Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-5.5
+    title: Ensure Kernel.Dmesg_Restrict Is Configured
+    objective: Ensure Kernel.Dmesg_Restrict Is Configured
+    group: initial-setup
+    assessment-requirements:
+      - id: sysctl_kernel_dmesg_restrict
+        text: Kernel.Dmesg_Restrict Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-5.6
+    title: Ensure Kernel.Kptr_Restrict Is Configured
+    objective: Ensure Kernel.Kptr_Restrict Is Configured
+    group: initial-setup
+    assessment-requirements:
+      - id: sysctl_kernel_kptr_restrict
+        text: Kernel.Kptr_Restrict Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-5.7
+    title: Ensure Kernel.Yama.Ptrace_Scope Is Configured
+    objective: Ensure Kernel.Yama.Ptrace_Scope Is Configured
+    group: initial-setup
+    assessment-requirements:
+      - id: sysctl_kernel_yama_ptrace_scope
+        text: Kernel.Yama.Ptrace_Scope Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-5.8
+    title: Ensure Kernel.Randomize_Va_Space Is Configured
+    objective: Ensure Kernel.Randomize_Va_Space Is Configured
+    group: initial-setup
+    assessment-requirements:
+      - id: sysctl_kernel_randomize_va_space
+        text: Kernel.Randomize_Va_Space Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-5.9
+    title: Ensure Systemd-Coredump Processsizemax Is Configured
+    objective: Ensure Systemd-Coredump Processsizemax Is Configured
+    group: initial-setup
+    assessment-requirements:
+      - id: coredump_disable_backtraces
+        text: Systemd-Coredump Processsizemax Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-5.10
+    title: Ensure Systemd-Coredump Storage Is Configured
+    objective: Ensure Systemd-Coredump Storage Is Configured
+    group: initial-setup
+    assessment-requirements:
+      - id: coredump_disable_storage
+        text: Systemd-Coredump Storage Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-6.2
+    title: Ensure System Wide Crypto Policy Disables Sha1 Hash And Signature Support
+    objective: Ensure System Wide Crypto Policy Disables Sha1 Hash And Signature Support
+    group: initial-setup
+    assessment-requirements:
+      - id: cis_fedora_1-6.2-ar
+        text: System Wide Crypto Policy Disables Sha1 Hash And Signature Support MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-6.3
+    title: Ensure System Wide Crypto Policy Macs Are Configured
+    objective: Ensure System Wide Crypto Policy Macs Are Configured
+    group: initial-setup
+    assessment-requirements:
+      - id: cis_fedora_1-6.3-ar
+        text: System Wide Crypto Policy Macs Are Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-6.4
+    title: Ensure System Wide Crypto Policy Disables Cbc For Ssh
+    objective: Ensure System Wide Crypto Policy Disables Cbc For Ssh
+    group: initial-setup
+    assessment-requirements:
+      - id: cis_fedora_1-6.4-ar
+        text: System Wide Crypto Policy Disables Cbc For Ssh MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-7.1
+    title: Ensure /Etc/Motd Is Configured
+    objective: Ensure /Etc/Motd Is Configured
+    group: initial-setup
+    assessment-requirements:
+      - id: banner_etc_motd_cis
+        text: /Etc/Motd Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-7.2
+    title: Ensure /Etc/Issue Is Configured
+    objective: Ensure /Etc/Issue Is Configured
+    group: initial-setup
+    assessment-requirements:
+      - id: banner_etc_issue_cis
+        text: /Etc/Issue Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-7.3
+    title: Ensure /Etc/Issue.Net Is Configured
+    objective: Ensure /Etc/Issue.Net Is Configured
+    group: initial-setup
+    assessment-requirements:
+      - id: banner_etc_issue_net_cis
+        text: /Etc/Issue.Net Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-7.4
+    title: Ensure Access To /Etc/Motd Is Configured
+    objective: Ensure Access To /Etc/Motd Is Configured
+    group: initial-setup
+    assessment-requirements:
+      - id: file_groupowner_etc_motd
+        text: Access To /Etc/Motd Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_owner_etc_motd
+        text: Access To /Etc/Motd Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_permissions_etc_motd
+        text: Access To /Etc/Motd Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-7.5
+    title: Ensure Access To /Etc/Issue Is Configured
+    objective: Ensure Access To /Etc/Issue Is Configured
+    group: initial-setup
+    assessment-requirements:
+      - id: file_groupowner_etc_issue
+        text: Access To /Etc/Issue Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_owner_etc_issue
+        text: Access To /Etc/Issue Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_permissions_etc_issue
+        text: Access To /Etc/Issue Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-7.6
+    title: Ensure Access To /Etc/Issue.Net Is Configured
+    objective: Ensure Access To /Etc/Issue.Net Is Configured
+    group: initial-setup
+    assessment-requirements:
+      - id: file_groupowner_etc_issue_net
+        text: Access To /Etc/Issue.Net Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_owner_etc_issue_net
+        text: Access To /Etc/Issue.Net Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_permissions_etc_issue_net
+        text: Access To /Etc/Issue.Net Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-8.1
+    title: Ensure Gdm Login Banner Is Configured
+    objective: Ensure Gdm Login Banner Is Configured
+    group: initial-setup
+    assessment-requirements:
+      - id: dconf_gnome_banner_enabled
+        text: Gdm Login Banner Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: dconf_gnome_login_banner_text
+        text: Gdm Login Banner Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-8.2
+    title: Ensure Gdm Disable-User-List Is Configured
+    objective: Ensure Gdm Disable-User-List Is Configured
+    group: initial-setup
+    assessment-requirements:
+      - id: dconf_gnome_disable_user_list
+        text: Gdm Disable-User-List Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-8.3
+    title: Ensure Gdm Screen Lock Is Configured
+    objective: Ensure Gdm Screen Lock Is Configured
+    group: initial-setup
+    assessment-requirements:
+      - id: dconf_gnome_screensaver_idle_delay
+        text: Gdm Screen Lock Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: dconf_gnome_screensaver_lock_delay
+        text: Gdm Screen Lock Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: dconf_gnome_screensaver_user_locks
+        text: Gdm Screen Lock Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: dconf_gnome_session_idle_user_locks
+        text: Gdm Screen Lock Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-8.4
+    title: Ensure GDM Automount Is Disabled
+    objective: Ensure GDM Automount Is Disabled
+    group: initial-setup
+    assessment-requirements:
+      - id: dconf_gnome_disable_automount
+        text: GDM Automount Is Disabled MUST be verified
+        applicability:
+          - fedora-linux
+      - id: dconf_gnome_disable_automount_open
+        text: GDM Automount Opening Is Disabled MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_1-8.5
+    title: Ensure Gdm Autorun-Never Is Configured
+    objective: Ensure Gdm Autorun-Never Is Configured
+    group: initial-setup
+    assessment-requirements:
+      - id: dconf_gnome_disable_autorun
+        text: Gdm Autorun-Never Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_2-1.1
+    title: Ensure Autofs Services Are Not In Use
+    objective: Ensure Autofs Services Are Not In Use
+    group: services
+    assessment-requirements:
+      - id: service_autofs_disabled
+        text: Autofs Services Are Not In Use MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_2-1.2
+    title: Ensure Avahi Server Services Are Not In Use
+    objective: Ensure Avahi Server Services Are Not In Use
+    group: services
+    assessment-requirements:
+      - id: service_avahi-daemon_disabled
+        text: Avahi Server Services Are Not In Use MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_2-1.3
+    title: Ensure Bluetooth Services Are Not In Use
+    objective: Ensure Bluetooth Services Are Not In Use
+    group: services
+    assessment-requirements:
+      - id: service_bluetooth_disabled
+        text: Bluetooth Services Are Not In Use MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_2-1.4
+    title: Ensure Dhcp Server Services Are Not In Use
+    objective: Ensure Dhcp Server Services Are Not In Use
+    group: services
+    assessment-requirements:
+      - id: package_kea_removed
+        text: Dhcp Server Services Are Not In Use MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_2-1.5
+    title: Ensure Dns Server Services Are Not In Use
+    objective: Ensure Dns Server Services Are Not In Use
+    group: services
+    assessment-requirements:
+      - id: package_bind_removed
+        text: Dns Server Services Are Not In Use MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_2-1.6
+    title: Ensure Dnsmasq Services Are Not In Use
+    objective: Ensure Dnsmasq Services Are Not In Use
+    group: services
+    assessment-requirements:
+      - id: package_dnsmasq_removed
+        text: Dnsmasq Services Are Not In Use MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_2-1.7
+    title: Ensure Ftp Server Services Are Not In Use
+    objective: Ensure Ftp Server Services Are Not In Use
+    group: services
+    assessment-requirements:
+      - id: package_vsftpd_removed
+        text: Ftp Server Services Are Not In Use MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_2-1.8
+    title: Ensure Message Access Server Services Are Not In Use
+    objective: Ensure Message Access Server Services Are Not In Use
+    group: services
+    assessment-requirements:
+      - id: package_cyrus-imapd_removed
+        text: Message Access Server Services Are Not In Use MUST be verified
+        applicability:
+          - fedora-linux
+      - id: package_dovecot_removed
+        text: Message Access Server Services Are Not In Use MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_2-1.9
+    title: Ensure Network File System Services Are Not In Use
+    objective: Ensure Network File System Services Are Not In Use
+    group: services
+    assessment-requirements:
+      - id: service_nfs_disabled
+        text: Network File System Services Are Not In Use MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_2-1.11
+    title: Ensure CUPS Services Are Not In Use
+    objective: Ensure CUPS Services Are Not In Use
+    group: services
+    assessment-requirements:
+      - id: service_cups_disabled
+        text: CUPS Services Are Not In Use MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_2-1.12
+    title: Ensure Rpcbind Services Are Not In Use
+    objective: Ensure Rpcbind Services Are Not In Use
+    group: services
+    assessment-requirements:
+      - id: service_rpcbind_disabled
+        text: Rpcbind Services Are Not In Use MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_2-1.13
+    title: Ensure Rsync Services Are Not In Use
+    objective: Ensure Rsync Services Are Not In Use
+    group: services
+    assessment-requirements:
+      - id: package_rsync_removed
+        text: Rsync Services Are Not In Use MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_2-1.14
+    title: Ensure Samba File Server Services Are Not In Use
+    objective: Ensure Samba File Server Services Are Not In Use
+    group: services
+    assessment-requirements:
+      - id: package_samba_removed
+        text: Samba File Server Services Are Not In Use MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_2-1.15
+    title: Ensure Snmp Services Are Not In Use
+    objective: Ensure Snmp Services Are Not In Use
+    group: services
+    assessment-requirements:
+      - id: package_net-snmp_removed
+        text: Snmp Services Are Not In Use MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_2-1.16
+    title: Ensure Telnet Server Services Are Not In Use
+    objective: Ensure Telnet Server Services Are Not In Use
+    group: services
+    assessment-requirements:
+      - id: package_telnet-server_removed
+        text: Telnet Server Services Are Not In Use MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_2-1.17
+    title: Ensure Tftp Server Services Are Not In Use
+    objective: Ensure Tftp Server Services Are Not In Use
+    group: services
+    assessment-requirements:
+      - id: package_tftp-server_removed
+        text: Tftp Server Services Are Not In Use MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_2-1.18
+    title: Ensure Web Proxy Server Services Are Not In Use
+    objective: Ensure Web Proxy Server Services Are Not In Use
+    group: services
+    assessment-requirements:
+      - id: package_squid_removed
+        text: Web Proxy Server Services Are Not In Use MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_2-1.19
+    title: Ensure Web Server Services Are Not In Use
+    objective: Ensure Web Server Services Are Not In Use
+    group: services
+    assessment-requirements:
+      - id: package_httpd_removed
+        text: Web Server Services Are Not In Use MUST be verified
+        applicability:
+          - fedora-linux
+      - id: package_nginx_removed
+        text: Web Server Services Are Not In Use MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_2-1.23
+    title: Ensure Mail Transfer Agents Are Configured For Local-Only Mode
+    objective: Ensure Mail Transfer Agents Are Configured For Local-Only Mode
+    group: services
+    assessment-requirements:
+      - id: has_nonlocal_mta
+        text: Mail Transfer Agents Are Configured For Local-Only Mode MUST be verified
+        applicability:
+          - fedora-linux
+      - id: postfix_network_listening_disabled
+        text: Mail Transfer Agents Are Configured For Local-Only Mode MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_2-2.1
+    title: Ensure Ftp Client Is Not Installed
+    objective: Ensure Ftp Client Is Not Installed
+    group: services
+    assessment-requirements:
+      - id: package_ftp_removed
+        text: Ftp Client Is Not Installed MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_2-2.4
+    title: Ensure Telnet Client Is Not Installed
+    objective: Ensure Telnet Client Is Not Installed
+    group: services
+    assessment-requirements:
+      - id: package_telnet_removed
+        text: Telnet Client Is Not Installed MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_2-2.5
+    title: Ensure Tftp Client Is Not Installed
+    objective: Ensure Tftp Client Is Not Installed
+    group: services
+    assessment-requirements:
+      - id: package_tftp_removed
+        text: Tftp Client Is Not Installed MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_2-3.2
+    title: Ensure Chrony Is Configured
+    objective: Ensure Chrony Is Configured
+    group: services
+    assessment-requirements:
+      - id: chronyd_specify_remote_server
+        text: Chrony Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_2-3.3
+    title: Ensure Chrony Is Not Run As The Root User
+    objective: Ensure Chrony Is Not Run As The Root User
+    group: services
+    assessment-requirements:
+      - id: chronyd_run_as_chrony_user
+        text: Chrony Is Not Run As The Root User MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_2-4.1.1
+    title: Ensure Cron Daemon Is Enabled And Active
+    objective: Ensure Cron Daemon Is Enabled And Active
+    group: services
+    assessment-requirements:
+      - id: package_cron_installed
+        text: Cron Daemon Is Enabled And Active MUST be verified
+        applicability:
+          - fedora-linux
+      - id: service_crond_enabled
+        text: Cron Daemon Is Enabled And Active MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_2-4.1.2
+    title: Ensure Access To /Etc/Crontab Is Configured
+    objective: Ensure Access To /Etc/Crontab Is Configured
+    group: services
+    assessment-requirements:
+      - id: file_groupowner_crontab
+        text: Access To /Etc/Crontab Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_owner_crontab
+        text: Access To /Etc/Crontab Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_permissions_crontab
+        text: Access To /Etc/Crontab Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_2-4.1.3
+    title: Ensure Access To /Etc/Cron.Hourly Is Configured
+    objective: Ensure Access To /Etc/Cron.Hourly Is Configured
+    group: services
+    assessment-requirements:
+      - id: file_groupowner_cron_hourly
+        text: Access To /Etc/Cron.Hourly Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_owner_cron_hourly
+        text: Access To /Etc/Cron.Hourly Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_permissions_cron_hourly
+        text: Access To /Etc/Cron.Hourly Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_2-4.1.4
+    title: Ensure Access To /Etc/Cron.Daily Is Configured
+    objective: Ensure Access To /Etc/Cron.Daily Is Configured
+    group: services
+    assessment-requirements:
+      - id: file_groupowner_cron_daily
+        text: Access To /Etc/Cron.Daily Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_owner_cron_daily
+        text: Access To /Etc/Cron.Daily Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_permissions_cron_daily
+        text: Access To /Etc/Cron.Daily Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_2-4.1.5
+    title: Ensure Access To /Etc/Cron.Weekly Is Configured
+    objective: Ensure Access To /Etc/Cron.Weekly Is Configured
+    group: services
+    assessment-requirements:
+      - id: file_groupowner_cron_weekly
+        text: Access To /Etc/Cron.Weekly Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_owner_cron_weekly
+        text: Access To /Etc/Cron.Weekly Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_permissions_cron_weekly
+        text: Access To /Etc/Cron.Weekly Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_2-4.1.6
+    title: Ensure Access To /Etc/Cron.Monthly Is Configured
+    objective: Ensure Access To /Etc/Cron.Monthly Is Configured
+    group: services
+    assessment-requirements:
+      - id: file_groupowner_cron_monthly
+        text: Access To /Etc/Cron.Monthly Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_owner_cron_monthly
+        text: Access To /Etc/Cron.Monthly Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_permissions_cron_monthly
+        text: Access To /Etc/Cron.Monthly Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_2-4.1.8
+    title: Ensure Access To /Etc/Cron.D Is Configured
+    objective: Ensure Access To /Etc/Cron.D Is Configured
+    group: services
+    assessment-requirements:
+      - id: file_groupowner_cron_d
+        text: Access To /Etc/Cron.D Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_owner_cron_d
+        text: Access To /Etc/Cron.D Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_permissions_cron_d
+        text: Access To /Etc/Cron.D Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_2-4.1.9
+    title: Ensure Access To Crontab Is Configured
+    objective: Ensure Access To Crontab Is Configured
+    group: services
+    assessment-requirements:
+      - id: file_cron_allow_exists
+        text: Access To Crontab Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_cron_deny_not_exist
+        text: Access To Crontab Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_groupowner_cron_allow
+        text: Access To Crontab Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_owner_cron_allow
+        text: Access To Crontab Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_permissions_cron_allow
+        text: Access To Crontab Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_2-4.2.1
+    title: Ensure Access To At Is Configured
+    objective: Ensure Access To At Is Configured
+    group: services
+    assessment-requirements:
+      - id: file_at_deny_not_exist
+        text: Access To At Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_groupowner_at_allow
+        text: Access To At Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_owner_at_allow
+        text: Access To At Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_permissions_at_allow
+        text: Access To At Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_3-1.2
+    title: Ensure Wireless Interfaces Are Disabled
+    objective: Ensure Wireless Interfaces Are Disabled
+    group: network
+    assessment-requirements:
+      - id: wireless_disable_interfaces
+        text: Wireless Interfaces Are Disabled MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_3-2.1
+    title: Ensure Atm Kernel Module Is Not Available
+    objective: Ensure Atm Kernel Module Is Not Available
+    group: network
+    assessment-requirements:
+      - id: kernel_module_atm_disabled
+        text: Atm Kernel Module Is Not Available MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_3-2.2
+    title: Ensure Can Kernel Module Is Not Available
+    objective: Ensure Can Kernel Module Is Not Available
+    group: network
+    assessment-requirements:
+      - id: kernel_module_can_disabled
+        text: Can Kernel Module Is Not Available MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_3-2.3
+    title: Ensure Dccp Kernel Module Is Not Available
+    objective: Ensure Dccp Kernel Module Is Not Available
+    group: network
+    assessment-requirements:
+      - id: kernel_module_dccp_disabled
+        text: Dccp Kernel Module Is Not Available MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_3-2.4
+    title: Ensure Tipc Kernel Module Is Not Available
+    objective: Ensure Tipc Kernel Module Is Not Available
+    group: network
+    assessment-requirements:
+      - id: kernel_module_tipc_disabled
+        text: Tipc Kernel Module Is Not Available MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_3-2.5
+    title: Ensure Rds Kernel Module Is Not Available
+    objective: Ensure Rds Kernel Module Is Not Available
+    group: network
+    assessment-requirements:
+      - id: kernel_module_rds_disabled
+        text: Rds Kernel Module Is Not Available MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_3-3.1.4
+    title: Ensure Net.Ipv4.Conf.All.Send_Redirects Is Configured
+    objective: Ensure Net.Ipv4.Conf.All.Send_Redirects Is Configured
+    group: network
+    assessment-requirements:
+      - id: sysctl_net_ipv4_conf_all_send_redirects
+        text: Net.Ipv4.Conf.All.Send_Redirects Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_3-3.1.5
+    title: Ensure Net.Ipv4.Conf.Default.Send_Redirects Is Configured
+    objective: Ensure Net.Ipv4.Conf.Default.Send_Redirects Is Configured
+    group: network
+    assessment-requirements:
+      - id: sysctl_net_ipv4_conf_default_send_redirects
+        text: Net.Ipv4.Conf.Default.Send_Redirects Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_3-3.1.6
+    title: Ensure Net.Ipv4.Icmp_Ignore_Bogus_Error_Responses Is Configured
+    objective: Ensure Net.Ipv4.Icmp_Ignore_Bogus_Error_Responses Is Configured
+    group: network
+    assessment-requirements:
+      - id: sysctl_net_ipv4_icmp_ignore_bogus_error_responses
+        text: Net.Ipv4.Icmp_Ignore_Bogus_Error_Responses Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_3-3.1.7
+    title: Ensure Net.Ipv4.Icmp_Echo_Ignore_Broadcasts Is Configured
+    objective: Ensure Net.Ipv4.Icmp_Echo_Ignore_Broadcasts Is Configured
+    group: network
+    assessment-requirements:
+      - id: sysctl_net_ipv4_icmp_echo_ignore_broadcasts
+        text: Net.Ipv4.Icmp_Echo_Ignore_Broadcasts Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_3-3.1.8
+    title: Ensure Net.Ipv4.Conf.All.Accept_Redirects Is Configured
+    objective: Ensure Net.Ipv4.Conf.All.Accept_Redirects Is Configured
+    group: network
+    assessment-requirements:
+      - id: sysctl_net_ipv4_conf_all_accept_redirects
+        text: Net.Ipv4.Conf.All.Accept_Redirects Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_3-3.1.9
+    title: Ensure Net.Ipv4.Conf.Default.Accept_Redirects Is Configured
+    objective: Ensure Net.Ipv4.Conf.Default.Accept_Redirects Is Configured
+    group: network
+    assessment-requirements:
+      - id: sysctl_net_ipv4_conf_default_accept_redirects
+        text: Net.Ipv4.Conf.Default.Accept_Redirects Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_3-3.1.10
+    title: Ensure Net.Ipv4.Conf.All.Secure_Redirects Is Configured
+    objective: Ensure Net.Ipv4.Conf.All.Secure_Redirects Is Configured
+    group: network
+    assessment-requirements:
+      - id: sysctl_net_ipv4_conf_all_secure_redirects
+        text: Net.Ipv4.Conf.All.Secure_Redirects Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_3-3.1.11
+    title: Ensure Net.Ipv4.Conf.Default.Secure_Redirects Is Configured
+    objective: Ensure Net.Ipv4.Conf.Default.Secure_Redirects Is Configured
+    group: network
+    assessment-requirements:
+      - id: sysctl_net_ipv4_conf_default_secure_redirects
+        text: Net.Ipv4.Conf.Default.Secure_Redirects Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_3-3.1.12
+    title: Ensure Net.Ipv4.Conf.All.Rp_Filter Is Configured
+    objective: Ensure Net.Ipv4.Conf.All.Rp_Filter Is Configured
+    group: network
+    assessment-requirements:
+      - id: sysctl_net_ipv4_conf_all_rp_filter
+        text: Net.Ipv4.Conf.All.Rp_Filter Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_3-3.1.13
+    title: Ensure Net.Ipv4.Conf.Default.Rp_Filter Is Configured
+    objective: Ensure Net.Ipv4.Conf.Default.Rp_Filter Is Configured
+    group: network
+    assessment-requirements:
+      - id: sysctl_net_ipv4_conf_default_rp_filter
+        text: Net.Ipv4.Conf.Default.Rp_Filter Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_3-3.1.14
+    title: Ensure Net.Ipv4.Conf.All.Accept_Source_Route Is Configured
+    objective: Ensure Net.Ipv4.Conf.All.Accept_Source_Route Is Configured
+    group: network
+    assessment-requirements:
+      - id: sysctl_net_ipv4_conf_all_accept_source_route
+        text: Net.Ipv4.Conf.All.Accept_Source_Route Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_3-3.1.15
+    title: Ensure Net.Ipv4.Conf.Default.Accept_Source_Route Is Configured
+    objective: Ensure Net.Ipv4.Conf.Default.Accept_Source_Route Is Configured
+    group: network
+    assessment-requirements:
+      - id: sysctl_net_ipv4_conf_default_accept_source_route
+        text: Net.Ipv4.Conf.Default.Accept_Source_Route Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_3-3.1.16
+    title: Ensure Net.Ipv4.Conf.All.Log_Martians Is Configured
+    objective: Ensure Net.Ipv4.Conf.All.Log_Martians Is Configured
+    group: network
+    assessment-requirements:
+      - id: sysctl_net_ipv4_conf_all_log_martians
+        text: Net.Ipv4.Conf.All.Log_Martians Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_3-3.1.17
+    title: Ensure Net.Ipv4.Conf.Default.Log_Martians Is Configured
+    objective: Ensure Net.Ipv4.Conf.Default.Log_Martians Is Configured
+    group: network
+    assessment-requirements:
+      - id: sysctl_net_ipv4_conf_default_log_martians
+        text: Net.Ipv4.Conf.Default.Log_Martians Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_3-3.1.18
+    title: Ensure Net.Ipv4.Tcp_Syncookies Is Configured
+    objective: Ensure Net.Ipv4.Tcp_Syncookies Is Configured
+    group: network
+    assessment-requirements:
+      - id: sysctl_net_ipv4_tcp_syncookies
+        text: Net.Ipv4.Tcp_Syncookies Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_3-3.2.1
+    title: Ensure Net.Ipv6.Conf.All.Forwarding Is Configured
+    objective: Ensure Net.Ipv6.Conf.All.Forwarding Is Configured
+    group: network
+    assessment-requirements:
+      - id: sysctl_net_ipv6_conf_all_forwarding
+        text: Net.Ipv6.Conf.All.Forwarding Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_3-3.2.3
+    title: Ensure Net.Ipv6.Conf.All.Accept_Redirects Is Configured
+    objective: Ensure Net.Ipv6.Conf.All.Accept_Redirects Is Configured
+    group: network
+    assessment-requirements:
+      - id: sysctl_net_ipv6_conf_all_accept_redirects
+        text: Net.Ipv6.Conf.All.Accept_Redirects Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_3-3.2.4
+    title: Ensure Net.Ipv6.Conf.Default.Accept_Redirects Is Configured
+    objective: Ensure Net.Ipv6.Conf.Default.Accept_Redirects Is Configured
+    group: network
+    assessment-requirements:
+      - id: sysctl_net_ipv6_conf_default_accept_redirects
+        text: Net.Ipv6.Conf.Default.Accept_Redirects Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_3-3.2.5
+    title: Ensure Net.Ipv6.Conf.All.Accept_Source_Route Is Configured
+    objective: Ensure Net.Ipv6.Conf.All.Accept_Source_Route Is Configured
+    group: network
+    assessment-requirements:
+      - id: sysctl_net_ipv6_conf_all_accept_source_route
+        text: Net.Ipv6.Conf.All.Accept_Source_Route Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_3-3.2.6
+    title: Ensure Net.Ipv6.Conf.Default.Accept_Source_Route Is Configured
+    objective: Ensure Net.Ipv6.Conf.Default.Accept_Source_Route Is Configured
+    group: network
+    assessment-requirements:
+      - id: sysctl_net_ipv6_conf_default_accept_source_route
+        text: Net.Ipv6.Conf.Default.Accept_Source_Route Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_3-3.2.7
+    title: Ensure Net.Ipv6.Conf.All.Accept_Ra Is Configured
+    objective: Ensure Net.Ipv6.Conf.All.Accept_Ra Is Configured
+    group: network
+    assessment-requirements:
+      - id: sysctl_net_ipv6_conf_all_accept_ra
+        text: Net.Ipv6.Conf.All.Accept_Ra Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_3-3.2.8
+    title: Ensure Net.Ipv6.Conf.Default.Accept_Ra Is Configured
+    objective: Ensure Net.Ipv6.Conf.Default.Accept_Ra Is Configured
+    group: network
+    assessment-requirements:
+      - id: sysctl_net_ipv6_conf_default_accept_ra
+        text: Net.Ipv6.Conf.Default.Accept_Ra Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_4-1.1
+    title: Ensure Nftables Is Installed
+    objective: Ensure Nftables Is Installed
+    group: firewall
+    assessment-requirements:
+      - id: package_nftables_installed
+        text: Nftables Is Installed MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_4-1.2
+    title: Ensure A Single Firewall Configuration Utility Is In Use
+    objective: Ensure A Single Firewall Configuration Utility Is In Use
+    group: firewall
+    assessment-requirements:
+      - id: package_firewalld_installed
+        text: A Single Firewall Configuration Utility Is In Use MUST be verified
+        applicability:
+          - fedora-linux
+      - id: service_firewalld_enabled
+        text: A Single Firewall Configuration Utility Is In Use MUST be verified
+        applicability:
+          - fedora-linux
+      - id: service_nftables_disabled
+        text: A Single Firewall Configuration Utility Is In Use MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_4-2.2
+    title: Ensure Firewalld Loopback Traffic Is Configured
+    objective: Ensure Firewalld Loopback Traffic Is Configured
+    group: firewall
+    assessment-requirements:
+      - id: firewalld_loopback_traffic_restricted
+        text: Firewalld Loopback Traffic Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: firewalld_loopback_traffic_trusted
+        text: Firewalld Loopback Traffic Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-1.1
+    title: Ensure Access To /Etc/Ssh/Sshd_Config Is Configured
+    objective: Ensure Access To /Etc/Ssh/Sshd_Config Is Configured
+    group: access-auth
+    assessment-requirements:
+      - id: file_groupowner_sshd_config
+        text: Access To /Etc/Ssh/Sshd_Config Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_owner_sshd_config
+        text: Access To /Etc/Ssh/Sshd_Config Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_permissions_sshd_config
+        text: Access To /Etc/Ssh/Sshd_Config Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-1.2
+    title: Ensure Access To Ssh Private Host Key Files Is Configured
+    objective: Ensure Access To Ssh Private Host Key Files Is Configured
+    group: access-auth
+    assessment-requirements:
+      - id: file_groupownership_sshd_private_key
+        text: Access To Ssh Private Host Key Files Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_ownership_sshd_private_key
+        text: Access To Ssh Private Host Key Files Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_permissions_sshd_private_key
+        text: Access To Ssh Private Host Key Files Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-1.3
+    title: Ensure Access To Ssh Public Host Key Files Is Configured
+    objective: Ensure Access To Ssh Public Host Key Files Is Configured
+    group: access-auth
+    assessment-requirements:
+      - id: file_groupownership_sshd_pub_key
+        text: Access To Ssh Public Host Key Files Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_ownership_sshd_pub_key
+        text: Access To Ssh Public Host Key Files Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_permissions_sshd_pub_key
+        text: Access To Ssh Public Host Key Files Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-1.4
+    title: Ensure Sshd Ciphers Are Configured
+    objective: Ensure Sshd Ciphers Are Configured
+    group: access-auth
+    assessment-requirements:
+      - id: cis_fedora_5-1.4-ar
+        text: Sshd Ciphers Are Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-1.5
+    title: Ensure Sshd Kexalgorithms Is Configured
+    objective: Ensure Sshd Kexalgorithms Is Configured
+    group: access-auth
+    assessment-requirements:
+      - id: cis_fedora_5-1.5-ar
+        text: Sshd Kexalgorithms Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-1.6
+    title: Ensure Sshd Macs Are Configured
+    objective: Ensure Sshd Macs Are Configured
+    group: access-auth
+    assessment-requirements:
+      - id: cis_fedora_5-1.6-ar
+        text: Sshd Macs Are Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-1.7
+    title: Ensure Sshd Access Is Configured
+    objective: Ensure Sshd Access Is Configured
+    group: access-auth
+    assessment-requirements:
+      - id: sshd_limit_user_access
+        text: Sshd Access Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-1.8
+    title: Ensure Sshd Banner Is Configured
+    objective: Ensure Sshd Banner Is Configured
+    group: access-auth
+    assessment-requirements:
+      - id: sshd_enable_warning_banner_net
+        text: Sshd Banner Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-1.9
+    title: Ensure Sshd Clientaliveinterval And Clientalivecountmax Are Configured
+    objective: Ensure Sshd Clientaliveinterval And Clientalivecountmax Are Configured
+    group: access-auth
+    assessment-requirements:
+      - id: sshd_set_idle_timeout
+        text: Sshd Clientaliveinterval And Clientalivecountmax Are Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: sshd_set_keepalive
+        text: Sshd Clientaliveinterval And Clientalivecountmax Are Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-1.12
+    title: Ensure Sshd Hostbasedauthentication Is Disabled
+    objective: Ensure Sshd Hostbasedauthentication Is Disabled
+    group: access-auth
+    assessment-requirements:
+      - id: disable_host_auth
+        text: Sshd Hostbasedauthentication Is Disabled MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-1.13
+    title: Ensure Sshd Ignorerhosts Is Enabled
+    objective: Ensure Sshd Ignorerhosts Is Enabled
+    group: access-auth
+    assessment-requirements:
+      - id: sshd_disable_rhosts
+        text: Sshd Ignorerhosts Is Enabled MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-1.14
+    title: Ensure Sshd Logingracetime Is Configured
+    objective: Ensure Sshd Logingracetime Is Configured
+    group: access-auth
+    assessment-requirements:
+      - id: sshd_set_login_grace_time
+        text: Sshd Logingracetime Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-1.15
+    title: Ensure Sshd Loglevel Is Configured
+    objective: Ensure Sshd Loglevel Is Configured
+    group: access-auth
+    assessment-requirements:
+      - id: sshd_set_loglevel_verbose
+        text: Sshd Loglevel Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-1.16
+    title: Ensure Sshd Maxauthtries Is Configured
+    objective: Ensure Sshd Maxauthtries Is Configured
+    group: access-auth
+    assessment-requirements:
+      - id: sshd_set_max_auth_tries
+        text: Sshd Maxauthtries Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-1.17
+    title: Ensure Sshd Maxstartups Is Configured
+    objective: Ensure Sshd Maxstartups Is Configured
+    group: access-auth
+    assessment-requirements:
+      - id: sshd_set_maxstartups
+        text: Sshd Maxstartups Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-1.18
+    title: Ensure Sshd Maxsessions Is Configured
+    objective: Ensure Sshd Maxsessions Is Configured
+    group: access-auth
+    assessment-requirements:
+      - id: sshd_set_max_sessions
+        text: Sshd Maxsessions Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-1.19
+    title: Ensure Sshd Permitemptypasswords Is Disabled
+    objective: Ensure Sshd Permitemptypasswords Is Disabled
+    group: access-auth
+    assessment-requirements:
+      - id: sshd_disable_empty_passwords
+        text: Sshd Permitemptypasswords Is Disabled MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-1.20
+    title: Ensure Sshd Permitrootlogin Is Disabled
+    objective: Ensure Sshd Permitrootlogin Is Disabled
+    group: access-auth
+    assessment-requirements:
+      - id: sshd_disable_root_login
+        text: Sshd Permitrootlogin Is Disabled MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-1.21
+    title: Ensure Sshd Permituserenvironment Is Disabled
+    objective: Ensure Sshd Permituserenvironment Is Disabled
+    group: access-auth
+    assessment-requirements:
+      - id: sshd_do_not_permit_user_env
+        text: Sshd Permituserenvironment Is Disabled MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-1.22
+    title: Ensure Sshd Usepam Is Enabled
+    objective: Ensure Sshd Usepam Is Enabled
+    group: access-auth
+    assessment-requirements:
+      - id: sshd_enable_pam
+        text: Sshd Usepam Is Enabled MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-2.1
+    title: Ensure Sudo Is Installed
+    objective: Ensure Sudo Is Installed
+    group: access-auth
+    assessment-requirements:
+      - id: package_sudo_installed
+        text: Sudo Is Installed MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-2.2
+    title: Ensure Sudo Commands Use Pty
+    objective: Ensure Sudo Commands Use Pty
+    group: access-auth
+    assessment-requirements:
+      - id: sudo_add_use_pty
+        text: Sudo Commands Use Pty MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-2.3
+    title: Ensure Sudo Log File Exists
+    objective: Ensure Sudo Log File Exists
+    group: access-auth
+    assessment-requirements:
+      - id: sudo_custom_logfile
+        text: Sudo Log File Exists MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-2.5
+    title: Ensure Re-Authentication For Privilege Escalation Is Not Disabled Globally
+    objective: Ensure Re-Authentication For Privilege Escalation Is Not Disabled Globally
+    group: access-auth
+    assessment-requirements:
+      - id: sudo_remove_no_authenticate
+        text: Re-Authentication For Privilege Escalation Is Not Disabled Globally MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-2.6
+    title: Ensure Sudo Timestamp_Timeout Is Configured
+    objective: Ensure Sudo Timestamp_Timeout Is Configured
+    group: access-auth
+    assessment-requirements:
+      - id: sudo_require_reauthentication
+        text: Sudo Timestamp_Timeout Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-2.7
+    title: Ensure Access To The Su Command Is Restricted
+    objective: Ensure Access To The Su Command Is Restricted
+    group: access-auth
+    assessment-requirements:
+      - id: ensure_pam_wheel_group_empty
+        text: Access To The Su Command Is Restricted MUST be verified
+        applicability:
+          - fedora-linux
+      - id: use_pam_wheel_group_for_su
+        text: Access To The Su Command Is Restricted MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-3.1.3
+    title: Ensure Latest Version Of Libpwquality Is Installed
+    objective: Ensure Latest Version Of Libpwquality Is Installed
+    group: access-auth
+    assessment-requirements:
+      - id: package_pam_pwquality_installed
+        text: Latest Version Of Libpwquality Is Installed MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-3.2.2
+    title: Ensure Pam_Faillock Module Is Enabled
+    objective: Ensure Pam_Faillock Module Is Enabled
+    group: access-auth
+    assessment-requirements:
+      - id: account_password_pam_faillock_password_auth
+        text: Pam_Faillock Module Is Enabled MUST be verified
+        applicability:
+          - fedora-linux
+      - id: account_password_pam_faillock_system_auth
+        text: Pam_Faillock Module Is Enabled MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-3.2.3
+    title: Ensure Pam_Pwquality Module Is Enabled
+    objective: Ensure Pam_Pwquality Module Is Enabled
+    group: access-auth
+    assessment-requirements:
+      - id: accounts_password_pam_pwquality_password_auth
+        text: Pam_Pwquality Module Is Enabled MUST be verified
+        applicability:
+          - fedora-linux
+      - id: accounts_password_pam_pwquality_system_auth
+        text: Pam_Pwquality Module Is Enabled MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-3.3.1.1
+    title: CIS Fedora 5 - 3.3.1.1
+    objective: CIS Fedora 5 - 3.3.1.1
+    group: access-auth
+    assessment-requirements:
+      - id: accounts_passwords_pam_faillock_deny
+        text: CIS Fedora 5 - 3.3.1.1 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-3.3.1.2
+    title: CIS Fedora 5 - 3.3.1.2
+    objective: CIS Fedora 5 - 3.3.1.2
+    group: access-auth
+    assessment-requirements:
+      - id: accounts_passwords_pam_faillock_unlock_time
+        text: CIS Fedora 5 - 3.3.1.2 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-3.3.2.1
+    title: CIS Fedora 5 - 3.3.2.1
+    objective: CIS Fedora 5 - 3.3.2.1
+    group: access-auth
+    assessment-requirements:
+      - id: accounts_password_pam_difok
+        text: CIS Fedora 5 - 3.3.2.1 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-3.3.2.2
+    title: CIS Fedora 5 - 3.3.2.2
+    objective: CIS Fedora 5 - 3.3.2.2
+    group: access-auth
+    assessment-requirements:
+      - id: accounts_password_pam_minlen
+        text: CIS Fedora 5 - 3.3.2.2 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-3.3.2.3
+    title: CIS Fedora 5 - 3.3.2.3
+    objective: CIS Fedora 5 - 3.3.2.3
+    group: access-auth
+    assessment-requirements:
+      - id: accounts_password_pam_minclass
+        text: CIS Fedora 5 - 3.3.2.3 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-3.3.2.4
+    title: CIS Fedora 5 - 3.3.2.4
+    objective: CIS Fedora 5 - 3.3.2.4
+    group: access-auth
+    assessment-requirements:
+      - id: accounts_password_pam_maxrepeat
+        text: CIS Fedora 5 - 3.3.2.4 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-3.3.2.6
+    title: CIS Fedora 5 - 3.3.2.6
+    objective: CIS Fedora 5 - 3.3.2.6
+    group: access-auth
+    assessment-requirements:
+      - id: accounts_password_pam_dictcheck
+        text: CIS Fedora 5 - 3.3.2.6 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-3.3.2.7
+    title: CIS Fedora 5 - 3.3.2.7
+    objective: CIS Fedora 5 - 3.3.2.7
+    group: access-auth
+    assessment-requirements:
+      - id: accounts_password_pam_enforce_root
+        text: CIS Fedora 5 - 3.3.2.7 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-3.3.3.1
+    title: CIS Fedora 5 - 3.3.3.1
+    objective: CIS Fedora 5 - 3.3.3.1
+    group: access-auth
+    assessment-requirements:
+      - id: accounts_password_pam_pwhistory_remember_password_auth
+        text: CIS Fedora 5 - 3.3.3.1 MUST be verified
+        applicability:
+          - fedora-linux
+      - id: accounts_password_pam_pwhistory_remember_system_auth
+        text: CIS Fedora 5 - 3.3.3.1 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-3.3.4.1
+    title: CIS Fedora 5 - 3.3.4.1
+    objective: CIS Fedora 5 - 3.3.4.1
+    group: access-auth
+    assessment-requirements:
+      - id: no_empty_passwords
+        text: CIS Fedora 5 - 3.3.4.1 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-3.3.4.3
+    title: CIS Fedora 5 - 3.3.4.3
+    objective: CIS Fedora 5 - 3.3.4.3
+    group: access-auth
+    assessment-requirements:
+      - id: set_password_hashing_algorithm_passwordauth
+        text: CIS Fedora 5 - 3.3.4.3 MUST be verified
+        applicability:
+          - fedora-linux
+      - id: set_password_hashing_algorithm_systemauth
+        text: CIS Fedora 5 - 3.3.4.3 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-4.1.1
+    title: Ensure Password Expiration Is Configured
+    objective: Ensure Password Expiration Is Configured
+    group: access-auth
+    assessment-requirements:
+      - id: accounts_maximum_age_login_defs
+        text: Password Expiration Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: accounts_password_set_max_life_existing
+        text: Password Expiration Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-4.1.3
+    title: Ensure Password Expiration Warning Days Is Configured
+    objective: Ensure Password Expiration Warning Days Is Configured
+    group: access-auth
+    assessment-requirements:
+      - id: accounts_password_set_warn_age_existing
+        text: Password Expiration Warning Days Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: accounts_password_warn_age_login_defs
+        text: Password Expiration Warning Days Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-4.1.4
+    title: Ensure Strong Password Hashing Algorithm Is Configured
+    objective: Ensure Strong Password Hashing Algorithm Is Configured
+    group: access-auth
+    assessment-requirements:
+      - id: set_password_hashing_algorithm_logindefs
+        text: Strong Password Hashing Algorithm Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-4.1.5
+    title: Ensure Inactive Password Lock Is Configured
+    objective: Ensure Inactive Password Lock Is Configured
+    group: access-auth
+    assessment-requirements:
+      - id: account_disable_post_pw_expiration
+        text: Inactive Password Lock Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: accounts_set_post_pw_existing
+        text: Inactive Password Lock Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-4.1.6
+    title: Ensure All Users Last Password Change Date Is In The Past
+    objective: Ensure All Users Last Password Change Date Is In The Past
+    group: access-auth
+    assessment-requirements:
+      - id: accounts_password_last_change_is_in_past
+        text: All Users Last Password Change Date Is In The Past MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-4.2.1
+    title: Ensure Root Is The Only Uid 0 Account
+    objective: Ensure Root Is The Only Uid 0 Account
+    group: access-auth
+    assessment-requirements:
+      - id: accounts_no_uid_except_zero
+        text: Root Is The Only Uid 0 Account MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-4.2.2
+    title: Ensure Root Is The Only Gid 0 Account
+    objective: Ensure Root Is The Only Gid 0 Account
+    group: access-auth
+    assessment-requirements:
+      - id: accounts_root_gid_zero
+        text: Root Is The Only Gid 0 Account MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-4.2.4
+    title: Ensure Root Account Access Is Controlled
+    objective: Ensure Root Account Access Is Controlled
+    group: access-auth
+    assessment-requirements:
+      - id: ensure_root_password_configured
+        text: Root Account Access Is Controlled MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-4.2.5
+    title: Ensure Root Path Integrity
+    objective: Ensure Root Path Integrity
+    group: access-auth
+    assessment-requirements:
+      - id: accounts_root_path_dirs_no_write
+        text: Root Path Integrity MUST be verified
+        applicability:
+          - fedora-linux
+      - id: root_path_no_dot
+        text: Root Path Integrity MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-4.2.7
+    title: Ensure System Accounts Do Not Have A Valid Login Shell
+    objective: Ensure System Accounts Do Not Have A Valid Login Shell
+    group: access-auth
+    assessment-requirements:
+      - id: no_password_auth_for_systemaccounts
+        text: System Accounts Do Not Have A Valid Login Shell MUST be verified
+        applicability:
+          - fedora-linux
+      - id: no_shelllogin_for_systemaccounts
+        text: System Accounts Do Not Have A Valid Login Shell MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-4.3.2
+    title: Ensure Default User Shell Timeout Is Configured
+    objective: Ensure Default User Shell Timeout Is Configured
+    group: access-auth
+    assessment-requirements:
+      - id: accounts_tmout
+        text: Default User Shell Timeout Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_5-4.3.3
+    title: Ensure Default User Umask Is Configured
+    objective: Ensure Default User Umask Is Configured
+    group: access-auth
+    assessment-requirements:
+      - id: accounts_umask_etc_bashrc
+        text: Default User Umask Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: accounts_umask_etc_login_defs
+        text: Default User Umask Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: accounts_umask_etc_profile
+        text: Default User Umask Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_6-1.1
+    title: Ensure Aide Is Installed
+    objective: Ensure Aide Is Installed
+    group: logging
+    assessment-requirements:
+      - id: aide_build_database
+        text: Aide Is Installed MUST be verified
+        applicability:
+          - fedora-linux
+      - id: package_aide_installed
+        text: Aide Is Installed MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_6-1.2
+    title: Ensure Filesystem Integrity Is Regularly Checked
+    objective: Ensure Filesystem Integrity Is Regularly Checked
+    group: logging
+    assessment-requirements:
+      - id: aide_periodic_cron_checking
+        text: Filesystem Integrity Is Regularly Checked MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_6-1.3
+    title: Ensure Cryptographic Mechanisms Are Used To Protect The Integrity Of Audit Tools
+    objective: Ensure Cryptographic Mechanisms Are Used To Protect The Integrity Of Audit Tools
+    group: logging
+    assessment-requirements:
+      - id: aide_check_audit_tools
+        text: Cryptographic Mechanisms Are Used To Protect The Integrity Of Audit Tools MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_6-2.1.1
+    title: Ensure Journald Service Is Active
+    objective: Ensure Journald Service Is Active
+    group: logging
+    assessment-requirements:
+      - id: service_systemd-journald_enabled
+        text: Journald Service Is Active MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_6-2.2.1.1
+    title: CIS Fedora 6 - 2.2.1.1
+    objective: CIS Fedora 6 - 2.2.1.1
+    group: logging
+    assessment-requirements:
+      - id: package_systemd-journal-remote_installed
+        text: CIS Fedora 6 - 2.2.1.1 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_6-2.2.1.4
+    title: CIS Fedora 6 - 2.2.1.4
+    objective: CIS Fedora 6 - 2.2.1.4
+    group: logging
+    assessment-requirements:
+      - id: socket_systemd-journal-remote_disabled
+        text: CIS Fedora 6 - 2.2.1.4 MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_6-2.2.3
+    title: Ensure Journald Compress Is Configured
+    objective: Ensure Journald Compress Is Configured
+    group: logging
+    assessment-requirements:
+      - id: journald_compress
+        text: Journald Compress Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_6-2.2.4
+    title: Ensure Journald Storage Is Configured
+    objective: Ensure Journald Storage Is Configured
+    group: logging
+    assessment-requirements:
+      - id: journald_storage
+        text: Journald Storage Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_6-2.6.1
+    title: Ensure Access To All Logfiles Has Been Configured
+    objective: Ensure Access To All Logfiles Has Been Configured
+    group: logging
+    assessment-requirements:
+      - id: rsyslog_files_groupownership
+        text: Access To All Logfiles Has Been Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: rsyslog_files_ownership
+        text: Access To All Logfiles Has Been Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: rsyslog_files_permissions
+        text: Access To All Logfiles Has Been Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_7-1.1
+    title: Ensure Access To /Etc/Passwd Is Configured
+    objective: Ensure Access To /Etc/Passwd Is Configured
+    group: maintenance
+    assessment-requirements:
+      - id: file_groupowner_etc_passwd
+        text: Access To /Etc/Passwd Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_owner_etc_passwd
+        text: Access To /Etc/Passwd Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_permissions_etc_passwd
+        text: Access To /Etc/Passwd Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_7-1.2
+    title: Ensure Access To /Etc/Passwd- Is Configured
+    objective: Ensure Access To /Etc/Passwd- Is Configured
+    group: maintenance
+    assessment-requirements:
+      - id: file_groupowner_backup_etc_passwd
+        text: Access To /Etc/Passwd- Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_owner_backup_etc_passwd
+        text: Access To /Etc/Passwd- Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_permissions_backup_etc_passwd
+        text: Access To /Etc/Passwd- Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_7-1.3
+    title: Ensure Access To /Etc/Group Is Configured
+    objective: Ensure Access To /Etc/Group Is Configured
+    group: maintenance
+    assessment-requirements:
+      - id: file_groupowner_etc_group
+        text: Access To /Etc/Group Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_owner_etc_group
+        text: Access To /Etc/Group Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_permissions_etc_group
+        text: Access To /Etc/Group Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_7-1.4
+    title: Ensure Access To /Etc/Group- Is Configured
+    objective: Ensure Access To /Etc/Group- Is Configured
+    group: maintenance
+    assessment-requirements:
+      - id: file_groupowner_backup_etc_group
+        text: Access To /Etc/Group- Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_owner_backup_etc_group
+        text: Access To /Etc/Group- Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_permissions_backup_etc_group
+        text: Access To /Etc/Group- Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_7-1.5
+    title: Ensure Access To /Etc/Shadow Is Configured
+    objective: Ensure Access To /Etc/Shadow Is Configured
+    group: maintenance
+    assessment-requirements:
+      - id: file_groupowner_etc_shadow
+        text: Access To /Etc/Shadow Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_owner_etc_shadow
+        text: Access To /Etc/Shadow Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_permissions_etc_shadow
+        text: Access To /Etc/Shadow Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_7-1.6
+    title: Ensure Access To /Etc/Shadow- Is Configured
+    objective: Ensure Access To /Etc/Shadow- Is Configured
+    group: maintenance
+    assessment-requirements:
+      - id: file_groupowner_backup_etc_shadow
+        text: Access To /Etc/Shadow- Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_owner_backup_etc_shadow
+        text: Access To /Etc/Shadow- Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_permissions_backup_etc_shadow
+        text: Access To /Etc/Shadow- Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_7-1.7
+    title: Ensure Access To /Etc/Gshadow Is Configured
+    objective: Ensure Access To /Etc/Gshadow Is Configured
+    group: maintenance
+    assessment-requirements:
+      - id: file_groupowner_etc_gshadow
+        text: Access To /Etc/Gshadow Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_owner_etc_gshadow
+        text: Access To /Etc/Gshadow Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_permissions_etc_gshadow
+        text: Access To /Etc/Gshadow Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_7-1.8
+    title: Ensure Access To /Etc/Gshadow- Is Configured
+    objective: Ensure Access To /Etc/Gshadow- Is Configured
+    group: maintenance
+    assessment-requirements:
+      - id: file_groupowner_backup_etc_gshadow
+        text: Access To /Etc/Gshadow- Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_owner_backup_etc_gshadow
+        text: Access To /Etc/Gshadow- Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_permissions_backup_etc_gshadow
+        text: Access To /Etc/Gshadow- Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_7-1.9
+    title: Ensure Access To /Etc/Shells Is Configured
+    objective: Ensure Access To /Etc/Shells Is Configured
+    group: maintenance
+    assessment-requirements:
+      - id: file_groupowner_etc_shells
+        text: Access To /Etc/Shells Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_owner_etc_shells
+        text: Access To /Etc/Shells Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_permissions_etc_shells
+        text: Access To /Etc/Shells Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_7-1.11
+    title: Ensure World Writable Files And Directories Are Secured
+    objective: Ensure World Writable Files And Directories Are Secured
+    group: maintenance
+    assessment-requirements:
+      - id: dir_perms_world_writable_sticky_bits
+        text: World Writable Files And Directories Are Secured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_permissions_unauthorized_world_writable
+        text: World Writable Files And Directories Are Secured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_7-2.1
+    title: Ensure Accounts In /Etc/Passwd Use Shadowed Passwords
+    objective: Ensure Accounts In /Etc/Passwd Use Shadowed Passwords
+    group: maintenance
+    assessment-requirements:
+      - id: accounts_password_all_shadowed
+        text: Accounts In /Etc/Passwd Use Shadowed Passwords MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_7-2.2
+    title: Ensure /Etc/Shadow Password Fields Are Not Empty
+    objective: Ensure /Etc/Shadow Password Fields Are Not Empty
+    group: maintenance
+    assessment-requirements:
+      - id: no_empty_passwords_etc_shadow
+        text: /Etc/Shadow Password Fields Are Not Empty MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_7-2.3
+    title: Ensure All Groups In /Etc/Passwd Exist In /Etc/Group
+    objective: Ensure All Groups In /Etc/Passwd Exist In /Etc/Group
+    group: maintenance
+    assessment-requirements:
+      - id: gid_passwd_group_same
+        text: All Groups In /Etc/Passwd Exist In /Etc/Group MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_7-2.4
+    title: Ensure No Duplicate Uids Exist
+    objective: Ensure No Duplicate Uids Exist
+    group: maintenance
+    assessment-requirements:
+      - id: account_unique_id
+        text: No Duplicate Uids Exist MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_7-2.5
+    title: Ensure No Duplicate Gids Exist
+    objective: Ensure No Duplicate Gids Exist
+    group: maintenance
+    assessment-requirements:
+      - id: group_unique_id
+        text: No Duplicate Gids Exist MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_7-2.6
+    title: Ensure No Duplicate User Names Exist
+    objective: Ensure No Duplicate User Names Exist
+    group: maintenance
+    assessment-requirements:
+      - id: account_unique_name
+        text: No Duplicate User Names Exist MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_7-2.7
+    title: Ensure No Duplicate Group Names Exist
+    objective: Ensure No Duplicate Group Names Exist
+    group: maintenance
+    assessment-requirements:
+      - id: group_unique_name
+        text: No Duplicate Group Names Exist MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_7-2.8
+    title: Ensure Local Interactive User Home Directories Are Configured
+    objective: Ensure Local Interactive User Home Directories Are Configured
+    group: maintenance
+    assessment-requirements:
+      - id: accounts_user_interactive_home_directory_exists
+        text: Local Interactive User Home Directories Are Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_ownership_home_directories
+        text: Local Interactive User Home Directories Are Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_permissions_home_directories
+        text: Local Interactive User Home Directories Are Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: cis_fedora_7-2.9
+    title: Ensure Local Interactive User Dot Files Access Is Configured
+    objective: Ensure Local Interactive User Dot Files Access Is Configured
+    group: maintenance
+    assessment-requirements:
+      - id: accounts_user_dot_group_ownership
+        text: Local Interactive User Dot Files Access Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: accounts_user_dot_user_ownership
+        text: Local Interactive User Dot Files Access Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: file_permission_user_init_files
+        text: Local Interactive User Dot Files Access Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: no_forward_files
+        text: Local Interactive User Dot Files Access Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+      - id: no_netrc_files
+        text: Local Interactive User Dot Files Access Is Configured MUST be verified
+        applicability:
+          - fedora-linux
+  - id: reload_dconf_db
+    title: Reload Dconf Database
+    objective: Reload Dconf Database
+    group: operations
+    assessment-requirements:
+      - id: dconf_db_up_to_date
+        text: The dconf database MUST be reloaded after configuration changes
+        applicability:
+          - fedora-linux

--- a/governance/catalogs/cis-fedora-l1-workstation-catalog.yaml
+++ b/governance/catalogs/cis-fedora-l1-workstation-catalog.yaml
@@ -1,0 +1,2154 @@
+title: CIS Fedora Linux - Level 1 Workstation
+metadata:
+    id: cis-fedora-l1-workstation
+    type: ControlCatalog
+    gemara-version: "0.24.0"
+    description: Control catalog derived from the CIS Fedora Linux Level 1 Workstation Benchmark
+    author:
+        id: complytime
+        name: ComplyTime
+        type: Software
+    applicability-groups:
+        - id: fedora-linux
+          title: Fedora Linux
+          description: Fedora Linux operating system
+groups:
+    - id: initial-setup
+      title: Initial Setup
+      description: Filesystem, software updates, SELinux, boot, kernel, crypto, and banner configuration
+    - id: services
+      title: Services
+      description: Network services, client packages, and time synchronization configuration
+    - id: network
+      title: Network Configuration
+      description: Kernel modules, IPv4, and IPv6 network stack configuration
+    - id: firewall
+      title: Host-Based Firewall
+      description: Firewall package installation and traffic filtering configuration
+    - id: access-auth
+      title: Access, Authentication, and Authorization
+      description: SSH, sudo, PAM, password, user account, and shell configuration
+    - id: logging
+      title: Logging and Auditing
+      description: System logging, journald, and file integrity monitoring configuration
+    - id: maintenance
+      title: System Maintenance
+      description: File permissions, user/group integrity, and home directory configuration
+    - id: operations
+      title: Operations
+      description: Operational tasks required for configuration application
+controls:
+    - id: cis_fedora_1-1.1.1
+      title: Ensure Cramfs Kernel Module Is Not Available
+      objective: Ensure Cramfs Kernel Module Is Not Available
+      group: initial-setup
+      assessment-requirements:
+          - id: kernel_module_cramfs_disabled
+            text: Cramfs Kernel Module Is Not Available MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-1.1.2
+      title: Ensure Freevxfs Kernel Module Is Not Available
+      objective: Ensure Freevxfs Kernel Module Is Not Available
+      group: initial-setup
+      assessment-requirements:
+          - id: kernel_module_freevxfs_disabled
+            text: Freevxfs Kernel Module Is Not Available MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-1.1.3
+      title: Ensure Hfs Kernel Module Is Not Available
+      objective: Ensure Hfs Kernel Module Is Not Available
+      group: initial-setup
+      assessment-requirements:
+          - id: kernel_module_hfs_disabled
+            text: Hfs Kernel Module Is Not Available MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-1.1.4
+      title: Ensure Hfsplus Kernel Module Is Not Available
+      objective: Ensure Hfsplus Kernel Module Is Not Available
+      group: initial-setup
+      assessment-requirements:
+          - id: kernel_module_hfsplus_disabled
+            text: Hfsplus Kernel Module Is Not Available MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-1.1.5
+      title: Ensure Jffs2 Kernel Module Is Not Available
+      objective: Ensure Jffs2 Kernel Module Is Not Available
+      group: initial-setup
+      assessment-requirements:
+          - id: kernel_module_jffs2_disabled
+            text: Jffs2 Kernel Module Is Not Available MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-1.2.1.1
+      title: CIS Fedora 1 - 1.2.1.1
+      objective: CIS Fedora 1 - 1.2.1.1
+      group: initial-setup
+      assessment-requirements:
+          - id: partition_for_tmp
+            text: CIS Fedora 1 - 1.2.1.1 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-1.2.1.2
+      title: CIS Fedora 1 - 1.2.1.2
+      objective: CIS Fedora 1 - 1.2.1.2
+      group: initial-setup
+      assessment-requirements:
+          - id: mount_option_tmp_nodev
+            text: CIS Fedora 1 - 1.2.1.2 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-1.2.1.3
+      title: CIS Fedora 1 - 1.2.1.3
+      objective: CIS Fedora 1 - 1.2.1.3
+      group: initial-setup
+      assessment-requirements:
+          - id: mount_option_tmp_nosuid
+            text: CIS Fedora 1 - 1.2.1.3 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-1.2.1.4
+      title: CIS Fedora 1 - 1.2.1.4
+      objective: CIS Fedora 1 - 1.2.1.4
+      group: initial-setup
+      assessment-requirements:
+          - id: mount_option_tmp_noexec
+            text: CIS Fedora 1 - 1.2.1.4 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-1.2.2.1
+      title: CIS Fedora 1 - 1.2.2.1
+      objective: CIS Fedora 1 - 1.2.2.1
+      group: initial-setup
+      assessment-requirements:
+          - id: partition_for_dev_shm
+            text: CIS Fedora 1 - 1.2.2.1 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-1.2.2.2
+      title: CIS Fedora 1 - 1.2.2.2
+      objective: CIS Fedora 1 - 1.2.2.2
+      group: initial-setup
+      assessment-requirements:
+          - id: mount_option_dev_shm_nodev
+            text: CIS Fedora 1 - 1.2.2.2 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-1.2.2.3
+      title: CIS Fedora 1 - 1.2.2.3
+      objective: CIS Fedora 1 - 1.2.2.3
+      group: initial-setup
+      assessment-requirements:
+          - id: mount_option_dev_shm_nosuid
+            text: CIS Fedora 1 - 1.2.2.3 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-1.2.2.4
+      title: CIS Fedora 1 - 1.2.2.4
+      objective: CIS Fedora 1 - 1.2.2.4
+      group: initial-setup
+      assessment-requirements:
+          - id: mount_option_dev_shm_noexec
+            text: CIS Fedora 1 - 1.2.2.4 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-1.2.3.2
+      title: CIS Fedora 1 - 1.2.3.2
+      objective: CIS Fedora 1 - 1.2.3.2
+      group: initial-setup
+      assessment-requirements:
+          - id: mount_option_home_nodev
+            text: CIS Fedora 1 - 1.2.3.2 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-1.2.3.3
+      title: CIS Fedora 1 - 1.2.3.3
+      objective: CIS Fedora 1 - 1.2.3.3
+      group: initial-setup
+      assessment-requirements:
+          - id: mount_option_home_nosuid
+            text: CIS Fedora 1 - 1.2.3.3 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-1.2.4.2
+      title: CIS Fedora 1 - 1.2.4.2
+      objective: CIS Fedora 1 - 1.2.4.2
+      group: initial-setup
+      assessment-requirements:
+          - id: mount_option_var_nodev
+            text: CIS Fedora 1 - 1.2.4.2 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-1.2.4.3
+      title: CIS Fedora 1 - 1.2.4.3
+      objective: CIS Fedora 1 - 1.2.4.3
+      group: initial-setup
+      assessment-requirements:
+          - id: mount_option_var_nosuid
+            text: CIS Fedora 1 - 1.2.4.3 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-1.2.5.2
+      title: CIS Fedora 1 - 1.2.5.2
+      objective: CIS Fedora 1 - 1.2.5.2
+      group: initial-setup
+      assessment-requirements:
+          - id: mount_option_var_tmp_nodev
+            text: CIS Fedora 1 - 1.2.5.2 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-1.2.5.3
+      title: CIS Fedora 1 - 1.2.5.3
+      objective: CIS Fedora 1 - 1.2.5.3
+      group: initial-setup
+      assessment-requirements:
+          - id: mount_option_var_tmp_nosuid
+            text: CIS Fedora 1 - 1.2.5.3 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-1.2.5.4
+      title: CIS Fedora 1 - 1.2.5.4
+      objective: CIS Fedora 1 - 1.2.5.4
+      group: initial-setup
+      assessment-requirements:
+          - id: mount_option_var_tmp_noexec
+            text: CIS Fedora 1 - 1.2.5.4 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-1.2.6.2
+      title: CIS Fedora 1 - 1.2.6.2
+      objective: CIS Fedora 1 - 1.2.6.2
+      group: initial-setup
+      assessment-requirements:
+          - id: mount_option_var_log_nodev
+            text: CIS Fedora 1 - 1.2.6.2 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-1.2.6.3
+      title: CIS Fedora 1 - 1.2.6.3
+      objective: CIS Fedora 1 - 1.2.6.3
+      group: initial-setup
+      assessment-requirements:
+          - id: mount_option_var_log_nosuid
+            text: CIS Fedora 1 - 1.2.6.3 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-1.2.6.4
+      title: CIS Fedora 1 - 1.2.6.4
+      objective: CIS Fedora 1 - 1.2.6.4
+      group: initial-setup
+      assessment-requirements:
+          - id: mount_option_var_log_noexec
+            text: CIS Fedora 1 - 1.2.6.4 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-1.2.7.2
+      title: CIS Fedora 1 - 1.2.7.2
+      objective: CIS Fedora 1 - 1.2.7.2
+      group: initial-setup
+      assessment-requirements:
+          - id: mount_option_var_log_audit_nodev
+            text: CIS Fedora 1 - 1.2.7.2 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-1.2.7.3
+      title: CIS Fedora 1 - 1.2.7.3
+      objective: CIS Fedora 1 - 1.2.7.3
+      group: initial-setup
+      assessment-requirements:
+          - id: mount_option_var_log_audit_nosuid
+            text: CIS Fedora 1 - 1.2.7.3 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-1.2.7.4
+      title: CIS Fedora 1 - 1.2.7.4
+      objective: CIS Fedora 1 - 1.2.7.4
+      group: initial-setup
+      assessment-requirements:
+          - id: mount_option_var_log_audit_noexec
+            text: CIS Fedora 1 - 1.2.7.4 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-2.1.2
+      title: Ensure Gpgcheck Is Configured
+      objective: Ensure Gpgcheck Is Configured
+      group: initial-setup
+      assessment-requirements:
+          - id: ensure_gpgcheck_globally_activated
+            text: Gpgcheck Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-3.1.1
+      title: Ensure Selinux Is Installed
+      objective: Ensure Selinux Is Installed
+      group: initial-setup
+      assessment-requirements:
+          - id: package_libselinux_installed
+            text: Selinux Is Installed MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-3.1.2
+      title: Ensure Selinux Is Not Disabled In Bootloader Configuration
+      objective: Ensure Selinux Is Not Disabled In Bootloader Configuration
+      group: initial-setup
+      assessment-requirements:
+          - id: grub2_enable_selinux
+            text: Selinux Is Not Disabled In Bootloader Configuration MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-3.1.3
+      title: Ensure Selinux Policy Is Configured
+      objective: Ensure Selinux Policy Is Configured
+      group: initial-setup
+      assessment-requirements:
+          - id: selinux_policytype
+            text: Selinux Policy Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-3.1.4
+      title: Ensure The Selinux Mode Is Not Disabled
+      objective: Ensure The Selinux Mode Is Not Disabled
+      group: initial-setup
+      assessment-requirements:
+          - id: selinux_not_disabled
+            text: The Selinux Mode Is Not Disabled MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-3.1.7
+      title: Ensure The Mcs Translation Service (Mcstrans) Is Not Installed
+      objective: Ensure The Mcs Translation Service (Mcstrans) Is Not Installed
+      group: initial-setup
+      assessment-requirements:
+          - id: package_mcstrans_removed
+            text: The Mcs Translation Service (Mcstrans) Is Not Installed MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-4.1
+      title: Ensure Bootloader Password Is Set
+      objective: Ensure Bootloader Password Is Set
+      group: initial-setup
+      assessment-requirements:
+          - id: grub2_password
+            text: Bootloader Password Is Set MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-5.1
+      title: Ensure Core File Size Is Configured
+      objective: Ensure Core File Size Is Configured
+      group: initial-setup
+      assessment-requirements:
+          - id: disable_users_coredumps
+            text: Core File Size Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-5.10
+      title: Ensure Systemd-Coredump Storage Is Configured
+      objective: Ensure Systemd-Coredump Storage Is Configured
+      group: initial-setup
+      assessment-requirements:
+          - id: coredump_disable_storage
+            text: Systemd-Coredump Storage Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-5.2
+      title: Ensure Fs.Protected_Hardlinks Is Configured
+      objective: Ensure Fs.Protected_Hardlinks Is Configured
+      group: initial-setup
+      assessment-requirements:
+          - id: sysctl_fs_protected_hardlinks
+            text: Fs.Protected_Hardlinks Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-5.3
+      title: Ensure Fs.Protected_Symlinks Is Configured
+      objective: Ensure Fs.Protected_Symlinks Is Configured
+      group: initial-setup
+      assessment-requirements:
+          - id: sysctl_fs_protected_symlinks
+            text: Fs.Protected_Symlinks Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-5.4
+      title: Ensure Fs.Suid_Dumpable Is Configured
+      objective: Ensure Fs.Suid_Dumpable Is Configured
+      group: initial-setup
+      assessment-requirements:
+          - id: sysctl_fs_suid_dumpable
+            text: Fs.Suid_Dumpable Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-5.5
+      title: Ensure Kernel.Dmesg_Restrict Is Configured
+      objective: Ensure Kernel.Dmesg_Restrict Is Configured
+      group: initial-setup
+      assessment-requirements:
+          - id: sysctl_kernel_dmesg_restrict
+            text: Kernel.Dmesg_Restrict Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-5.6
+      title: Ensure Kernel.Kptr_Restrict Is Configured
+      objective: Ensure Kernel.Kptr_Restrict Is Configured
+      group: initial-setup
+      assessment-requirements:
+          - id: sysctl_kernel_kptr_restrict
+            text: Kernel.Kptr_Restrict Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-5.7
+      title: Ensure Kernel.Yama.Ptrace_Scope Is Configured
+      objective: Ensure Kernel.Yama.Ptrace_Scope Is Configured
+      group: initial-setup
+      assessment-requirements:
+          - id: sysctl_kernel_yama_ptrace_scope
+            text: Kernel.Yama.Ptrace_Scope Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-5.8
+      title: Ensure Kernel.Randomize_Va_Space Is Configured
+      objective: Ensure Kernel.Randomize_Va_Space Is Configured
+      group: initial-setup
+      assessment-requirements:
+          - id: sysctl_kernel_randomize_va_space
+            text: Kernel.Randomize_Va_Space Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-5.9
+      title: Ensure Systemd-Coredump Processsizemax Is Configured
+      objective: Ensure Systemd-Coredump Processsizemax Is Configured
+      group: initial-setup
+      assessment-requirements:
+          - id: coredump_disable_backtraces
+            text: Systemd-Coredump Processsizemax Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-6.2
+      title: Ensure System Wide Crypto Policy Disables Sha1 Hash And Signature Support
+      objective: Ensure System Wide Crypto Policy Disables Sha1 Hash And Signature Support
+      group: initial-setup
+      assessment-requirements:
+          - id: cis_fedora_1-6.2-ar
+            text: System Wide Crypto Policy Disables Sha1 Hash And Signature Support MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-6.3
+      title: Ensure System Wide Crypto Policy Macs Are Configured
+      objective: Ensure System Wide Crypto Policy Macs Are Configured
+      group: initial-setup
+      assessment-requirements:
+          - id: cis_fedora_1-6.3-ar
+            text: System Wide Crypto Policy Macs Are Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-6.4
+      title: Ensure System Wide Crypto Policy Disables Cbc For Ssh
+      objective: Ensure System Wide Crypto Policy Disables Cbc For Ssh
+      group: initial-setup
+      assessment-requirements:
+          - id: cis_fedora_1-6.4-ar
+            text: System Wide Crypto Policy Disables Cbc For Ssh MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-7.1
+      title: Ensure /Etc/Motd Is Configured
+      objective: Ensure /Etc/Motd Is Configured
+      group: initial-setup
+      assessment-requirements:
+          - id: banner_etc_motd_cis
+            text: /Etc/Motd Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-7.2
+      title: Ensure /Etc/Issue Is Configured
+      objective: Ensure /Etc/Issue Is Configured
+      group: initial-setup
+      assessment-requirements:
+          - id: banner_etc_issue_cis
+            text: /Etc/Issue Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-7.3
+      title: Ensure /Etc/Issue.Net Is Configured
+      objective: Ensure /Etc/Issue.Net Is Configured
+      group: initial-setup
+      assessment-requirements:
+          - id: banner_etc_issue_net_cis
+            text: /Etc/Issue.Net Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-7.4
+      title: Ensure Access To /Etc/Motd Is Configured
+      objective: Ensure Access To /Etc/Motd Is Configured
+      group: initial-setup
+      assessment-requirements:
+          - id: file_groupowner_etc_motd
+            text: Access To /Etc/Motd Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_owner_etc_motd
+            text: Access To /Etc/Motd Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_permissions_etc_motd
+            text: Access To /Etc/Motd Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-7.5
+      title: Ensure Access To /Etc/Issue Is Configured
+      objective: Ensure Access To /Etc/Issue Is Configured
+      group: initial-setup
+      assessment-requirements:
+          - id: file_groupowner_etc_issue
+            text: Access To /Etc/Issue Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_owner_etc_issue
+            text: Access To /Etc/Issue Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_permissions_etc_issue
+            text: Access To /Etc/Issue Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-7.6
+      title: Ensure Access To /Etc/Issue.Net Is Configured
+      objective: Ensure Access To /Etc/Issue.Net Is Configured
+      group: initial-setup
+      assessment-requirements:
+          - id: file_groupowner_etc_issue_net
+            text: Access To /Etc/Issue.Net Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_owner_etc_issue_net
+            text: Access To /Etc/Issue.Net Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_permissions_etc_issue_net
+            text: Access To /Etc/Issue.Net Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-8.1
+      title: Ensure Gdm Login Banner Is Configured
+      objective: Ensure Gdm Login Banner Is Configured
+      group: initial-setup
+      assessment-requirements:
+          - id: dconf_gnome_banner_enabled
+            text: Gdm Login Banner Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: dconf_gnome_login_banner_text
+            text: Gdm Login Banner Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-8.2
+      title: Ensure Gdm Disable-User-List Is Configured
+      objective: Ensure Gdm Disable-User-List Is Configured
+      group: initial-setup
+      assessment-requirements:
+          - id: dconf_gnome_disable_user_list
+            text: Gdm Disable-User-List Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-8.3
+      title: Ensure Gdm Screen Lock Is Configured
+      objective: Ensure Gdm Screen Lock Is Configured
+      group: initial-setup
+      assessment-requirements:
+          - id: dconf_gnome_screensaver_idle_delay
+            text: Gdm Screen Lock Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: dconf_gnome_screensaver_lock_delay
+            text: Gdm Screen Lock Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: dconf_gnome_screensaver_user_locks
+            text: Gdm Screen Lock Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: dconf_gnome_session_idle_user_locks
+            text: Gdm Screen Lock Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_1-8.5
+      title: Ensure Gdm Autorun-Never Is Configured
+      objective: Ensure Gdm Autorun-Never Is Configured
+      group: initial-setup
+      assessment-requirements:
+          - id: dconf_gnome_disable_autorun
+            text: Gdm Autorun-Never Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_2-1.12
+      title: Ensure Rpcbind Services Are Not In Use
+      objective: Ensure Rpcbind Services Are Not In Use
+      group: services
+      assessment-requirements:
+          - id: service_rpcbind_disabled
+            text: Rpcbind Services Are Not In Use MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_2-1.13
+      title: Ensure Rsync Services Are Not In Use
+      objective: Ensure Rsync Services Are Not In Use
+      group: services
+      assessment-requirements:
+          - id: package_rsync_removed
+            text: Rsync Services Are Not In Use MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_2-1.14
+      title: Ensure Samba File Server Services Are Not In Use
+      objective: Ensure Samba File Server Services Are Not In Use
+      group: services
+      assessment-requirements:
+          - id: package_samba_removed
+            text: Samba File Server Services Are Not In Use MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_2-1.15
+      title: Ensure Snmp Services Are Not In Use
+      objective: Ensure Snmp Services Are Not In Use
+      group: services
+      assessment-requirements:
+          - id: package_net-snmp_removed
+            text: Snmp Services Are Not In Use MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_2-1.16
+      title: Ensure Telnet Server Services Are Not In Use
+      objective: Ensure Telnet Server Services Are Not In Use
+      group: services
+      assessment-requirements:
+          - id: package_telnet-server_removed
+            text: Telnet Server Services Are Not In Use MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_2-1.17
+      title: Ensure Tftp Server Services Are Not In Use
+      objective: Ensure Tftp Server Services Are Not In Use
+      group: services
+      assessment-requirements:
+          - id: package_tftp-server_removed
+            text: Tftp Server Services Are Not In Use MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_2-1.18
+      title: Ensure Web Proxy Server Services Are Not In Use
+      objective: Ensure Web Proxy Server Services Are Not In Use
+      group: services
+      assessment-requirements:
+          - id: package_squid_removed
+            text: Web Proxy Server Services Are Not In Use MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_2-1.19
+      title: Ensure Web Server Services Are Not In Use
+      objective: Ensure Web Server Services Are Not In Use
+      group: services
+      assessment-requirements:
+          - id: package_httpd_removed
+            text: Web Server Services Are Not In Use MUST be verified
+            applicability:
+                - fedora-linux
+          - id: package_nginx_removed
+            text: Web Server Services Are Not In Use MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_2-1.23
+      title: Ensure Mail Transfer Agents Are Configured For Local-Only Mode
+      objective: Ensure Mail Transfer Agents Are Configured For Local-Only Mode
+      group: services
+      assessment-requirements:
+          - id: has_nonlocal_mta
+            text: Mail Transfer Agents Are Configured For Local-Only Mode MUST be verified
+            applicability:
+                - fedora-linux
+          - id: postfix_network_listening_disabled
+            text: Mail Transfer Agents Are Configured For Local-Only Mode MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_2-1.4
+      title: Ensure Dhcp Server Services Are Not In Use
+      objective: Ensure Dhcp Server Services Are Not In Use
+      group: services
+      assessment-requirements:
+          - id: package_kea_removed
+            text: Dhcp Server Services Are Not In Use MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_2-1.5
+      title: Ensure Dns Server Services Are Not In Use
+      objective: Ensure Dns Server Services Are Not In Use
+      group: services
+      assessment-requirements:
+          - id: package_bind_removed
+            text: Dns Server Services Are Not In Use MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_2-1.6
+      title: Ensure Dnsmasq Services Are Not In Use
+      objective: Ensure Dnsmasq Services Are Not In Use
+      group: services
+      assessment-requirements:
+          - id: package_dnsmasq_removed
+            text: Dnsmasq Services Are Not In Use MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_2-1.7
+      title: Ensure Ftp Server Services Are Not In Use
+      objective: Ensure Ftp Server Services Are Not In Use
+      group: services
+      assessment-requirements:
+          - id: package_vsftpd_removed
+            text: Ftp Server Services Are Not In Use MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_2-1.8
+      title: Ensure Message Access Server Services Are Not In Use
+      objective: Ensure Message Access Server Services Are Not In Use
+      group: services
+      assessment-requirements:
+          - id: package_cyrus-imapd_removed
+            text: Message Access Server Services Are Not In Use MUST be verified
+            applicability:
+                - fedora-linux
+          - id: package_dovecot_removed
+            text: Message Access Server Services Are Not In Use MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_2-1.9
+      title: Ensure Network File System Services Are Not In Use
+      objective: Ensure Network File System Services Are Not In Use
+      group: services
+      assessment-requirements:
+          - id: service_nfs_disabled
+            text: Network File System Services Are Not In Use MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_2-2.1
+      title: Ensure Ftp Client Is Not Installed
+      objective: Ensure Ftp Client Is Not Installed
+      group: services
+      assessment-requirements:
+          - id: package_ftp_removed
+            text: Ftp Client Is Not Installed MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_2-2.4
+      title: Ensure Telnet Client Is Not Installed
+      objective: Ensure Telnet Client Is Not Installed
+      group: services
+      assessment-requirements:
+          - id: package_telnet_removed
+            text: Telnet Client Is Not Installed MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_2-2.5
+      title: Ensure Tftp Client Is Not Installed
+      objective: Ensure Tftp Client Is Not Installed
+      group: services
+      assessment-requirements:
+          - id: package_tftp_removed
+            text: Tftp Client Is Not Installed MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_2-3.2
+      title: Ensure Chrony Is Configured
+      objective: Ensure Chrony Is Configured
+      group: services
+      assessment-requirements:
+          - id: chronyd_specify_remote_server
+            text: Chrony Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_2-3.3
+      title: Ensure Chrony Is Not Run As The Root User
+      objective: Ensure Chrony Is Not Run As The Root User
+      group: services
+      assessment-requirements:
+          - id: chronyd_run_as_chrony_user
+            text: Chrony Is Not Run As The Root User MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_2-4.1.1
+      title: Ensure Cron Daemon Is Enabled And Active
+      objective: Ensure Cron Daemon Is Enabled And Active
+      group: services
+      assessment-requirements:
+          - id: package_cron_installed
+            text: Cron Daemon Is Enabled And Active MUST be verified
+            applicability:
+                - fedora-linux
+          - id: service_crond_enabled
+            text: Cron Daemon Is Enabled And Active MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_2-4.1.2
+      title: Ensure Access To /Etc/Crontab Is Configured
+      objective: Ensure Access To /Etc/Crontab Is Configured
+      group: services
+      assessment-requirements:
+          - id: file_groupowner_crontab
+            text: Access To /Etc/Crontab Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_owner_crontab
+            text: Access To /Etc/Crontab Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_permissions_crontab
+            text: Access To /Etc/Crontab Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_2-4.1.3
+      title: Ensure Access To /Etc/Cron.Hourly Is Configured
+      objective: Ensure Access To /Etc/Cron.Hourly Is Configured
+      group: services
+      assessment-requirements:
+          - id: file_groupowner_cron_hourly
+            text: Access To /Etc/Cron.Hourly Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_owner_cron_hourly
+            text: Access To /Etc/Cron.Hourly Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_permissions_cron_hourly
+            text: Access To /Etc/Cron.Hourly Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_2-4.1.4
+      title: Ensure Access To /Etc/Cron.Daily Is Configured
+      objective: Ensure Access To /Etc/Cron.Daily Is Configured
+      group: services
+      assessment-requirements:
+          - id: file_groupowner_cron_daily
+            text: Access To /Etc/Cron.Daily Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_owner_cron_daily
+            text: Access To /Etc/Cron.Daily Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_permissions_cron_daily
+            text: Access To /Etc/Cron.Daily Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_2-4.1.5
+      title: Ensure Access To /Etc/Cron.Weekly Is Configured
+      objective: Ensure Access To /Etc/Cron.Weekly Is Configured
+      group: services
+      assessment-requirements:
+          - id: file_groupowner_cron_weekly
+            text: Access To /Etc/Cron.Weekly Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_owner_cron_weekly
+            text: Access To /Etc/Cron.Weekly Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_permissions_cron_weekly
+            text: Access To /Etc/Cron.Weekly Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_2-4.1.6
+      title: Ensure Access To /Etc/Cron.Monthly Is Configured
+      objective: Ensure Access To /Etc/Cron.Monthly Is Configured
+      group: services
+      assessment-requirements:
+          - id: file_groupowner_cron_monthly
+            text: Access To /Etc/Cron.Monthly Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_owner_cron_monthly
+            text: Access To /Etc/Cron.Monthly Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_permissions_cron_monthly
+            text: Access To /Etc/Cron.Monthly Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_2-4.1.8
+      title: Ensure Access To /Etc/Cron.D Is Configured
+      objective: Ensure Access To /Etc/Cron.D Is Configured
+      group: services
+      assessment-requirements:
+          - id: file_groupowner_cron_d
+            text: Access To /Etc/Cron.D Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_owner_cron_d
+            text: Access To /Etc/Cron.D Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_permissions_cron_d
+            text: Access To /Etc/Cron.D Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_2-4.1.9
+      title: Ensure Access To Crontab Is Configured
+      objective: Ensure Access To Crontab Is Configured
+      group: services
+      assessment-requirements:
+          - id: file_cron_allow_exists
+            text: Access To Crontab Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_cron_deny_not_exist
+            text: Access To Crontab Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_groupowner_cron_allow
+            text: Access To Crontab Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_owner_cron_allow
+            text: Access To Crontab Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_permissions_cron_allow
+            text: Access To Crontab Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_2-4.2.1
+      title: Ensure Access To At Is Configured
+      objective: Ensure Access To At Is Configured
+      group: services
+      assessment-requirements:
+          - id: file_at_deny_not_exist
+            text: Access To At Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_groupowner_at_allow
+            text: Access To At Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_owner_at_allow
+            text: Access To At Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_permissions_at_allow
+            text: Access To At Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_3-2.1
+      title: Ensure Atm Kernel Module Is Not Available
+      objective: Ensure Atm Kernel Module Is Not Available
+      group: network
+      assessment-requirements:
+          - id: kernel_module_atm_disabled
+            text: Atm Kernel Module Is Not Available MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_3-2.2
+      title: Ensure Can Kernel Module Is Not Available
+      objective: Ensure Can Kernel Module Is Not Available
+      group: network
+      assessment-requirements:
+          - id: kernel_module_can_disabled
+            text: Can Kernel Module Is Not Available MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_3-2.3
+      title: Ensure Dccp Kernel Module Is Not Available
+      objective: Ensure Dccp Kernel Module Is Not Available
+      group: network
+      assessment-requirements:
+          - id: kernel_module_dccp_disabled
+            text: Dccp Kernel Module Is Not Available MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_3-2.4
+      title: Ensure Tipc Kernel Module Is Not Available
+      objective: Ensure Tipc Kernel Module Is Not Available
+      group: network
+      assessment-requirements:
+          - id: kernel_module_tipc_disabled
+            text: Tipc Kernel Module Is Not Available MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_3-2.5
+      title: Ensure Rds Kernel Module Is Not Available
+      objective: Ensure Rds Kernel Module Is Not Available
+      group: network
+      assessment-requirements:
+          - id: kernel_module_rds_disabled
+            text: Rds Kernel Module Is Not Available MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_3-3.1.1
+      title: Ensure Net.Ipv4.Ip_Forward Is Configured
+      objective: Ensure Net.Ipv4.Ip_Forward Is Configured
+      group: network
+      assessment-requirements:
+          - id: sysctl_net_ipv4_ip_forward
+            text: Net.Ipv4.Ip_Forward Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_3-3.1.10
+      title: Ensure Net.Ipv4.Conf.All.Secure_Redirects Is Configured
+      objective: Ensure Net.Ipv4.Conf.All.Secure_Redirects Is Configured
+      group: network
+      assessment-requirements:
+          - id: sysctl_net_ipv4_conf_all_secure_redirects
+            text: Net.Ipv4.Conf.All.Secure_Redirects Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_3-3.1.11
+      title: Ensure Net.Ipv4.Conf.Default.Secure_Redirects Is Configured
+      objective: Ensure Net.Ipv4.Conf.Default.Secure_Redirects Is Configured
+      group: network
+      assessment-requirements:
+          - id: sysctl_net_ipv4_conf_default_secure_redirects
+            text: Net.Ipv4.Conf.Default.Secure_Redirects Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_3-3.1.12
+      title: Ensure Net.Ipv4.Conf.All.Rp_Filter Is Configured
+      objective: Ensure Net.Ipv4.Conf.All.Rp_Filter Is Configured
+      group: network
+      assessment-requirements:
+          - id: sysctl_net_ipv4_conf_all_rp_filter
+            text: Net.Ipv4.Conf.All.Rp_Filter Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_3-3.1.13
+      title: Ensure Net.Ipv4.Conf.Default.Rp_Filter Is Configured
+      objective: Ensure Net.Ipv4.Conf.Default.Rp_Filter Is Configured
+      group: network
+      assessment-requirements:
+          - id: sysctl_net_ipv4_conf_default_rp_filter
+            text: Net.Ipv4.Conf.Default.Rp_Filter Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_3-3.1.14
+      title: Ensure Net.Ipv4.Conf.All.Accept_Source_Route Is Configured
+      objective: Ensure Net.Ipv4.Conf.All.Accept_Source_Route Is Configured
+      group: network
+      assessment-requirements:
+          - id: sysctl_net_ipv4_conf_all_accept_source_route
+            text: Net.Ipv4.Conf.All.Accept_Source_Route Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_3-3.1.15
+      title: Ensure Net.Ipv4.Conf.Default.Accept_Source_Route Is Configured
+      objective: Ensure Net.Ipv4.Conf.Default.Accept_Source_Route Is Configured
+      group: network
+      assessment-requirements:
+          - id: sysctl_net_ipv4_conf_default_accept_source_route
+            text: Net.Ipv4.Conf.Default.Accept_Source_Route Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_3-3.1.16
+      title: Ensure Net.Ipv4.Conf.All.Log_Martians Is Configured
+      objective: Ensure Net.Ipv4.Conf.All.Log_Martians Is Configured
+      group: network
+      assessment-requirements:
+          - id: sysctl_net_ipv4_conf_all_log_martians
+            text: Net.Ipv4.Conf.All.Log_Martians Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_3-3.1.17
+      title: Ensure Net.Ipv4.Conf.Default.Log_Martians Is Configured
+      objective: Ensure Net.Ipv4.Conf.Default.Log_Martians Is Configured
+      group: network
+      assessment-requirements:
+          - id: sysctl_net_ipv4_conf_default_log_martians
+            text: Net.Ipv4.Conf.Default.Log_Martians Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_3-3.1.18
+      title: Ensure Net.Ipv4.Tcp_Syncookies Is Configured
+      objective: Ensure Net.Ipv4.Tcp_Syncookies Is Configured
+      group: network
+      assessment-requirements:
+          - id: sysctl_net_ipv4_tcp_syncookies
+            text: Net.Ipv4.Tcp_Syncookies Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_3-3.1.4
+      title: Ensure Net.Ipv4.Conf.All.Send_Redirects Is Configured
+      objective: Ensure Net.Ipv4.Conf.All.Send_Redirects Is Configured
+      group: network
+      assessment-requirements:
+          - id: sysctl_net_ipv4_conf_all_send_redirects
+            text: Net.Ipv4.Conf.All.Send_Redirects Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_3-3.1.5
+      title: Ensure Net.Ipv4.Conf.Default.Send_Redirects Is Configured
+      objective: Ensure Net.Ipv4.Conf.Default.Send_Redirects Is Configured
+      group: network
+      assessment-requirements:
+          - id: sysctl_net_ipv4_conf_default_send_redirects
+            text: Net.Ipv4.Conf.Default.Send_Redirects Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_3-3.1.6
+      title: Ensure Net.Ipv4.Icmp_Ignore_Bogus_Error_Responses Is Configured
+      objective: Ensure Net.Ipv4.Icmp_Ignore_Bogus_Error_Responses Is Configured
+      group: network
+      assessment-requirements:
+          - id: sysctl_net_ipv4_icmp_ignore_bogus_error_responses
+            text: Net.Ipv4.Icmp_Ignore_Bogus_Error_Responses Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_3-3.1.7
+      title: Ensure Net.Ipv4.Icmp_Echo_Ignore_Broadcasts Is Configured
+      objective: Ensure Net.Ipv4.Icmp_Echo_Ignore_Broadcasts Is Configured
+      group: network
+      assessment-requirements:
+          - id: sysctl_net_ipv4_icmp_echo_ignore_broadcasts
+            text: Net.Ipv4.Icmp_Echo_Ignore_Broadcasts Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_3-3.1.8
+      title: Ensure Net.Ipv4.Conf.All.Accept_Redirects Is Configured
+      objective: Ensure Net.Ipv4.Conf.All.Accept_Redirects Is Configured
+      group: network
+      assessment-requirements:
+          - id: sysctl_net_ipv4_conf_all_accept_redirects
+            text: Net.Ipv4.Conf.All.Accept_Redirects Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_3-3.1.9
+      title: Ensure Net.Ipv4.Conf.Default.Accept_Redirects Is Configured
+      objective: Ensure Net.Ipv4.Conf.Default.Accept_Redirects Is Configured
+      group: network
+      assessment-requirements:
+          - id: sysctl_net_ipv4_conf_default_accept_redirects
+            text: Net.Ipv4.Conf.Default.Accept_Redirects Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_3-3.2.1
+      title: Ensure Net.Ipv6.Conf.All.Forwarding Is Configured
+      objective: Ensure Net.Ipv6.Conf.All.Forwarding Is Configured
+      group: network
+      assessment-requirements:
+          - id: sysctl_net_ipv6_conf_all_forwarding
+            text: Net.Ipv6.Conf.All.Forwarding Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_3-3.2.3
+      title: Ensure Net.Ipv6.Conf.All.Accept_Redirects Is Configured
+      objective: Ensure Net.Ipv6.Conf.All.Accept_Redirects Is Configured
+      group: network
+      assessment-requirements:
+          - id: sysctl_net_ipv6_conf_all_accept_redirects
+            text: Net.Ipv6.Conf.All.Accept_Redirects Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_3-3.2.4
+      title: Ensure Net.Ipv6.Conf.Default.Accept_Redirects Is Configured
+      objective: Ensure Net.Ipv6.Conf.Default.Accept_Redirects Is Configured
+      group: network
+      assessment-requirements:
+          - id: sysctl_net_ipv6_conf_default_accept_redirects
+            text: Net.Ipv6.Conf.Default.Accept_Redirects Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_3-3.2.5
+      title: Ensure Net.Ipv6.Conf.All.Accept_Source_Route Is Configured
+      objective: Ensure Net.Ipv6.Conf.All.Accept_Source_Route Is Configured
+      group: network
+      assessment-requirements:
+          - id: sysctl_net_ipv6_conf_all_accept_source_route
+            text: Net.Ipv6.Conf.All.Accept_Source_Route Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_3-3.2.6
+      title: Ensure Net.Ipv6.Conf.Default.Accept_Source_Route Is Configured
+      objective: Ensure Net.Ipv6.Conf.Default.Accept_Source_Route Is Configured
+      group: network
+      assessment-requirements:
+          - id: sysctl_net_ipv6_conf_default_accept_source_route
+            text: Net.Ipv6.Conf.Default.Accept_Source_Route Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_3-3.2.7
+      title: Ensure Net.Ipv6.Conf.All.Accept_Ra Is Configured
+      objective: Ensure Net.Ipv6.Conf.All.Accept_Ra Is Configured
+      group: network
+      assessment-requirements:
+          - id: sysctl_net_ipv6_conf_all_accept_ra
+            text: Net.Ipv6.Conf.All.Accept_Ra Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_3-3.2.8
+      title: Ensure Net.Ipv6.Conf.Default.Accept_Ra Is Configured
+      objective: Ensure Net.Ipv6.Conf.Default.Accept_Ra Is Configured
+      group: network
+      assessment-requirements:
+          - id: sysctl_net_ipv6_conf_default_accept_ra
+            text: Net.Ipv6.Conf.Default.Accept_Ra Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_4-1.1
+      title: Ensure Nftables Is Installed
+      objective: Ensure Nftables Is Installed
+      group: firewall
+      assessment-requirements:
+          - id: package_nftables_installed
+            text: Nftables Is Installed MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_4-1.2
+      title: Ensure A Single Firewall Configuration Utility Is In Use
+      objective: Ensure A Single Firewall Configuration Utility Is In Use
+      group: firewall
+      assessment-requirements:
+          - id: package_firewalld_installed
+            text: A Single Firewall Configuration Utility Is In Use MUST be verified
+            applicability:
+                - fedora-linux
+          - id: service_firewalld_enabled
+            text: A Single Firewall Configuration Utility Is In Use MUST be verified
+            applicability:
+                - fedora-linux
+          - id: service_nftables_disabled
+            text: A Single Firewall Configuration Utility Is In Use MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_4-2.2
+      title: Ensure Firewalld Loopback Traffic Is Configured
+      objective: Ensure Firewalld Loopback Traffic Is Configured
+      group: firewall
+      assessment-requirements:
+          - id: firewalld_loopback_traffic_restricted
+            text: Firewalld Loopback Traffic Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: firewalld_loopback_traffic_trusted
+            text: Firewalld Loopback Traffic Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-1.1
+      title: Ensure Access To /Etc/Ssh/Sshd_Config Is Configured
+      objective: Ensure Access To /Etc/Ssh/Sshd_Config Is Configured
+      group: access-auth
+      assessment-requirements:
+          - id: file_groupowner_sshd_config
+            text: Access To /Etc/Ssh/Sshd_Config Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_owner_sshd_config
+            text: Access To /Etc/Ssh/Sshd_Config Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_permissions_sshd_config
+            text: Access To /Etc/Ssh/Sshd_Config Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-1.11
+      title: Ensure Sshd Gssapiauthentication Is Disabled
+      objective: Ensure Sshd Gssapiauthentication Is Disabled
+      group: access-auth
+      assessment-requirements:
+          - id: sshd_disable_gssapi_auth
+            text: Sshd Gssapiauthentication Is Disabled MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-1.12
+      title: Ensure Sshd Hostbasedauthentication Is Disabled
+      objective: Ensure Sshd Hostbasedauthentication Is Disabled
+      group: access-auth
+      assessment-requirements:
+          - id: disable_host_auth
+            text: Sshd Hostbasedauthentication Is Disabled MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-1.13
+      title: Ensure Sshd Ignorerhosts Is Enabled
+      objective: Ensure Sshd Ignorerhosts Is Enabled
+      group: access-auth
+      assessment-requirements:
+          - id: sshd_disable_rhosts
+            text: Sshd Ignorerhosts Is Enabled MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-1.14
+      title: Ensure Sshd Logingracetime Is Configured
+      objective: Ensure Sshd Logingracetime Is Configured
+      group: access-auth
+      assessment-requirements:
+          - id: sshd_set_login_grace_time
+            text: Sshd Logingracetime Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-1.15
+      title: Ensure Sshd Loglevel Is Configured
+      objective: Ensure Sshd Loglevel Is Configured
+      group: access-auth
+      assessment-requirements:
+          - id: sshd_set_loglevel_verbose
+            text: Sshd Loglevel Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-1.16
+      title: Ensure Sshd Maxauthtries Is Configured
+      objective: Ensure Sshd Maxauthtries Is Configured
+      group: access-auth
+      assessment-requirements:
+          - id: sshd_set_max_auth_tries
+            text: Sshd Maxauthtries Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-1.17
+      title: Ensure Sshd Maxstartups Is Configured
+      objective: Ensure Sshd Maxstartups Is Configured
+      group: access-auth
+      assessment-requirements:
+          - id: sshd_set_maxstartups
+            text: Sshd Maxstartups Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-1.18
+      title: Ensure Sshd Maxsessions Is Configured
+      objective: Ensure Sshd Maxsessions Is Configured
+      group: access-auth
+      assessment-requirements:
+          - id: sshd_set_max_sessions
+            text: Sshd Maxsessions Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-1.19
+      title: Ensure Sshd Permitemptypasswords Is Disabled
+      objective: Ensure Sshd Permitemptypasswords Is Disabled
+      group: access-auth
+      assessment-requirements:
+          - id: sshd_disable_empty_passwords
+            text: Sshd Permitemptypasswords Is Disabled MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-1.2
+      title: Ensure Access To Ssh Private Host Key Files Is Configured
+      objective: Ensure Access To Ssh Private Host Key Files Is Configured
+      group: access-auth
+      assessment-requirements:
+          - id: file_groupownership_sshd_private_key
+            text: Access To Ssh Private Host Key Files Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_ownership_sshd_private_key
+            text: Access To Ssh Private Host Key Files Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_permissions_sshd_private_key
+            text: Access To Ssh Private Host Key Files Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-1.20
+      title: Ensure Sshd Permitrootlogin Is Disabled
+      objective: Ensure Sshd Permitrootlogin Is Disabled
+      group: access-auth
+      assessment-requirements:
+          - id: sshd_disable_root_login
+            text: Sshd Permitrootlogin Is Disabled MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-1.21
+      title: Ensure Sshd Permituserenvironment Is Disabled
+      objective: Ensure Sshd Permituserenvironment Is Disabled
+      group: access-auth
+      assessment-requirements:
+          - id: sshd_do_not_permit_user_env
+            text: Sshd Permituserenvironment Is Disabled MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-1.22
+      title: Ensure Sshd Usepam Is Enabled
+      objective: Ensure Sshd Usepam Is Enabled
+      group: access-auth
+      assessment-requirements:
+          - id: sshd_enable_pam
+            text: Sshd Usepam Is Enabled MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-1.3
+      title: Ensure Access To Ssh Public Host Key Files Is Configured
+      objective: Ensure Access To Ssh Public Host Key Files Is Configured
+      group: access-auth
+      assessment-requirements:
+          - id: file_groupownership_sshd_pub_key
+            text: Access To Ssh Public Host Key Files Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_ownership_sshd_pub_key
+            text: Access To Ssh Public Host Key Files Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_permissions_sshd_pub_key
+            text: Access To Ssh Public Host Key Files Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-1.4
+      title: Ensure Sshd Ciphers Are Configured
+      objective: Ensure Sshd Ciphers Are Configured
+      group: access-auth
+      assessment-requirements:
+          - id: cis_fedora_5-1.4-ar
+            text: Sshd Ciphers Are Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-1.5
+      title: Ensure Sshd Kexalgorithms Is Configured
+      objective: Ensure Sshd Kexalgorithms Is Configured
+      group: access-auth
+      assessment-requirements:
+          - id: cis_fedora_5-1.5-ar
+            text: Sshd Kexalgorithms Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-1.6
+      title: Ensure Sshd Macs Are Configured
+      objective: Ensure Sshd Macs Are Configured
+      group: access-auth
+      assessment-requirements:
+          - id: cis_fedora_5-1.6-ar
+            text: Sshd Macs Are Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-1.7
+      title: Ensure Sshd Access Is Configured
+      objective: Ensure Sshd Access Is Configured
+      group: access-auth
+      assessment-requirements:
+          - id: sshd_limit_user_access
+            text: Sshd Access Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-1.8
+      title: Ensure Sshd Banner Is Configured
+      objective: Ensure Sshd Banner Is Configured
+      group: access-auth
+      assessment-requirements:
+          - id: sshd_enable_warning_banner_net
+            text: Sshd Banner Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-1.9
+      title: Ensure Sshd Clientaliveinterval And Clientalivecountmax Are Configured
+      objective: Ensure Sshd Clientaliveinterval And Clientalivecountmax Are Configured
+      group: access-auth
+      assessment-requirements:
+          - id: sshd_set_idle_timeout
+            text: Sshd Clientaliveinterval And Clientalivecountmax Are Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: sshd_set_keepalive
+            text: Sshd Clientaliveinterval And Clientalivecountmax Are Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-2.1
+      title: Ensure Sudo Is Installed
+      objective: Ensure Sudo Is Installed
+      group: access-auth
+      assessment-requirements:
+          - id: package_sudo_installed
+            text: Sudo Is Installed MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-2.2
+      title: Ensure Sudo Commands Use Pty
+      objective: Ensure Sudo Commands Use Pty
+      group: access-auth
+      assessment-requirements:
+          - id: sudo_add_use_pty
+            text: Sudo Commands Use Pty MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-2.3
+      title: Ensure Sudo Log File Exists
+      objective: Ensure Sudo Log File Exists
+      group: access-auth
+      assessment-requirements:
+          - id: sudo_custom_logfile
+            text: Sudo Log File Exists MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-2.5
+      title: Ensure Re-Authentication For Privilege Escalation Is Not Disabled Globally
+      objective: Ensure Re-Authentication For Privilege Escalation Is Not Disabled Globally
+      group: access-auth
+      assessment-requirements:
+          - id: sudo_remove_no_authenticate
+            text: Re-Authentication For Privilege Escalation Is Not Disabled Globally MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-2.6
+      title: Ensure Sudo Timestamp_Timeout Is Configured
+      objective: Ensure Sudo Timestamp_Timeout Is Configured
+      group: access-auth
+      assessment-requirements:
+          - id: sudo_require_reauthentication
+            text: Sudo Timestamp_Timeout Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-2.7
+      title: Ensure Access To The Su Command Is Restricted
+      objective: Ensure Access To The Su Command Is Restricted
+      group: access-auth
+      assessment-requirements:
+          - id: ensure_pam_wheel_group_empty
+            text: Access To The Su Command Is Restricted MUST be verified
+            applicability:
+                - fedora-linux
+          - id: use_pam_wheel_group_for_su
+            text: Access To The Su Command Is Restricted MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-3.1.3
+      title: Ensure Latest Version Of Libpwquality Is Installed
+      objective: Ensure Latest Version Of Libpwquality Is Installed
+      group: access-auth
+      assessment-requirements:
+          - id: package_pam_pwquality_installed
+            text: Latest Version Of Libpwquality Is Installed MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-3.2.2
+      title: Ensure Pam_Faillock Module Is Enabled
+      objective: Ensure Pam_Faillock Module Is Enabled
+      group: access-auth
+      assessment-requirements:
+          - id: account_password_pam_faillock_password_auth
+            text: Pam_Faillock Module Is Enabled MUST be verified
+            applicability:
+                - fedora-linux
+          - id: account_password_pam_faillock_system_auth
+            text: Pam_Faillock Module Is Enabled MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-3.2.3
+      title: Ensure Pam_Pwquality Module Is Enabled
+      objective: Ensure Pam_Pwquality Module Is Enabled
+      group: access-auth
+      assessment-requirements:
+          - id: accounts_password_pam_pwquality_password_auth
+            text: Pam_Pwquality Module Is Enabled MUST be verified
+            applicability:
+                - fedora-linux
+          - id: accounts_password_pam_pwquality_system_auth
+            text: Pam_Pwquality Module Is Enabled MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-3.3.1.1
+      title: CIS Fedora 5 - 3.3.1.1
+      objective: CIS Fedora 5 - 3.3.1.1
+      group: access-auth
+      assessment-requirements:
+          - id: accounts_passwords_pam_faillock_deny
+            text: CIS Fedora 5 - 3.3.1.1 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-3.3.1.2
+      title: CIS Fedora 5 - 3.3.1.2
+      objective: CIS Fedora 5 - 3.3.1.2
+      group: access-auth
+      assessment-requirements:
+          - id: accounts_passwords_pam_faillock_unlock_time
+            text: CIS Fedora 5 - 3.3.1.2 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-3.3.2.1
+      title: CIS Fedora 5 - 3.3.2.1
+      objective: CIS Fedora 5 - 3.3.2.1
+      group: access-auth
+      assessment-requirements:
+          - id: accounts_password_pam_difok
+            text: CIS Fedora 5 - 3.3.2.1 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-3.3.2.2
+      title: CIS Fedora 5 - 3.3.2.2
+      objective: CIS Fedora 5 - 3.3.2.2
+      group: access-auth
+      assessment-requirements:
+          - id: accounts_password_pam_minlen
+            text: CIS Fedora 5 - 3.3.2.2 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-3.3.2.3
+      title: CIS Fedora 5 - 3.3.2.3
+      objective: CIS Fedora 5 - 3.3.2.3
+      group: access-auth
+      assessment-requirements:
+          - id: accounts_password_pam_minclass
+            text: CIS Fedora 5 - 3.3.2.3 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-3.3.2.4
+      title: CIS Fedora 5 - 3.3.2.4
+      objective: CIS Fedora 5 - 3.3.2.4
+      group: access-auth
+      assessment-requirements:
+          - id: accounts_password_pam_maxrepeat
+            text: CIS Fedora 5 - 3.3.2.4 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-3.3.2.6
+      title: CIS Fedora 5 - 3.3.2.6
+      objective: CIS Fedora 5 - 3.3.2.6
+      group: access-auth
+      assessment-requirements:
+          - id: accounts_password_pam_dictcheck
+            text: CIS Fedora 5 - 3.3.2.6 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-3.3.2.7
+      title: CIS Fedora 5 - 3.3.2.7
+      objective: CIS Fedora 5 - 3.3.2.7
+      group: access-auth
+      assessment-requirements:
+          - id: accounts_password_pam_enforce_root
+            text: CIS Fedora 5 - 3.3.2.7 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-3.3.3.1
+      title: CIS Fedora 5 - 3.3.3.1
+      objective: CIS Fedora 5 - 3.3.3.1
+      group: access-auth
+      assessment-requirements:
+          - id: accounts_password_pam_pwhistory_remember_password_auth
+            text: CIS Fedora 5 - 3.3.3.1 MUST be verified
+            applicability:
+                - fedora-linux
+          - id: accounts_password_pam_pwhistory_remember_system_auth
+            text: CIS Fedora 5 - 3.3.3.1 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-3.3.4.1
+      title: CIS Fedora 5 - 3.3.4.1
+      objective: CIS Fedora 5 - 3.3.4.1
+      group: access-auth
+      assessment-requirements:
+          - id: no_empty_passwords
+            text: CIS Fedora 5 - 3.3.4.1 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-3.3.4.3
+      title: CIS Fedora 5 - 3.3.4.3
+      objective: CIS Fedora 5 - 3.3.4.3
+      group: access-auth
+      assessment-requirements:
+          - id: set_password_hashing_algorithm_passwordauth
+            text: CIS Fedora 5 - 3.3.4.3 MUST be verified
+            applicability:
+                - fedora-linux
+          - id: set_password_hashing_algorithm_systemauth
+            text: CIS Fedora 5 - 3.3.4.3 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-4.1.1
+      title: Ensure Password Expiration Is Configured
+      objective: Ensure Password Expiration Is Configured
+      group: access-auth
+      assessment-requirements:
+          - id: accounts_maximum_age_login_defs
+            text: Password Expiration Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: accounts_password_set_max_life_existing
+            text: Password Expiration Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-4.1.3
+      title: Ensure Password Expiration Warning Days Is Configured
+      objective: Ensure Password Expiration Warning Days Is Configured
+      group: access-auth
+      assessment-requirements:
+          - id: accounts_password_set_warn_age_existing
+            text: Password Expiration Warning Days Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: accounts_password_warn_age_login_defs
+            text: Password Expiration Warning Days Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-4.1.4
+      title: Ensure Strong Password Hashing Algorithm Is Configured
+      objective: Ensure Strong Password Hashing Algorithm Is Configured
+      group: access-auth
+      assessment-requirements:
+          - id: set_password_hashing_algorithm_logindefs
+            text: Strong Password Hashing Algorithm Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-4.1.5
+      title: Ensure Inactive Password Lock Is Configured
+      objective: Ensure Inactive Password Lock Is Configured
+      group: access-auth
+      assessment-requirements:
+          - id: account_disable_post_pw_expiration
+            text: Inactive Password Lock Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: accounts_set_post_pw_existing
+            text: Inactive Password Lock Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-4.1.6
+      title: Ensure All Users Last Password Change Date Is In The Past
+      objective: Ensure All Users Last Password Change Date Is In The Past
+      group: access-auth
+      assessment-requirements:
+          - id: accounts_password_last_change_is_in_past
+            text: All Users Last Password Change Date Is In The Past MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-4.2.1
+      title: Ensure Root Is The Only Uid 0 Account
+      objective: Ensure Root Is The Only Uid 0 Account
+      group: access-auth
+      assessment-requirements:
+          - id: accounts_no_uid_except_zero
+            text: Root Is The Only Uid 0 Account MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-4.2.2
+      title: Ensure Root Is The Only Gid 0 Account
+      objective: Ensure Root Is The Only Gid 0 Account
+      group: access-auth
+      assessment-requirements:
+          - id: accounts_root_gid_zero
+            text: Root Is The Only Gid 0 Account MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-4.2.4
+      title: Ensure Root Account Access Is Controlled
+      objective: Ensure Root Account Access Is Controlled
+      group: access-auth
+      assessment-requirements:
+          - id: ensure_root_password_configured
+            text: Root Account Access Is Controlled MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-4.2.5
+      title: Ensure Root Path Integrity
+      objective: Ensure Root Path Integrity
+      group: access-auth
+      assessment-requirements:
+          - id: accounts_root_path_dirs_no_write
+            text: Root Path Integrity MUST be verified
+            applicability:
+                - fedora-linux
+          - id: root_path_no_dot
+            text: Root Path Integrity MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-4.2.7
+      title: Ensure System Accounts Do Not Have A Valid Login Shell
+      objective: Ensure System Accounts Do Not Have A Valid Login Shell
+      group: access-auth
+      assessment-requirements:
+          - id: no_password_auth_for_systemaccounts
+            text: System Accounts Do Not Have A Valid Login Shell MUST be verified
+            applicability:
+                - fedora-linux
+          - id: no_shelllogin_for_systemaccounts
+            text: System Accounts Do Not Have A Valid Login Shell MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-4.3.2
+      title: Ensure Default User Shell Timeout Is Configured
+      objective: Ensure Default User Shell Timeout Is Configured
+      group: access-auth
+      assessment-requirements:
+          - id: accounts_tmout
+            text: Default User Shell Timeout Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_5-4.3.3
+      title: Ensure Default User Umask Is Configured
+      objective: Ensure Default User Umask Is Configured
+      group: access-auth
+      assessment-requirements:
+          - id: accounts_umask_etc_bashrc
+            text: Default User Umask Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: accounts_umask_etc_login_defs
+            text: Default User Umask Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: accounts_umask_etc_profile
+            text: Default User Umask Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_6-1.1
+      title: Ensure Aide Is Installed
+      objective: Ensure Aide Is Installed
+      group: logging
+      assessment-requirements:
+          - id: aide_build_database
+            text: Aide Is Installed MUST be verified
+            applicability:
+                - fedora-linux
+          - id: package_aide_installed
+            text: Aide Is Installed MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_6-1.2
+      title: Ensure Filesystem Integrity Is Regularly Checked
+      objective: Ensure Filesystem Integrity Is Regularly Checked
+      group: logging
+      assessment-requirements:
+          - id: aide_periodic_cron_checking
+            text: Filesystem Integrity Is Regularly Checked MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_6-1.3
+      title: Ensure Cryptographic Mechanisms Are Used To Protect The Integrity Of Audit Tools
+      objective: Ensure Cryptographic Mechanisms Are Used To Protect The Integrity Of Audit Tools
+      group: logging
+      assessment-requirements:
+          - id: aide_check_audit_tools
+            text: Cryptographic Mechanisms Are Used To Protect The Integrity Of Audit Tools MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_6-2.1.1
+      title: Ensure Journald Service Is Active
+      objective: Ensure Journald Service Is Active
+      group: logging
+      assessment-requirements:
+          - id: service_systemd-journald_enabled
+            text: Journald Service Is Active MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_6-2.2.1.1
+      title: CIS Fedora 6 - 2.2.1.1
+      objective: CIS Fedora 6 - 2.2.1.1
+      group: logging
+      assessment-requirements:
+          - id: package_systemd-journal-remote_installed
+            text: CIS Fedora 6 - 2.2.1.1 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_6-2.2.1.4
+      title: CIS Fedora 6 - 2.2.1.4
+      objective: CIS Fedora 6 - 2.2.1.4
+      group: logging
+      assessment-requirements:
+          - id: socket_systemd-journal-remote_disabled
+            text: CIS Fedora 6 - 2.2.1.4 MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_6-2.2.3
+      title: Ensure Journald Compress Is Configured
+      objective: Ensure Journald Compress Is Configured
+      group: logging
+      assessment-requirements:
+          - id: journald_compress
+            text: Journald Compress Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_6-2.2.4
+      title: Ensure Journald Storage Is Configured
+      objective: Ensure Journald Storage Is Configured
+      group: logging
+      assessment-requirements:
+          - id: journald_storage
+            text: Journald Storage Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_6-2.6.1
+      title: Ensure Access To All Logfiles Has Been Configured
+      objective: Ensure Access To All Logfiles Has Been Configured
+      group: logging
+      assessment-requirements:
+          - id: rsyslog_files_groupownership
+            text: Access To All Logfiles Has Been Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: rsyslog_files_ownership
+            text: Access To All Logfiles Has Been Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: rsyslog_files_permissions
+            text: Access To All Logfiles Has Been Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_7-1.1
+      title: Ensure Access To /Etc/Passwd Is Configured
+      objective: Ensure Access To /Etc/Passwd Is Configured
+      group: maintenance
+      assessment-requirements:
+          - id: file_groupowner_etc_passwd
+            text: Access To /Etc/Passwd Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_owner_etc_passwd
+            text: Access To /Etc/Passwd Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_permissions_etc_passwd
+            text: Access To /Etc/Passwd Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_7-1.11
+      title: Ensure World Writable Files And Directories Are Secured
+      objective: Ensure World Writable Files And Directories Are Secured
+      group: maintenance
+      assessment-requirements:
+          - id: dir_perms_world_writable_sticky_bits
+            text: World Writable Files And Directories Are Secured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_permissions_unauthorized_world_writable
+            text: World Writable Files And Directories Are Secured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_7-1.2
+      title: Ensure Access To /Etc/Passwd- Is Configured
+      objective: Ensure Access To /Etc/Passwd- Is Configured
+      group: maintenance
+      assessment-requirements:
+          - id: file_groupowner_backup_etc_passwd
+            text: Access To /Etc/Passwd- Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_owner_backup_etc_passwd
+            text: Access To /Etc/Passwd- Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_permissions_backup_etc_passwd
+            text: Access To /Etc/Passwd- Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_7-1.3
+      title: Ensure Access To /Etc/Group Is Configured
+      objective: Ensure Access To /Etc/Group Is Configured
+      group: maintenance
+      assessment-requirements:
+          - id: file_groupowner_etc_group
+            text: Access To /Etc/Group Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_owner_etc_group
+            text: Access To /Etc/Group Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_permissions_etc_group
+            text: Access To /Etc/Group Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_7-1.4
+      title: Ensure Access To /Etc/Group- Is Configured
+      objective: Ensure Access To /Etc/Group- Is Configured
+      group: maintenance
+      assessment-requirements:
+          - id: file_groupowner_backup_etc_group
+            text: Access To /Etc/Group- Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_owner_backup_etc_group
+            text: Access To /Etc/Group- Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_permissions_backup_etc_group
+            text: Access To /Etc/Group- Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_7-1.5
+      title: Ensure Access To /Etc/Shadow Is Configured
+      objective: Ensure Access To /Etc/Shadow Is Configured
+      group: maintenance
+      assessment-requirements:
+          - id: file_groupowner_etc_shadow
+            text: Access To /Etc/Shadow Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_owner_etc_shadow
+            text: Access To /Etc/Shadow Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_permissions_etc_shadow
+            text: Access To /Etc/Shadow Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_7-1.6
+      title: Ensure Access To /Etc/Shadow- Is Configured
+      objective: Ensure Access To /Etc/Shadow- Is Configured
+      group: maintenance
+      assessment-requirements:
+          - id: file_groupowner_backup_etc_shadow
+            text: Access To /Etc/Shadow- Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_owner_backup_etc_shadow
+            text: Access To /Etc/Shadow- Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_permissions_backup_etc_shadow
+            text: Access To /Etc/Shadow- Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_7-1.7
+      title: Ensure Access To /Etc/Gshadow Is Configured
+      objective: Ensure Access To /Etc/Gshadow Is Configured
+      group: maintenance
+      assessment-requirements:
+          - id: file_groupowner_etc_gshadow
+            text: Access To /Etc/Gshadow Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_owner_etc_gshadow
+            text: Access To /Etc/Gshadow Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_permissions_etc_gshadow
+            text: Access To /Etc/Gshadow Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_7-1.8
+      title: Ensure Access To /Etc/Gshadow- Is Configured
+      objective: Ensure Access To /Etc/Gshadow- Is Configured
+      group: maintenance
+      assessment-requirements:
+          - id: file_groupowner_backup_etc_gshadow
+            text: Access To /Etc/Gshadow- Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_owner_backup_etc_gshadow
+            text: Access To /Etc/Gshadow- Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_permissions_backup_etc_gshadow
+            text: Access To /Etc/Gshadow- Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_7-1.9
+      title: Ensure Access To /Etc/Shells Is Configured
+      objective: Ensure Access To /Etc/Shells Is Configured
+      group: maintenance
+      assessment-requirements:
+          - id: file_groupowner_etc_shells
+            text: Access To /Etc/Shells Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_owner_etc_shells
+            text: Access To /Etc/Shells Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_permissions_etc_shells
+            text: Access To /Etc/Shells Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_7-2.1
+      title: Ensure Accounts In /Etc/Passwd Use Shadowed Passwords
+      objective: Ensure Accounts In /Etc/Passwd Use Shadowed Passwords
+      group: maintenance
+      assessment-requirements:
+          - id: accounts_password_all_shadowed
+            text: Accounts In /Etc/Passwd Use Shadowed Passwords MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_7-2.2
+      title: Ensure /Etc/Shadow Password Fields Are Not Empty
+      objective: Ensure /Etc/Shadow Password Fields Are Not Empty
+      group: maintenance
+      assessment-requirements:
+          - id: no_empty_passwords_etc_shadow
+            text: /Etc/Shadow Password Fields Are Not Empty MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_7-2.3
+      title: Ensure All Groups In /Etc/Passwd Exist In /Etc/Group
+      objective: Ensure All Groups In /Etc/Passwd Exist In /Etc/Group
+      group: maintenance
+      assessment-requirements:
+          - id: gid_passwd_group_same
+            text: All Groups In /Etc/Passwd Exist In /Etc/Group MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_7-2.4
+      title: Ensure No Duplicate Uids Exist
+      objective: Ensure No Duplicate Uids Exist
+      group: maintenance
+      assessment-requirements:
+          - id: account_unique_id
+            text: No Duplicate Uids Exist MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_7-2.5
+      title: Ensure No Duplicate Gids Exist
+      objective: Ensure No Duplicate Gids Exist
+      group: maintenance
+      assessment-requirements:
+          - id: group_unique_id
+            text: No Duplicate Gids Exist MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_7-2.6
+      title: Ensure No Duplicate User Names Exist
+      objective: Ensure No Duplicate User Names Exist
+      group: maintenance
+      assessment-requirements:
+          - id: account_unique_name
+            text: No Duplicate User Names Exist MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_7-2.7
+      title: Ensure No Duplicate Group Names Exist
+      objective: Ensure No Duplicate Group Names Exist
+      group: maintenance
+      assessment-requirements:
+          - id: group_unique_name
+            text: No Duplicate Group Names Exist MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_7-2.8
+      title: Ensure Local Interactive User Home Directories Are Configured
+      objective: Ensure Local Interactive User Home Directories Are Configured
+      group: maintenance
+      assessment-requirements:
+          - id: accounts_user_interactive_home_directory_exists
+            text: Local Interactive User Home Directories Are Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_ownership_home_directories
+            text: Local Interactive User Home Directories Are Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_permissions_home_directories
+            text: Local Interactive User Home Directories Are Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: cis_fedora_7-2.9
+      title: Ensure Local Interactive User Dot Files Access Is Configured
+      objective: Ensure Local Interactive User Dot Files Access Is Configured
+      group: maintenance
+      assessment-requirements:
+          - id: accounts_user_dot_group_ownership
+            text: Local Interactive User Dot Files Access Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: accounts_user_dot_user_ownership
+            text: Local Interactive User Dot Files Access Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: file_permission_user_init_files
+            text: Local Interactive User Dot Files Access Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: no_forward_files
+            text: Local Interactive User Dot Files Access Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+          - id: no_netrc_files
+            text: Local Interactive User Dot Files Access Is Configured MUST be verified
+            applicability:
+                - fedora-linux
+    - id: reload_dconf_db
+      title: Reload Dconf Database
+      objective: Reload Dconf Database
+      group: operations
+      assessment-requirements:
+          - id: dconf_db_up_to_date
+            text: The dconf database MUST be reloaded after configuration changes
+            applicability:
+                - fedora-linux

--- a/governance/guidance/cis-fedora-l1-guidance.yaml
+++ b/governance/guidance/cis-fedora-l1-guidance.yaml
@@ -1,0 +1,137 @@
+title: CIS Fedora Linux - Level 1 Guidance
+type: Standard
+metadata:
+  id: cis-fedora-l1-guidance
+  type: GuidanceCatalog
+  gemara-version: "0.24.0"
+  description: Guidance catalog for the CIS Fedora Linux Level 1 Benchmark. Provides rationale and context for each control family covering filesystem hardening, service minimization, network security, firewall configuration, access controls, logging, and system maintenance. Shared across Server and Workstation profiles.
+  author:
+    id: complytime
+    name: ComplyTime
+    type: Software
+groups:
+  - id: initial-setup
+    title: Initial Setup
+    description: Filesystem, software updates, SELinux, boot, kernel, crypto, and banner configuration
+  - id: services
+    title: Services
+    description: Network services, client packages, and time synchronization configuration
+  - id: network
+    title: Network Configuration
+    description: Kernel modules, IPv4, and IPv6 network stack configuration
+  - id: firewall
+    title: Host-Based Firewall
+    description: Firewall package installation and traffic filtering configuration
+  - id: access-auth
+    title: Access, Authentication, and Authorization
+    description: SSH, sudo, PAM, password, user account, and shell configuration
+  - id: logging
+    title: Logging and Auditing
+    description: System logging, journald, and file integrity monitoring configuration
+  - id: maintenance
+    title: System Maintenance
+    description: File permissions, user/group integrity, and home directory configuration
+  - id: operations
+    title: Operations
+    description: Operational tasks required for configuration application
+guidelines:
+  - id: guidance-initial-setup
+    title: CIS Fedora Server L1 - Initial Setup
+    objective: Ensure foundational system hardening is applied before the system enters production
+    group: initial-setup
+    statements:
+      - id: guidance-initial-setup-s1
+        text: Organizations SHOULD disable unused filesystem kernel modules (cramfs, freevxfs, hfs, hfsplus, jffs2, firewire-core, usb-storage) to reduce the kernel attack surface. CIS Benchmark sections 1.1.1.x.
+      - id: guidance-initial-setup-s2
+        text: Organizations MUST configure separate partitions for /tmp, /dev/shm, /home, /var, /var/tmp, /var/log, and /var/log/audit with appropriate mount options (nodev, nosuid, noexec) to limit the impact of filesystem-based attacks. CIS Benchmark sections 1.2.x.
+      - id: guidance-initial-setup-s3
+        text: Organizations MUST ensure package management (GPG check) is enabled to verify the integrity of installed software. CIS Benchmark section 2.1.2.
+      - id: guidance-initial-setup-s4
+        text: Organizations MUST install and configure SELinux with an appropriate policy type and ensure it is not disabled in the bootloader configuration. The setroubleshoot and mcstrans packages should be removed. CIS Benchmark sections 3.1.x.
+      - id: guidance-initial-setup-s5
+        text: Organizations SHOULD set a bootloader password to prevent unauthorized kernel parameter modifications. CIS Benchmark section 4.1.
+      - id: guidance-initial-setup-s6
+        text: Organizations SHOULD harden kernel parameters including core dump restrictions, protected hard/symlinks, ASLR, dmesg restriction, kptr restriction, and ptrace scope to limit information leakage and exploitation. CIS Benchmark sections 5.x.
+      - id: guidance-initial-setup-s7
+        text: Organizations MUST configure system-wide cryptographic policies to disable weak algorithms (SHA1, CBC for SSH) and ensure strong MACs. CIS Benchmark sections 6.x.
+      - id: guidance-initial-setup-s8
+        text: Organizations MUST configure login banners (/etc/motd, /etc/issue, /etc/issue.net) with appropriate content and file permissions. GDM login banner, screen lock, automount, and autorun settings should be configured where applicable. CIS Benchmark sections 7.x, 8.x.
+  - id: guidance-services
+    title: CIS Fedora Server L1 - Services
+    objective: Minimize the system attack surface by disabling or removing unnecessary network services and client packages
+    group: services
+    statements:
+      - id: guidance-services-s1
+        text: Organizations MUST disable or remove unnecessary network services including autofs, avahi-daemon, bluetooth, CUPS, DHCP (kea), DNS (bind), dnsmasq, FTP (vsftpd), IMAP/POP (cyrus-imapd, dovecot), NFS, rpcbind, rsync, Samba, SNMP, telnet-server, TFTP server, Squid proxy, and web servers (httpd, nginx). CIS Benchmark sections 2.1.x.
+      - id: guidance-services-s2
+        text: Organizations MUST remove unnecessary client packages including FTP, telnet, and TFTP clients. CIS Benchmark sections 2.2.x.
+      - id: guidance-services-s3
+        text: Organizations MUST configure time synchronization using chrony with a remote server and ensure it runs as the chrony user (not root). CIS Benchmark sections 2.3.x.
+      - id: guidance-services-s4
+        text: Organizations MUST install and enable the cron daemon, configure proper file permissions on cron directories (/etc/crontab, cron.hourly, cron.daily, cron.weekly, cron.monthly, cron.d), and restrict access to cron and at using allow/deny files. CIS Benchmark sections 2.4.x.
+      - id: guidance-services-s5
+        text: Organizations MUST configure mail transfer agents for local-only mode and ensure postfix does not listen on external interfaces. CIS Benchmark section 2.1.23.
+  - id: guidance-network
+    title: CIS Fedora Server L1 - Network Configuration
+    objective: Harden network stack configuration to prevent common network-based attacks
+    group: network
+    statements:
+      - id: guidance-network-s1
+        text: Organizations SHOULD disable unnecessary kernel network modules (ATM, CAN, DCCP, TIPC, RDS) and wireless interfaces to reduce the network attack surface. CIS Benchmark sections 3.1.x, 3.2.x.
+      - id: guidance-network-s2
+        text: Organizations MUST configure IPv4 sysctl parameters to disable IP forwarding, reject source-routed packets, ignore ICMP redirects, enable reverse path filtering, log martian packets, and enable TCP SYN cookies. CIS Benchmark sections 3.3.1.x.
+      - id: guidance-network-s3
+        text: Organizations MUST configure IPv6 sysctl parameters to disable forwarding, reject redirects, source-routed packets, and router advertisements. CIS Benchmark sections 3.3.2.x.
+  - id: guidance-firewall
+    title: CIS Fedora Server L1 - Host-Based Firewall
+    objective: Ensure a properly configured host-based firewall limits network exposure
+    group: firewall
+    statements:
+      - id: guidance-firewall-s1
+        text: Organizations MUST install nftables and firewalld, enable the firewalld service, disable the nftables service (when using firewalld as the primary firewall), and configure loopback traffic filtering. CIS Benchmark sections 4.x.
+  - id: guidance-access-auth
+    title: CIS Fedora Server L1 - Access, Authentication, and Authorization
+    objective: Enforce strong access controls to prevent unauthorized access and privilege escalation
+    group: access-auth
+    statements:
+      - id: guidance-access-auth-s1
+        text: Organizations MUST harden SSH server configuration including proper file permissions on sshd_config and host key files, disabling root login, empty passwords, host-based authentication, rhosts, user environment, and configuring login grace time, log level, max auth tries, max startups, max sessions, idle timeout, keepalive, PAM usage, access restrictions, and warning banner. Strong key exchange algorithms, MACs, and ciphers should be configured. CIS Benchmark sections 5.1.x.
+      - id: guidance-access-auth-s2
+        text: Organizations MUST install sudo, configure it to use a PTY and custom log file, ensure re-authentication is required, configure timestamp timeout, and restrict access to the su command using pam_wheel. CIS Benchmark sections 5.2.x.
+      - id: guidance-access-auth-s3
+        text: Organizations MUST install libpwquality, enable pam_faillock and pam_pwquality modules, configure account lockout (deny, unlock_time), password quality (difok, minlen, minclass, maxrepeat, dictcheck, enforce_root), password history, and ensure no empty passwords are allowed. Strong password hashing algorithms should be used. CIS Benchmark sections 5.3.x.
+      - id: guidance-access-auth-s4
+        text: Organizations MUST configure password expiration, warning days, inactive password lock, strong hashing in login.defs and libuser.conf, ensure root is the only UID 0 and GID 0 account, verify root path integrity, and ensure system accounts do not have valid login shells. CIS Benchmark sections 5.4.x.
+      - id: guidance-access-auth-s5
+        text: Organizations MUST configure default user shell timeout (TMOUT) and umask settings in /etc/bashrc, /etc/login.defs, and /etc/profile. CIS Benchmark sections 5.4.3.x.
+  - id: guidance-logging
+    title: CIS Fedora Server L1 - Logging and Auditing
+    objective: Ensure comprehensive logging for incident detection and forensic analysis
+    group: logging
+    statements:
+      - id: guidance-logging-s1
+        text: Organizations MUST install AIDE, build its initial database, configure periodic integrity checking via cron, and use cryptographic mechanisms to protect audit tool integrity. CIS Benchmark sections 6.1.x.
+      - id: guidance-logging-s2
+        text: Organizations MUST enable the systemd-journald service, install systemd-journal-remote (and disable its socket for receive), configure journald to compress logs and use persistent storage. CIS Benchmark sections 6.2.x.
+      - id: guidance-logging-s3
+        text: Organizations MUST configure proper ownership and permissions on rsyslog log files to prevent unauthorized access. CIS Benchmark section 6.2.6.1.
+  - id: guidance-maintenance
+    title: CIS Fedora Server L1 - System Maintenance
+    objective: Maintain proper file permissions and account hygiene to prevent privilege escalation
+    group: maintenance
+    statements:
+      - id: guidance-maintenance-s1
+        text: Organizations MUST configure proper ownership and permissions on critical system files including /etc/passwd, /etc/passwd-, /etc/group, /etc/group-, /etc/shadow, /etc/shadow-, /etc/gshadow, /etc/gshadow-, /etc/shells, and GRUB configuration files. CIS Benchmark sections 7.1.x.
+      - id: guidance-maintenance-s2
+        text: Organizations MUST ensure world-writable files have sticky bits set, no unauthorized world-writable files exist, no unowned or ungrouped files exist, and user configuration files have appropriate settings. CIS Benchmark sections 7.1.11.
+      - id: guidance-maintenance-s3
+        text: Organizations MUST ensure all accounts use shadowed passwords, no empty shadow password fields exist, all groups in /etc/passwd exist in /etc/group, no duplicate UIDs/GIDs/usernames/groupnames exist, and home directories are properly configured with correct ownership and permissions. CIS Benchmark sections 7.2.x.
+      - id: guidance-maintenance-s4
+        text: Organizations MUST ensure user dot files have proper ownership and permissions, and no .forward or .netrc files exist. CIS Benchmark section 7.2.9.
+  - id: guidance-operations
+    title: CIS Fedora Server L1 - Operations
+    objective: Ensure operational tasks are completed after configuration changes
+    group: operations
+    statements:
+      - id: guidance-operations-s1
+        text: The dconf database MUST be reloaded after any GDM or GNOME configuration changes to ensure settings take effect.

--- a/governance/policies/cis-fedora-l1-server-policy.yaml
+++ b/governance/policies/cis-fedora-l1-server-policy.yaml
@@ -1,0 +1,2021 @@
+title: CIS Fedora Linux - Level 1 Server Policy
+metadata:
+  id: cis-fedora-l1-server-policy
+  type: Policy
+  gemara-version: 0.24.0
+  description: Automated evaluation policy for the CIS Fedora Linux Level 1 Server Benchmark
+  author:
+    id: complytime
+    name: ComplyTime
+    type: Software
+  mapping-references:
+    - id: cis-fedora-l1-server
+      title: CIS Fedora Linux - Level 1 Server
+      version: 1.0.0
+      description: Control catalog for CIS Fedora Linux Level 1 Server Benchmark
+contacts:
+  responsible:
+    - name: System Administrator
+  accountable:
+    - name: Security Team
+scope:
+  in:
+    technologies:
+      - Fedora Linux
+    users:
+      - Server administrators
+imports:
+  catalogs:
+    - reference-id: cis-fedora-l1-server
+adherence:
+  evaluation-methods:
+    - id: openscap-automated
+      type: Gate
+      mode: Automated
+      description: OpenSCAP automated compliance evaluation
+      executor:
+        id: openscap
+        name: OpenSCAP
+        type: Software
+  assessment-plans:
+    - id: account_disable_post_pw_expiration
+      requirement-id: account_disable_post_pw_expiration
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: account_password_pam_faillock_password_auth
+      requirement-id: account_password_pam_faillock_password_auth
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: account_password_pam_faillock_system_auth
+      requirement-id: account_password_pam_faillock_system_auth
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: account_unique_id
+      requirement-id: account_unique_id
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: account_unique_name
+      requirement-id: account_unique_name
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: accounts_maximum_age_login_defs
+      requirement-id: accounts_maximum_age_login_defs
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: accounts_no_uid_except_zero
+      requirement-id: accounts_no_uid_except_zero
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: accounts_password_all_shadowed
+      requirement-id: accounts_password_all_shadowed
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: accounts_password_last_change_is_in_past
+      requirement-id: accounts_password_last_change_is_in_past
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: accounts_password_pam_dictcheck
+      requirement-id: accounts_password_pam_dictcheck
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: accounts_password_pam_difok
+      requirement-id: accounts_password_pam_difok
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: accounts_password_pam_enforce_root
+      requirement-id: accounts_password_pam_enforce_root
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: accounts_password_pam_maxrepeat
+      requirement-id: accounts_password_pam_maxrepeat
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: accounts_password_pam_minclass
+      requirement-id: accounts_password_pam_minclass
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: accounts_password_pam_minlen
+      requirement-id: accounts_password_pam_minlen
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: accounts_password_pam_pwhistory_remember_password_auth
+      requirement-id: accounts_password_pam_pwhistory_remember_password_auth
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: accounts_password_pam_pwhistory_remember_system_auth
+      requirement-id: accounts_password_pam_pwhistory_remember_system_auth
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: accounts_password_pam_pwquality_password_auth
+      requirement-id: accounts_password_pam_pwquality_password_auth
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: accounts_password_pam_pwquality_system_auth
+      requirement-id: accounts_password_pam_pwquality_system_auth
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: accounts_password_set_max_life_existing
+      requirement-id: accounts_password_set_max_life_existing
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: accounts_password_set_warn_age_existing
+      requirement-id: accounts_password_set_warn_age_existing
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: accounts_password_warn_age_login_defs
+      requirement-id: accounts_password_warn_age_login_defs
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: accounts_passwords_pam_faillock_deny
+      requirement-id: accounts_passwords_pam_faillock_deny
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: accounts_passwords_pam_faillock_unlock_time
+      requirement-id: accounts_passwords_pam_faillock_unlock_time
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: accounts_root_gid_zero
+      requirement-id: accounts_root_gid_zero
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: accounts_root_path_dirs_no_write
+      requirement-id: accounts_root_path_dirs_no_write
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: accounts_set_post_pw_existing
+      requirement-id: accounts_set_post_pw_existing
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: accounts_tmout
+      requirement-id: accounts_tmout
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: accounts_umask_etc_bashrc
+      requirement-id: accounts_umask_etc_bashrc
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: accounts_umask_etc_login_defs
+      requirement-id: accounts_umask_etc_login_defs
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: accounts_umask_etc_profile
+      requirement-id: accounts_umask_etc_profile
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: accounts_user_dot_group_ownership
+      requirement-id: accounts_user_dot_group_ownership
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: accounts_user_dot_user_ownership
+      requirement-id: accounts_user_dot_user_ownership
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: accounts_user_interactive_home_directory_exists
+      requirement-id: accounts_user_interactive_home_directory_exists
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: aide_build_database
+      requirement-id: aide_build_database
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: aide_check_audit_tools
+      requirement-id: aide_check_audit_tools
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: aide_periodic_cron_checking
+      requirement-id: aide_periodic_cron_checking
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: banner_etc_issue_cis
+      requirement-id: banner_etc_issue_cis
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: banner_etc_issue_net_cis
+      requirement-id: banner_etc_issue_net_cis
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: banner_etc_motd_cis
+      requirement-id: banner_etc_motd_cis
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: chronyd_run_as_chrony_user
+      requirement-id: chronyd_run_as_chrony_user
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: chronyd_specify_remote_server
+      requirement-id: chronyd_specify_remote_server
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: coredump_disable_backtraces
+      requirement-id: coredump_disable_backtraces
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: coredump_disable_storage
+      requirement-id: coredump_disable_storage
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: dconf_db_up_to_date
+      requirement-id: dconf_db_up_to_date
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: dconf_gnome_banner_enabled
+      requirement-id: dconf_gnome_banner_enabled
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - frequency: on-demand
+      id: dconf_gnome_disable_automount
+      requirement-id: dconf_gnome_disable_automount
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - frequency: on-demand
+      id: dconf_gnome_disable_automount_open
+      requirement-id: dconf_gnome_disable_automount_open
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: dconf_gnome_disable_autorun
+      requirement-id: dconf_gnome_disable_autorun
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: dconf_gnome_disable_user_list
+      requirement-id: dconf_gnome_disable_user_list
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: dconf_gnome_login_banner_text
+      requirement-id: dconf_gnome_login_banner_text
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: dconf_gnome_screensaver_idle_delay
+      requirement-id: dconf_gnome_screensaver_idle_delay
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: dconf_gnome_screensaver_lock_delay
+      requirement-id: dconf_gnome_screensaver_lock_delay
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: dconf_gnome_screensaver_user_locks
+      requirement-id: dconf_gnome_screensaver_user_locks
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: dconf_gnome_session_idle_user_locks
+      requirement-id: dconf_gnome_session_idle_user_locks
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: dir_perms_world_writable_sticky_bits
+      requirement-id: dir_perms_world_writable_sticky_bits
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: disable_host_auth
+      requirement-id: disable_host_auth
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: disable_users_coredumps
+      requirement-id: disable_users_coredumps
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: ensure_gpgcheck_globally_activated
+      requirement-id: ensure_gpgcheck_globally_activated
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: ensure_pam_wheel_group_empty
+      requirement-id: ensure_pam_wheel_group_empty
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: ensure_root_password_configured
+      requirement-id: ensure_root_password_configured
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_at_deny_not_exist
+      requirement-id: file_at_deny_not_exist
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_cron_allow_exists
+      requirement-id: file_cron_allow_exists
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_cron_deny_not_exist
+      requirement-id: file_cron_deny_not_exist
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_groupowner_at_allow
+      requirement-id: file_groupowner_at_allow
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_groupowner_backup_etc_group
+      requirement-id: file_groupowner_backup_etc_group
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_groupowner_backup_etc_gshadow
+      requirement-id: file_groupowner_backup_etc_gshadow
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_groupowner_backup_etc_passwd
+      requirement-id: file_groupowner_backup_etc_passwd
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_groupowner_backup_etc_shadow
+      requirement-id: file_groupowner_backup_etc_shadow
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_groupowner_cron_allow
+      requirement-id: file_groupowner_cron_allow
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_groupowner_cron_d
+      requirement-id: file_groupowner_cron_d
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_groupowner_cron_daily
+      requirement-id: file_groupowner_cron_daily
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_groupowner_cron_hourly
+      requirement-id: file_groupowner_cron_hourly
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_groupowner_cron_monthly
+      requirement-id: file_groupowner_cron_monthly
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_groupowner_cron_weekly
+      requirement-id: file_groupowner_cron_weekly
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_groupowner_crontab
+      requirement-id: file_groupowner_crontab
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_groupowner_etc_group
+      requirement-id: file_groupowner_etc_group
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_groupowner_etc_gshadow
+      requirement-id: file_groupowner_etc_gshadow
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_groupowner_etc_issue
+      requirement-id: file_groupowner_etc_issue
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_groupowner_etc_issue_net
+      requirement-id: file_groupowner_etc_issue_net
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_groupowner_etc_motd
+      requirement-id: file_groupowner_etc_motd
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_groupowner_etc_passwd
+      requirement-id: file_groupowner_etc_passwd
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_groupowner_etc_shadow
+      requirement-id: file_groupowner_etc_shadow
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_groupowner_etc_shells
+      requirement-id: file_groupowner_etc_shells
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_groupowner_sshd_config
+      requirement-id: file_groupowner_sshd_config
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_groupownership_sshd_private_key
+      requirement-id: file_groupownership_sshd_private_key
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_groupownership_sshd_pub_key
+      requirement-id: file_groupownership_sshd_pub_key
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_owner_at_allow
+      requirement-id: file_owner_at_allow
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_owner_backup_etc_group
+      requirement-id: file_owner_backup_etc_group
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_owner_backup_etc_gshadow
+      requirement-id: file_owner_backup_etc_gshadow
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_owner_backup_etc_passwd
+      requirement-id: file_owner_backup_etc_passwd
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_owner_backup_etc_shadow
+      requirement-id: file_owner_backup_etc_shadow
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_owner_cron_allow
+      requirement-id: file_owner_cron_allow
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_owner_cron_d
+      requirement-id: file_owner_cron_d
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_owner_cron_daily
+      requirement-id: file_owner_cron_daily
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_owner_cron_hourly
+      requirement-id: file_owner_cron_hourly
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_owner_cron_monthly
+      requirement-id: file_owner_cron_monthly
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_owner_cron_weekly
+      requirement-id: file_owner_cron_weekly
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_owner_crontab
+      requirement-id: file_owner_crontab
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_owner_etc_group
+      requirement-id: file_owner_etc_group
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_owner_etc_gshadow
+      requirement-id: file_owner_etc_gshadow
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_owner_etc_issue
+      requirement-id: file_owner_etc_issue
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_owner_etc_issue_net
+      requirement-id: file_owner_etc_issue_net
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_owner_etc_motd
+      requirement-id: file_owner_etc_motd
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_owner_etc_passwd
+      requirement-id: file_owner_etc_passwd
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_owner_etc_shadow
+      requirement-id: file_owner_etc_shadow
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_owner_etc_shells
+      requirement-id: file_owner_etc_shells
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_owner_sshd_config
+      requirement-id: file_owner_sshd_config
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_ownership_home_directories
+      requirement-id: file_ownership_home_directories
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_ownership_sshd_private_key
+      requirement-id: file_ownership_sshd_private_key
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_ownership_sshd_pub_key
+      requirement-id: file_ownership_sshd_pub_key
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_permission_user_init_files
+      requirement-id: file_permission_user_init_files
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_permissions_at_allow
+      requirement-id: file_permissions_at_allow
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_permissions_backup_etc_group
+      requirement-id: file_permissions_backup_etc_group
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_permissions_backup_etc_gshadow
+      requirement-id: file_permissions_backup_etc_gshadow
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_permissions_backup_etc_passwd
+      requirement-id: file_permissions_backup_etc_passwd
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_permissions_backup_etc_shadow
+      requirement-id: file_permissions_backup_etc_shadow
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_permissions_cron_allow
+      requirement-id: file_permissions_cron_allow
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_permissions_cron_d
+      requirement-id: file_permissions_cron_d
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_permissions_cron_daily
+      requirement-id: file_permissions_cron_daily
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_permissions_cron_hourly
+      requirement-id: file_permissions_cron_hourly
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_permissions_cron_monthly
+      requirement-id: file_permissions_cron_monthly
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_permissions_cron_weekly
+      requirement-id: file_permissions_cron_weekly
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_permissions_crontab
+      requirement-id: file_permissions_crontab
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_permissions_etc_group
+      requirement-id: file_permissions_etc_group
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_permissions_etc_gshadow
+      requirement-id: file_permissions_etc_gshadow
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_permissions_etc_issue
+      requirement-id: file_permissions_etc_issue
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_permissions_etc_issue_net
+      requirement-id: file_permissions_etc_issue_net
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_permissions_etc_motd
+      requirement-id: file_permissions_etc_motd
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_permissions_etc_passwd
+      requirement-id: file_permissions_etc_passwd
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_permissions_etc_shadow
+      requirement-id: file_permissions_etc_shadow
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_permissions_etc_shells
+      requirement-id: file_permissions_etc_shells
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_permissions_home_directories
+      requirement-id: file_permissions_home_directories
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_permissions_sshd_config
+      requirement-id: file_permissions_sshd_config
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_permissions_sshd_private_key
+      requirement-id: file_permissions_sshd_private_key
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_permissions_sshd_pub_key
+      requirement-id: file_permissions_sshd_pub_key
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: file_permissions_unauthorized_world_writable
+      requirement-id: file_permissions_unauthorized_world_writable
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: firewalld_loopback_traffic_restricted
+      requirement-id: firewalld_loopback_traffic_restricted
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: firewalld_loopback_traffic_trusted
+      requirement-id: firewalld_loopback_traffic_trusted
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: gid_passwd_group_same
+      requirement-id: gid_passwd_group_same
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: group_unique_id
+      requirement-id: group_unique_id
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: group_unique_name
+      requirement-id: group_unique_name
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: grub2_enable_selinux
+      requirement-id: grub2_enable_selinux
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: grub2_password
+      requirement-id: grub2_password
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: has_nonlocal_mta
+      requirement-id: has_nonlocal_mta
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: journald_compress
+      requirement-id: journald_compress
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: journald_storage
+      requirement-id: journald_storage
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: kernel_module_atm_disabled
+      requirement-id: kernel_module_atm_disabled
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: kernel_module_can_disabled
+      requirement-id: kernel_module_can_disabled
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: kernel_module_cramfs_disabled
+      requirement-id: kernel_module_cramfs_disabled
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: kernel_module_dccp_disabled
+      requirement-id: kernel_module_dccp_disabled
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - frequency: on-demand
+      id: kernel_module_firewire-core_disabled
+      requirement-id: kernel_module_firewire-core_disabled
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: kernel_module_freevxfs_disabled
+      requirement-id: kernel_module_freevxfs_disabled
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: kernel_module_hfs_disabled
+      requirement-id: kernel_module_hfs_disabled
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: kernel_module_hfsplus_disabled
+      requirement-id: kernel_module_hfsplus_disabled
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: kernel_module_jffs2_disabled
+      requirement-id: kernel_module_jffs2_disabled
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: kernel_module_rds_disabled
+      requirement-id: kernel_module_rds_disabled
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: kernel_module_tipc_disabled
+      requirement-id: kernel_module_tipc_disabled
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - frequency: on-demand
+      id: kernel_module_usb-storage_disabled
+      requirement-id: kernel_module_usb-storage_disabled
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: mount_option_dev_shm_nodev
+      requirement-id: mount_option_dev_shm_nodev
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: mount_option_dev_shm_noexec
+      requirement-id: mount_option_dev_shm_noexec
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: mount_option_dev_shm_nosuid
+      requirement-id: mount_option_dev_shm_nosuid
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: mount_option_home_nodev
+      requirement-id: mount_option_home_nodev
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: mount_option_home_nosuid
+      requirement-id: mount_option_home_nosuid
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: mount_option_tmp_nodev
+      requirement-id: mount_option_tmp_nodev
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: mount_option_tmp_noexec
+      requirement-id: mount_option_tmp_noexec
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: mount_option_tmp_nosuid
+      requirement-id: mount_option_tmp_nosuid
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: mount_option_var_log_audit_nodev
+      requirement-id: mount_option_var_log_audit_nodev
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: mount_option_var_log_audit_noexec
+      requirement-id: mount_option_var_log_audit_noexec
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: mount_option_var_log_audit_nosuid
+      requirement-id: mount_option_var_log_audit_nosuid
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: mount_option_var_log_nodev
+      requirement-id: mount_option_var_log_nodev
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: mount_option_var_log_noexec
+      requirement-id: mount_option_var_log_noexec
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: mount_option_var_log_nosuid
+      requirement-id: mount_option_var_log_nosuid
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: mount_option_var_nodev
+      requirement-id: mount_option_var_nodev
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: mount_option_var_nosuid
+      requirement-id: mount_option_var_nosuid
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: mount_option_var_tmp_nodev
+      requirement-id: mount_option_var_tmp_nodev
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: mount_option_var_tmp_noexec
+      requirement-id: mount_option_var_tmp_noexec
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: mount_option_var_tmp_nosuid
+      requirement-id: mount_option_var_tmp_nosuid
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: no_empty_passwords
+      requirement-id: no_empty_passwords
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: no_empty_passwords_etc_shadow
+      requirement-id: no_empty_passwords_etc_shadow
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: no_forward_files
+      requirement-id: no_forward_files
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: no_netrc_files
+      requirement-id: no_netrc_files
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: no_password_auth_for_systemaccounts
+      requirement-id: no_password_auth_for_systemaccounts
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: no_shelllogin_for_systemaccounts
+      requirement-id: no_shelllogin_for_systemaccounts
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: package_aide_installed
+      requirement-id: package_aide_installed
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: package_bind_removed
+      requirement-id: package_bind_removed
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: package_cron_installed
+      requirement-id: package_cron_installed
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: package_cyrus-imapd_removed
+      requirement-id: package_cyrus-imapd_removed
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: package_dnsmasq_removed
+      requirement-id: package_dnsmasq_removed
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: package_dovecot_removed
+      requirement-id: package_dovecot_removed
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: package_firewalld_installed
+      requirement-id: package_firewalld_installed
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: package_ftp_removed
+      requirement-id: package_ftp_removed
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: package_httpd_removed
+      requirement-id: package_httpd_removed
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: package_kea_removed
+      requirement-id: package_kea_removed
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: package_libselinux_installed
+      requirement-id: package_libselinux_installed
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: package_mcstrans_removed
+      requirement-id: package_mcstrans_removed
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: package_net-snmp_removed
+      requirement-id: package_net-snmp_removed
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: package_nftables_installed
+      requirement-id: package_nftables_installed
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: package_nginx_removed
+      requirement-id: package_nginx_removed
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: package_pam_pwquality_installed
+      requirement-id: package_pam_pwquality_installed
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: package_rsync_removed
+      requirement-id: package_rsync_removed
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: package_samba_removed
+      requirement-id: package_samba_removed
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - frequency: on-demand
+      id: package_setroubleshoot_removed
+      requirement-id: package_setroubleshoot_removed
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: package_squid_removed
+      requirement-id: package_squid_removed
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: package_sudo_installed
+      requirement-id: package_sudo_installed
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: package_systemd-journal-remote_installed
+      requirement-id: package_systemd-journal-remote_installed
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: package_telnet-server_removed
+      requirement-id: package_telnet-server_removed
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: package_telnet_removed
+      requirement-id: package_telnet_removed
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: package_tftp-server_removed
+      requirement-id: package_tftp-server_removed
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: package_tftp_removed
+      requirement-id: package_tftp_removed
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: package_vsftpd_removed
+      requirement-id: package_vsftpd_removed
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: partition_for_dev_shm
+      requirement-id: partition_for_dev_shm
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: partition_for_tmp
+      requirement-id: partition_for_tmp
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: postfix_network_listening_disabled
+      requirement-id: postfix_network_listening_disabled
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: root_path_no_dot
+      requirement-id: root_path_no_dot
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: rsyslog_files_groupownership
+      requirement-id: rsyslog_files_groupownership
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: rsyslog_files_ownership
+      requirement-id: rsyslog_files_ownership
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: rsyslog_files_permissions
+      requirement-id: rsyslog_files_permissions
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: selinux_not_disabled
+      requirement-id: selinux_not_disabled
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: selinux_policytype
+      requirement-id: selinux_policytype
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - frequency: on-demand
+      id: service_autofs_disabled
+      requirement-id: service_autofs_disabled
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - frequency: on-demand
+      id: service_avahi-daemon_disabled
+      requirement-id: service_avahi-daemon_disabled
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - frequency: on-demand
+      id: service_bluetooth_disabled
+      requirement-id: service_bluetooth_disabled
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: service_crond_enabled
+      requirement-id: service_crond_enabled
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - frequency: on-demand
+      id: service_cups_disabled
+      requirement-id: service_cups_disabled
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: service_firewalld_enabled
+      requirement-id: service_firewalld_enabled
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: service_nfs_disabled
+      requirement-id: service_nfs_disabled
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: service_nftables_disabled
+      requirement-id: service_nftables_disabled
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: service_rpcbind_disabled
+      requirement-id: service_rpcbind_disabled
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: service_systemd-journald_enabled
+      requirement-id: service_systemd-journald_enabled
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: set_password_hashing_algorithm_logindefs
+      requirement-id: set_password_hashing_algorithm_logindefs
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: set_password_hashing_algorithm_passwordauth
+      requirement-id: set_password_hashing_algorithm_passwordauth
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: set_password_hashing_algorithm_systemauth
+      requirement-id: set_password_hashing_algorithm_systemauth
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: socket_systemd-journal-remote_disabled
+      requirement-id: socket_systemd-journal-remote_disabled
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sshd_disable_empty_passwords
+      requirement-id: sshd_disable_empty_passwords
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sshd_disable_rhosts
+      requirement-id: sshd_disable_rhosts
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sshd_disable_root_login
+      requirement-id: sshd_disable_root_login
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sshd_do_not_permit_user_env
+      requirement-id: sshd_do_not_permit_user_env
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sshd_enable_pam
+      requirement-id: sshd_enable_pam
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sshd_enable_warning_banner_net
+      requirement-id: sshd_enable_warning_banner_net
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sshd_limit_user_access
+      requirement-id: sshd_limit_user_access
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sshd_set_idle_timeout
+      requirement-id: sshd_set_idle_timeout
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sshd_set_keepalive
+      requirement-id: sshd_set_keepalive
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sshd_set_login_grace_time
+      requirement-id: sshd_set_login_grace_time
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sshd_set_loglevel_verbose
+      requirement-id: sshd_set_loglevel_verbose
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sshd_set_max_auth_tries
+      requirement-id: sshd_set_max_auth_tries
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sshd_set_max_sessions
+      requirement-id: sshd_set_max_sessions
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sshd_set_maxstartups
+      requirement-id: sshd_set_maxstartups
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sudo_add_use_pty
+      requirement-id: sudo_add_use_pty
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sudo_custom_logfile
+      requirement-id: sudo_custom_logfile
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sudo_remove_no_authenticate
+      requirement-id: sudo_remove_no_authenticate
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sudo_require_reauthentication
+      requirement-id: sudo_require_reauthentication
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sysctl_fs_protected_hardlinks
+      requirement-id: sysctl_fs_protected_hardlinks
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sysctl_fs_protected_symlinks
+      requirement-id: sysctl_fs_protected_symlinks
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sysctl_fs_suid_dumpable
+      requirement-id: sysctl_fs_suid_dumpable
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sysctl_kernel_dmesg_restrict
+      requirement-id: sysctl_kernel_dmesg_restrict
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sysctl_kernel_kptr_restrict
+      requirement-id: sysctl_kernel_kptr_restrict
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sysctl_kernel_randomize_va_space
+      requirement-id: sysctl_kernel_randomize_va_space
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sysctl_kernel_yama_ptrace_scope
+      requirement-id: sysctl_kernel_yama_ptrace_scope
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sysctl_net_ipv4_conf_all_accept_redirects
+      requirement-id: sysctl_net_ipv4_conf_all_accept_redirects
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sysctl_net_ipv4_conf_all_accept_source_route
+      requirement-id: sysctl_net_ipv4_conf_all_accept_source_route
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sysctl_net_ipv4_conf_all_log_martians
+      requirement-id: sysctl_net_ipv4_conf_all_log_martians
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sysctl_net_ipv4_conf_all_rp_filter
+      requirement-id: sysctl_net_ipv4_conf_all_rp_filter
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sysctl_net_ipv4_conf_all_secure_redirects
+      requirement-id: sysctl_net_ipv4_conf_all_secure_redirects
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sysctl_net_ipv4_conf_all_send_redirects
+      requirement-id: sysctl_net_ipv4_conf_all_send_redirects
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sysctl_net_ipv4_conf_default_accept_redirects
+      requirement-id: sysctl_net_ipv4_conf_default_accept_redirects
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sysctl_net_ipv4_conf_default_accept_source_route
+      requirement-id: sysctl_net_ipv4_conf_default_accept_source_route
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sysctl_net_ipv4_conf_default_log_martians
+      requirement-id: sysctl_net_ipv4_conf_default_log_martians
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sysctl_net_ipv4_conf_default_rp_filter
+      requirement-id: sysctl_net_ipv4_conf_default_rp_filter
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sysctl_net_ipv4_conf_default_secure_redirects
+      requirement-id: sysctl_net_ipv4_conf_default_secure_redirects
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sysctl_net_ipv4_conf_default_send_redirects
+      requirement-id: sysctl_net_ipv4_conf_default_send_redirects
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sysctl_net_ipv4_icmp_echo_ignore_broadcasts
+      requirement-id: sysctl_net_ipv4_icmp_echo_ignore_broadcasts
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sysctl_net_ipv4_icmp_ignore_bogus_error_responses
+      requirement-id: sysctl_net_ipv4_icmp_ignore_bogus_error_responses
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sysctl_net_ipv4_tcp_syncookies
+      requirement-id: sysctl_net_ipv4_tcp_syncookies
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sysctl_net_ipv6_conf_all_accept_ra
+      requirement-id: sysctl_net_ipv6_conf_all_accept_ra
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sysctl_net_ipv6_conf_all_accept_redirects
+      requirement-id: sysctl_net_ipv6_conf_all_accept_redirects
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sysctl_net_ipv6_conf_all_accept_source_route
+      requirement-id: sysctl_net_ipv6_conf_all_accept_source_route
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sysctl_net_ipv6_conf_all_forwarding
+      requirement-id: sysctl_net_ipv6_conf_all_forwarding
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sysctl_net_ipv6_conf_default_accept_ra
+      requirement-id: sysctl_net_ipv6_conf_default_accept_ra
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sysctl_net_ipv6_conf_default_accept_redirects
+      requirement-id: sysctl_net_ipv6_conf_default_accept_redirects
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: sysctl_net_ipv6_conf_default_accept_source_route
+      requirement-id: sysctl_net_ipv6_conf_default_accept_source_route
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - id: use_pam_wheel_group_for_su
+      requirement-id: use_pam_wheel_group_for_su
+      frequency: on-demand
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+    - frequency: on-demand
+      id: wireless_disable_interfaces
+      requirement-id: wireless_disable_interfaces
+      evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated

--- a/governance/policies/cis-fedora-l1-workstation-policy.yaml
+++ b/governance/policies/cis-fedora-l1-workstation-policy.yaml
@@ -1,0 +1,1965 @@
+title: CIS Fedora Linux - Level 1 Workstation Policy
+metadata:
+    id: cis-fedora-l1-workstation-policy
+    type: Policy
+    gemara-version: "0.24.0"
+    description: Automated evaluation policy for the CIS Fedora Linux Level 1 Workstation Benchmark
+    author:
+        id: complytime
+        name: ComplyTime
+        type: Software
+    mapping-references:
+        - id: cis-fedora-l1-workstation
+          title: CIS Fedora Linux - Level 1 Workstation
+          version: 1.0.0
+          description: Control catalog for CIS Fedora Linux Level 1 Workstation Benchmark
+contacts:
+    responsible:
+        - name: System Administrator
+    accountable:
+        - name: Security Team
+scope:
+    in:
+        technologies:
+            - Fedora Linux
+        users:
+            - Workstation users
+imports:
+    catalogs:
+        - reference-id: cis-fedora-l1-workstation
+adherence:
+    evaluation-methods:
+        - id: openscap-automated
+          type: Gate
+          mode: Automated
+          description: OpenSCAP automated compliance evaluation
+          executor:
+              id: openscap
+              name: OpenSCAP
+              type: Software
+    assessment-plans:
+        - id: account_disable_post_pw_expiration
+          requirement-id: account_disable_post_pw_expiration
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: account_password_pam_faillock_password_auth
+          requirement-id: account_password_pam_faillock_password_auth
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: account_password_pam_faillock_system_auth
+          requirement-id: account_password_pam_faillock_system_auth
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: account_unique_id
+          requirement-id: account_unique_id
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: account_unique_name
+          requirement-id: account_unique_name
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: accounts_maximum_age_login_defs
+          requirement-id: accounts_maximum_age_login_defs
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: accounts_no_uid_except_zero
+          requirement-id: accounts_no_uid_except_zero
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: accounts_password_all_shadowed
+          requirement-id: accounts_password_all_shadowed
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: accounts_password_last_change_is_in_past
+          requirement-id: accounts_password_last_change_is_in_past
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: accounts_password_pam_dictcheck
+          requirement-id: accounts_password_pam_dictcheck
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: accounts_password_pam_difok
+          requirement-id: accounts_password_pam_difok
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: accounts_password_pam_enforce_root
+          requirement-id: accounts_password_pam_enforce_root
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: accounts_password_pam_maxrepeat
+          requirement-id: accounts_password_pam_maxrepeat
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: accounts_password_pam_minclass
+          requirement-id: accounts_password_pam_minclass
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: accounts_password_pam_minlen
+          requirement-id: accounts_password_pam_minlen
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: accounts_password_pam_pwhistory_remember_password_auth
+          requirement-id: accounts_password_pam_pwhistory_remember_password_auth
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: accounts_password_pam_pwhistory_remember_system_auth
+          requirement-id: accounts_password_pam_pwhistory_remember_system_auth
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: accounts_password_pam_pwquality_password_auth
+          requirement-id: accounts_password_pam_pwquality_password_auth
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: accounts_password_pam_pwquality_system_auth
+          requirement-id: accounts_password_pam_pwquality_system_auth
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: accounts_password_set_max_life_existing
+          requirement-id: accounts_password_set_max_life_existing
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: accounts_password_set_warn_age_existing
+          requirement-id: accounts_password_set_warn_age_existing
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: accounts_password_warn_age_login_defs
+          requirement-id: accounts_password_warn_age_login_defs
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: accounts_passwords_pam_faillock_deny
+          requirement-id: accounts_passwords_pam_faillock_deny
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: accounts_passwords_pam_faillock_unlock_time
+          requirement-id: accounts_passwords_pam_faillock_unlock_time
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: accounts_root_gid_zero
+          requirement-id: accounts_root_gid_zero
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: accounts_root_path_dirs_no_write
+          requirement-id: accounts_root_path_dirs_no_write
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: accounts_set_post_pw_existing
+          requirement-id: accounts_set_post_pw_existing
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: accounts_tmout
+          requirement-id: accounts_tmout
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: accounts_umask_etc_bashrc
+          requirement-id: accounts_umask_etc_bashrc
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: accounts_umask_etc_login_defs
+          requirement-id: accounts_umask_etc_login_defs
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: accounts_umask_etc_profile
+          requirement-id: accounts_umask_etc_profile
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: accounts_user_dot_group_ownership
+          requirement-id: accounts_user_dot_group_ownership
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: accounts_user_dot_user_ownership
+          requirement-id: accounts_user_dot_user_ownership
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: accounts_user_interactive_home_directory_exists
+          requirement-id: accounts_user_interactive_home_directory_exists
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: aide_build_database
+          requirement-id: aide_build_database
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: aide_check_audit_tools
+          requirement-id: aide_check_audit_tools
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: aide_periodic_cron_checking
+          requirement-id: aide_periodic_cron_checking
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: banner_etc_issue_cis
+          requirement-id: banner_etc_issue_cis
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: banner_etc_issue_net_cis
+          requirement-id: banner_etc_issue_net_cis
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: banner_etc_motd_cis
+          requirement-id: banner_etc_motd_cis
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: chronyd_run_as_chrony_user
+          requirement-id: chronyd_run_as_chrony_user
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: chronyd_specify_remote_server
+          requirement-id: chronyd_specify_remote_server
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: coredump_disable_backtraces
+          requirement-id: coredump_disable_backtraces
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: coredump_disable_storage
+          requirement-id: coredump_disable_storage
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: dconf_db_up_to_date
+          requirement-id: dconf_db_up_to_date
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: dconf_gnome_banner_enabled
+          requirement-id: dconf_gnome_banner_enabled
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: dconf_gnome_disable_autorun
+          requirement-id: dconf_gnome_disable_autorun
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: dconf_gnome_disable_user_list
+          requirement-id: dconf_gnome_disable_user_list
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: dconf_gnome_login_banner_text
+          requirement-id: dconf_gnome_login_banner_text
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: dconf_gnome_screensaver_idle_delay
+          requirement-id: dconf_gnome_screensaver_idle_delay
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: dconf_gnome_screensaver_lock_delay
+          requirement-id: dconf_gnome_screensaver_lock_delay
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: dconf_gnome_screensaver_user_locks
+          requirement-id: dconf_gnome_screensaver_user_locks
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: dconf_gnome_session_idle_user_locks
+          requirement-id: dconf_gnome_session_idle_user_locks
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: dir_perms_world_writable_sticky_bits
+          requirement-id: dir_perms_world_writable_sticky_bits
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: disable_host_auth
+          requirement-id: disable_host_auth
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: disable_users_coredumps
+          requirement-id: disable_users_coredumps
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: ensure_gpgcheck_globally_activated
+          requirement-id: ensure_gpgcheck_globally_activated
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: ensure_pam_wheel_group_empty
+          requirement-id: ensure_pam_wheel_group_empty
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: ensure_root_password_configured
+          requirement-id: ensure_root_password_configured
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_at_deny_not_exist
+          requirement-id: file_at_deny_not_exist
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_cron_allow_exists
+          requirement-id: file_cron_allow_exists
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_cron_deny_not_exist
+          requirement-id: file_cron_deny_not_exist
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_groupowner_at_allow
+          requirement-id: file_groupowner_at_allow
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_groupowner_backup_etc_group
+          requirement-id: file_groupowner_backup_etc_group
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_groupowner_backup_etc_gshadow
+          requirement-id: file_groupowner_backup_etc_gshadow
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_groupowner_backup_etc_passwd
+          requirement-id: file_groupowner_backup_etc_passwd
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_groupowner_backup_etc_shadow
+          requirement-id: file_groupowner_backup_etc_shadow
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_groupowner_cron_allow
+          requirement-id: file_groupowner_cron_allow
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_groupowner_cron_d
+          requirement-id: file_groupowner_cron_d
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_groupowner_cron_daily
+          requirement-id: file_groupowner_cron_daily
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_groupowner_cron_hourly
+          requirement-id: file_groupowner_cron_hourly
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_groupowner_cron_monthly
+          requirement-id: file_groupowner_cron_monthly
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_groupowner_cron_weekly
+          requirement-id: file_groupowner_cron_weekly
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_groupowner_crontab
+          requirement-id: file_groupowner_crontab
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_groupowner_etc_group
+          requirement-id: file_groupowner_etc_group
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_groupowner_etc_gshadow
+          requirement-id: file_groupowner_etc_gshadow
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_groupowner_etc_issue
+          requirement-id: file_groupowner_etc_issue
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_groupowner_etc_issue_net
+          requirement-id: file_groupowner_etc_issue_net
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_groupowner_etc_motd
+          requirement-id: file_groupowner_etc_motd
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_groupowner_etc_passwd
+          requirement-id: file_groupowner_etc_passwd
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_groupowner_etc_shadow
+          requirement-id: file_groupowner_etc_shadow
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_groupowner_etc_shells
+          requirement-id: file_groupowner_etc_shells
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_groupowner_sshd_config
+          requirement-id: file_groupowner_sshd_config
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_groupownership_sshd_private_key
+          requirement-id: file_groupownership_sshd_private_key
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_groupownership_sshd_pub_key
+          requirement-id: file_groupownership_sshd_pub_key
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_owner_at_allow
+          requirement-id: file_owner_at_allow
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_owner_backup_etc_group
+          requirement-id: file_owner_backup_etc_group
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_owner_backup_etc_gshadow
+          requirement-id: file_owner_backup_etc_gshadow
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_owner_backup_etc_passwd
+          requirement-id: file_owner_backup_etc_passwd
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_owner_backup_etc_shadow
+          requirement-id: file_owner_backup_etc_shadow
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_owner_cron_allow
+          requirement-id: file_owner_cron_allow
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_owner_cron_d
+          requirement-id: file_owner_cron_d
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_owner_cron_daily
+          requirement-id: file_owner_cron_daily
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_owner_cron_hourly
+          requirement-id: file_owner_cron_hourly
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_owner_cron_monthly
+          requirement-id: file_owner_cron_monthly
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_owner_cron_weekly
+          requirement-id: file_owner_cron_weekly
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_owner_crontab
+          requirement-id: file_owner_crontab
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_owner_etc_group
+          requirement-id: file_owner_etc_group
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_owner_etc_gshadow
+          requirement-id: file_owner_etc_gshadow
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_owner_etc_issue
+          requirement-id: file_owner_etc_issue
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_owner_etc_issue_net
+          requirement-id: file_owner_etc_issue_net
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_owner_etc_motd
+          requirement-id: file_owner_etc_motd
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_owner_etc_passwd
+          requirement-id: file_owner_etc_passwd
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_owner_etc_shadow
+          requirement-id: file_owner_etc_shadow
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_owner_etc_shells
+          requirement-id: file_owner_etc_shells
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_owner_sshd_config
+          requirement-id: file_owner_sshd_config
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_ownership_home_directories
+          requirement-id: file_ownership_home_directories
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_ownership_sshd_private_key
+          requirement-id: file_ownership_sshd_private_key
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_ownership_sshd_pub_key
+          requirement-id: file_ownership_sshd_pub_key
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_permission_user_init_files
+          requirement-id: file_permission_user_init_files
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_permissions_at_allow
+          requirement-id: file_permissions_at_allow
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_permissions_backup_etc_group
+          requirement-id: file_permissions_backup_etc_group
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_permissions_backup_etc_gshadow
+          requirement-id: file_permissions_backup_etc_gshadow
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_permissions_backup_etc_passwd
+          requirement-id: file_permissions_backup_etc_passwd
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_permissions_backup_etc_shadow
+          requirement-id: file_permissions_backup_etc_shadow
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_permissions_cron_allow
+          requirement-id: file_permissions_cron_allow
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_permissions_cron_d
+          requirement-id: file_permissions_cron_d
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_permissions_cron_daily
+          requirement-id: file_permissions_cron_daily
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_permissions_cron_hourly
+          requirement-id: file_permissions_cron_hourly
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_permissions_cron_monthly
+          requirement-id: file_permissions_cron_monthly
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_permissions_cron_weekly
+          requirement-id: file_permissions_cron_weekly
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_permissions_crontab
+          requirement-id: file_permissions_crontab
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_permissions_etc_group
+          requirement-id: file_permissions_etc_group
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_permissions_etc_gshadow
+          requirement-id: file_permissions_etc_gshadow
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_permissions_etc_issue
+          requirement-id: file_permissions_etc_issue
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_permissions_etc_issue_net
+          requirement-id: file_permissions_etc_issue_net
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_permissions_etc_motd
+          requirement-id: file_permissions_etc_motd
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_permissions_etc_passwd
+          requirement-id: file_permissions_etc_passwd
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_permissions_etc_shadow
+          requirement-id: file_permissions_etc_shadow
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_permissions_etc_shells
+          requirement-id: file_permissions_etc_shells
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_permissions_home_directories
+          requirement-id: file_permissions_home_directories
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_permissions_sshd_config
+          requirement-id: file_permissions_sshd_config
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_permissions_sshd_private_key
+          requirement-id: file_permissions_sshd_private_key
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_permissions_sshd_pub_key
+          requirement-id: file_permissions_sshd_pub_key
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: file_permissions_unauthorized_world_writable
+          requirement-id: file_permissions_unauthorized_world_writable
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: firewalld_loopback_traffic_restricted
+          requirement-id: firewalld_loopback_traffic_restricted
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: firewalld_loopback_traffic_trusted
+          requirement-id: firewalld_loopback_traffic_trusted
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: gid_passwd_group_same
+          requirement-id: gid_passwd_group_same
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: group_unique_id
+          requirement-id: group_unique_id
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: group_unique_name
+          requirement-id: group_unique_name
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: grub2_enable_selinux
+          requirement-id: grub2_enable_selinux
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: grub2_password
+          requirement-id: grub2_password
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: has_nonlocal_mta
+          requirement-id: has_nonlocal_mta
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: journald_compress
+          requirement-id: journald_compress
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: journald_storage
+          requirement-id: journald_storage
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: kernel_module_atm_disabled
+          requirement-id: kernel_module_atm_disabled
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: kernel_module_can_disabled
+          requirement-id: kernel_module_can_disabled
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: kernel_module_cramfs_disabled
+          requirement-id: kernel_module_cramfs_disabled
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: kernel_module_dccp_disabled
+          requirement-id: kernel_module_dccp_disabled
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: kernel_module_freevxfs_disabled
+          requirement-id: kernel_module_freevxfs_disabled
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: kernel_module_hfs_disabled
+          requirement-id: kernel_module_hfs_disabled
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: kernel_module_hfsplus_disabled
+          requirement-id: kernel_module_hfsplus_disabled
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: kernel_module_jffs2_disabled
+          requirement-id: kernel_module_jffs2_disabled
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: kernel_module_rds_disabled
+          requirement-id: kernel_module_rds_disabled
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: kernel_module_tipc_disabled
+          requirement-id: kernel_module_tipc_disabled
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: mount_option_dev_shm_nodev
+          requirement-id: mount_option_dev_shm_nodev
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: mount_option_dev_shm_noexec
+          requirement-id: mount_option_dev_shm_noexec
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: mount_option_dev_shm_nosuid
+          requirement-id: mount_option_dev_shm_nosuid
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: mount_option_home_nodev
+          requirement-id: mount_option_home_nodev
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: mount_option_home_nosuid
+          requirement-id: mount_option_home_nosuid
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: mount_option_tmp_nodev
+          requirement-id: mount_option_tmp_nodev
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: mount_option_tmp_noexec
+          requirement-id: mount_option_tmp_noexec
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: mount_option_tmp_nosuid
+          requirement-id: mount_option_tmp_nosuid
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: mount_option_var_log_audit_nodev
+          requirement-id: mount_option_var_log_audit_nodev
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: mount_option_var_log_audit_noexec
+          requirement-id: mount_option_var_log_audit_noexec
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: mount_option_var_log_audit_nosuid
+          requirement-id: mount_option_var_log_audit_nosuid
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: mount_option_var_log_nodev
+          requirement-id: mount_option_var_log_nodev
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: mount_option_var_log_noexec
+          requirement-id: mount_option_var_log_noexec
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: mount_option_var_log_nosuid
+          requirement-id: mount_option_var_log_nosuid
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: mount_option_var_nodev
+          requirement-id: mount_option_var_nodev
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: mount_option_var_nosuid
+          requirement-id: mount_option_var_nosuid
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: mount_option_var_tmp_nodev
+          requirement-id: mount_option_var_tmp_nodev
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: mount_option_var_tmp_noexec
+          requirement-id: mount_option_var_tmp_noexec
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: mount_option_var_tmp_nosuid
+          requirement-id: mount_option_var_tmp_nosuid
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: no_empty_passwords
+          requirement-id: no_empty_passwords
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: no_empty_passwords_etc_shadow
+          requirement-id: no_empty_passwords_etc_shadow
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: no_forward_files
+          requirement-id: no_forward_files
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: no_netrc_files
+          requirement-id: no_netrc_files
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: no_password_auth_for_systemaccounts
+          requirement-id: no_password_auth_for_systemaccounts
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: no_shelllogin_for_systemaccounts
+          requirement-id: no_shelllogin_for_systemaccounts
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: package_aide_installed
+          requirement-id: package_aide_installed
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: package_bind_removed
+          requirement-id: package_bind_removed
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: package_cron_installed
+          requirement-id: package_cron_installed
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: package_cyrus-imapd_removed
+          requirement-id: package_cyrus-imapd_removed
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: package_dnsmasq_removed
+          requirement-id: package_dnsmasq_removed
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: package_dovecot_removed
+          requirement-id: package_dovecot_removed
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: package_firewalld_installed
+          requirement-id: package_firewalld_installed
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: package_ftp_removed
+          requirement-id: package_ftp_removed
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: package_httpd_removed
+          requirement-id: package_httpd_removed
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: package_kea_removed
+          requirement-id: package_kea_removed
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: package_libselinux_installed
+          requirement-id: package_libselinux_installed
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: package_mcstrans_removed
+          requirement-id: package_mcstrans_removed
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: package_net-snmp_removed
+          requirement-id: package_net-snmp_removed
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: package_nftables_installed
+          requirement-id: package_nftables_installed
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: package_nginx_removed
+          requirement-id: package_nginx_removed
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: package_pam_pwquality_installed
+          requirement-id: package_pam_pwquality_installed
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: package_rsync_removed
+          requirement-id: package_rsync_removed
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: package_samba_removed
+          requirement-id: package_samba_removed
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: package_squid_removed
+          requirement-id: package_squid_removed
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: package_sudo_installed
+          requirement-id: package_sudo_installed
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: package_systemd-journal-remote_installed
+          requirement-id: package_systemd-journal-remote_installed
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: package_telnet-server_removed
+          requirement-id: package_telnet-server_removed
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: package_telnet_removed
+          requirement-id: package_telnet_removed
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: package_tftp-server_removed
+          requirement-id: package_tftp-server_removed
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: package_tftp_removed
+          requirement-id: package_tftp_removed
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: package_vsftpd_removed
+          requirement-id: package_vsftpd_removed
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: partition_for_dev_shm
+          requirement-id: partition_for_dev_shm
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: partition_for_tmp
+          requirement-id: partition_for_tmp
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: postfix_network_listening_disabled
+          requirement-id: postfix_network_listening_disabled
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: root_path_no_dot
+          requirement-id: root_path_no_dot
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: rsyslog_files_groupownership
+          requirement-id: rsyslog_files_groupownership
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: rsyslog_files_ownership
+          requirement-id: rsyslog_files_ownership
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: rsyslog_files_permissions
+          requirement-id: rsyslog_files_permissions
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: selinux_not_disabled
+          requirement-id: selinux_not_disabled
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: selinux_policytype
+          requirement-id: selinux_policytype
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: service_crond_enabled
+          requirement-id: service_crond_enabled
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: service_firewalld_enabled
+          requirement-id: service_firewalld_enabled
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: service_nfs_disabled
+          requirement-id: service_nfs_disabled
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: service_nftables_disabled
+          requirement-id: service_nftables_disabled
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: service_rpcbind_disabled
+          requirement-id: service_rpcbind_disabled
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: service_systemd-journald_enabled
+          requirement-id: service_systemd-journald_enabled
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: set_password_hashing_algorithm_logindefs
+          requirement-id: set_password_hashing_algorithm_logindefs
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: set_password_hashing_algorithm_passwordauth
+          requirement-id: set_password_hashing_algorithm_passwordauth
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: set_password_hashing_algorithm_systemauth
+          requirement-id: set_password_hashing_algorithm_systemauth
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: socket_systemd-journal-remote_disabled
+          requirement-id: socket_systemd-journal-remote_disabled
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sshd_disable_empty_passwords
+          requirement-id: sshd_disable_empty_passwords
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sshd_disable_gssapi_auth
+          requirement-id: sshd_disable_gssapi_auth
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sshd_disable_rhosts
+          requirement-id: sshd_disable_rhosts
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sshd_disable_root_login
+          requirement-id: sshd_disable_root_login
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sshd_do_not_permit_user_env
+          requirement-id: sshd_do_not_permit_user_env
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sshd_enable_pam
+          requirement-id: sshd_enable_pam
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sshd_enable_warning_banner_net
+          requirement-id: sshd_enable_warning_banner_net
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sshd_limit_user_access
+          requirement-id: sshd_limit_user_access
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sshd_set_idle_timeout
+          requirement-id: sshd_set_idle_timeout
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sshd_set_keepalive
+          requirement-id: sshd_set_keepalive
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sshd_set_login_grace_time
+          requirement-id: sshd_set_login_grace_time
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sshd_set_loglevel_verbose
+          requirement-id: sshd_set_loglevel_verbose
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sshd_set_max_auth_tries
+          requirement-id: sshd_set_max_auth_tries
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sshd_set_max_sessions
+          requirement-id: sshd_set_max_sessions
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sshd_set_maxstartups
+          requirement-id: sshd_set_maxstartups
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sudo_add_use_pty
+          requirement-id: sudo_add_use_pty
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sudo_custom_logfile
+          requirement-id: sudo_custom_logfile
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sudo_remove_no_authenticate
+          requirement-id: sudo_remove_no_authenticate
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sudo_require_reauthentication
+          requirement-id: sudo_require_reauthentication
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sysctl_fs_protected_hardlinks
+          requirement-id: sysctl_fs_protected_hardlinks
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sysctl_fs_protected_symlinks
+          requirement-id: sysctl_fs_protected_symlinks
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sysctl_fs_suid_dumpable
+          requirement-id: sysctl_fs_suid_dumpable
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sysctl_kernel_dmesg_restrict
+          requirement-id: sysctl_kernel_dmesg_restrict
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sysctl_kernel_kptr_restrict
+          requirement-id: sysctl_kernel_kptr_restrict
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sysctl_kernel_randomize_va_space
+          requirement-id: sysctl_kernel_randomize_va_space
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sysctl_kernel_yama_ptrace_scope
+          requirement-id: sysctl_kernel_yama_ptrace_scope
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sysctl_net_ipv4_conf_all_accept_redirects
+          requirement-id: sysctl_net_ipv4_conf_all_accept_redirects
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sysctl_net_ipv4_conf_all_accept_source_route
+          requirement-id: sysctl_net_ipv4_conf_all_accept_source_route
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sysctl_net_ipv4_conf_all_log_martians
+          requirement-id: sysctl_net_ipv4_conf_all_log_martians
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sysctl_net_ipv4_conf_all_rp_filter
+          requirement-id: sysctl_net_ipv4_conf_all_rp_filter
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sysctl_net_ipv4_conf_all_secure_redirects
+          requirement-id: sysctl_net_ipv4_conf_all_secure_redirects
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sysctl_net_ipv4_conf_all_send_redirects
+          requirement-id: sysctl_net_ipv4_conf_all_send_redirects
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sysctl_net_ipv4_conf_default_accept_redirects
+          requirement-id: sysctl_net_ipv4_conf_default_accept_redirects
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sysctl_net_ipv4_conf_default_accept_source_route
+          requirement-id: sysctl_net_ipv4_conf_default_accept_source_route
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sysctl_net_ipv4_conf_default_log_martians
+          requirement-id: sysctl_net_ipv4_conf_default_log_martians
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sysctl_net_ipv4_conf_default_rp_filter
+          requirement-id: sysctl_net_ipv4_conf_default_rp_filter
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sysctl_net_ipv4_conf_default_secure_redirects
+          requirement-id: sysctl_net_ipv4_conf_default_secure_redirects
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sysctl_net_ipv4_conf_default_send_redirects
+          requirement-id: sysctl_net_ipv4_conf_default_send_redirects
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sysctl_net_ipv4_icmp_echo_ignore_broadcasts
+          requirement-id: sysctl_net_ipv4_icmp_echo_ignore_broadcasts
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sysctl_net_ipv4_icmp_ignore_bogus_error_responses
+          requirement-id: sysctl_net_ipv4_icmp_ignore_bogus_error_responses
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sysctl_net_ipv4_ip_forward
+          requirement-id: sysctl_net_ipv4_ip_forward
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sysctl_net_ipv4_tcp_syncookies
+          requirement-id: sysctl_net_ipv4_tcp_syncookies
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sysctl_net_ipv6_conf_all_accept_ra
+          requirement-id: sysctl_net_ipv6_conf_all_accept_ra
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sysctl_net_ipv6_conf_all_accept_redirects
+          requirement-id: sysctl_net_ipv6_conf_all_accept_redirects
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sysctl_net_ipv6_conf_all_accept_source_route
+          requirement-id: sysctl_net_ipv6_conf_all_accept_source_route
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sysctl_net_ipv6_conf_all_forwarding
+          requirement-id: sysctl_net_ipv6_conf_all_forwarding
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sysctl_net_ipv6_conf_default_accept_ra
+          requirement-id: sysctl_net_ipv6_conf_default_accept_ra
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sysctl_net_ipv6_conf_default_accept_redirects
+          requirement-id: sysctl_net_ipv6_conf_default_accept_redirects
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: sysctl_net_ipv6_conf_default_accept_source_route
+          requirement-id: sysctl_net_ipv6_conf_default_accept_source_route
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated
+        - id: use_pam_wheel_group_for_su
+          requirement-id: use_pam_wheel_group_for_su
+          frequency: on-demand
+          evaluation-methods:
+              - id: openscap-automated
+                type: Gate
+                mode: Automated


### PR DESCRIPTION
## Summary

This PR adds a subset of layers for following initial Gemara Content:
- CIS Fedora L1 Workstation
- CIS Fedora L1 Server
- Finos Common Cloud Control

It also proposes a structured layout that organizes compliance artifacts by layer. This structure is designed to support CI-driven OCI artifact publishing (e.g., to Quay.io via `oras`) without hardcoding policy names or duplicating shared files.

### Repository Structure

```
guidance/     # Layer 1 - GuidanceCatalogs
catalogs/     # Layer 2 - ControlCatalogs
policies/     # Layer 3 - Policies
mappings/     # MappingDocuments (reference only, not bundled into OCI artifacts)
bundles/      # Declarative manifests defining which layers compose each OCI artifact
```

### Proposed Bundle Manifests

Each file in `bundles/` declares the layers that should be assembled into a single OCI artifact. For example:

```yaml
# bundles/cis-fedora-l1-server.yaml
layers:
  - guidance/cis-fedora-l1-server.yaml
  - catalogs/cis-fedora-l1-server.yaml
  - policies/cis-fedora-l1-server.yaml
```

This enables a CI workflow to dynamically iterate over `bundles/*.yaml`, read the layer list, and push each as an OCI artifact.