### PR TITLE
feat(ci): policy OCI publish to GHCR and Quay

### DIFF
--- a/.github/workflows/publish-policy-oci.yml
+++ b/.github/workflows/publish-policy-oci.yml
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+# Gemara policy OCI: GHCR staging (pack + attest) → sign/verify → Quay promote
+# (spec: specs/001-policy-oci-publish/…)
+#
+# Staging, sign, and Quay: workflow_call to sonupreetam/org-infra-tests (mirrors
+# complytime/org-infra; public until upstream ships the same files). Bump SHA in README (FR-006).
+# Quay default: test_complytime/…
+
+name: Publish policy OCI
+
+"on":
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Tag for GHCR and Quay (e.g. v0.1.0, sha-abc123de)"
+        required: true
+        type: string
+      allow_unprotected_ref:
+        description: >-
+          Set true if the default branch is not protected (e.g. fork) so
+          staging, sign, and attestation jobs run.
+        required: false
+        type: boolean
+        default: false
+      bundle_file:
+        description: "Root Gemara bundle YAML (relative to repo root)"
+        required: false
+        type: string
+        default: bundles/cis-fedora-l1-workstation.yaml
+      dest_image:
+        description: >-
+          Quay path (namespace/repository) without registry. Default is a POC namespace;
+          set continuouscompliance/complytime-policies for org production.
+        required: false
+        type: string
+        default: test_complytime/complytime-policies
+
+concurrency:
+  group: publish-policy-oci
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+
+jobs:
+  assert-quay:
+    name: Check Quay + image name
+    runs-on: ubuntu-latest
+    outputs:
+      repo_lc: ${{ steps.image.outputs.repo_lc }}
+    steps:
+      - name: Require QUAY_ROBOT_* for promote
+        env:
+          QUAY_USER: ${{ secrets.QUAY_ROBOT_USERNAME }}
+          QUAY_TOKEN: ${{ secrets.QUAY_ROBOT_TOKEN }}
+        run: |
+          if [ -z "${QUAY_USER}" ] || [ -z "${QUAY_TOKEN}" ]; then
+            echo '::error::Missing QUAY_ROBOT_USERNAME or QUAY_ROBOT_TOKEN.'
+            echo 'Add both: repo Settings, Secrets and variables, Actions.'
+            echo 'Forks do not inherit secrets from the upstream repository.'
+            exit 1
+          fi
+      - name: GHCR image name (lowercase)
+        id: image
+        run: |
+          r='${{ github.repository }}'
+          echo "repo_lc=${r,,}" >> "$GITHUB_OUTPUT"
+
+  publish-ghcr:
+    name: Staging to GHCR (Gemara)
+    needs: assert-quay
+    if: success() && (github.ref_protected || inputs.allow_unprotected_ref)
+    uses: sonupreetam/org-infra-tests/.github/workflows/reusable_publish_oras.yml@8ffcea997fc3026f62fc54c645974c51b42b7aa0
+    with:
+      publish_mode: gemara
+      image_name: ${{ needs.assert-quay.outputs.repo_lc }}
+      oci_tag: ${{ inputs.release_tag }}
+      bundle_file: ${{ inputs.bundle_file }}
+      allow_unprotected_ref: ${{ inputs.allow_unprotected_ref }}
+    secrets: inherit
+
+  sign-verify:
+    name: Keyless sign + verify attestations
+    needs: publish-ghcr
+    uses: sonupreetam/org-infra-tests/.github/workflows/reusable_sign_and_verify.yml@8ffcea997fc3026f62fc54c645974c51b42b7aa0
+    with:
+      image_name: ${{ needs.publish-ghcr.outputs.image }}
+      digest: ${{ needs.publish-ghcr.outputs.digest }}
+      allowed_identity_regex: ${{ format('https://github.com/{0}/.*', github.repository_owner) }}
+      verify_vuln: false
+      allow_unprotected_ref: ${{ inputs.allow_unprotected_ref }}
+    secrets: inherit
+
+  promote:
+    name: Promote to Quay
+    needs: [assert-quay, sign-verify]
+    permissions:
+      contents: read
+      packages: read
+    uses: sonupreetam/org-infra-tests/.github/workflows/resuable_publish_quay.yml@8ffcea997fc3026f62fc54c645974c51b42b7aa0
+    with:
+      source_registry: ghcr.io
+      source_image: ${{ needs.assert-quay.outputs.repo_lc }}
+      source_tag: ${{ inputs.release_tag }}
+      dest_registry: quay.io
+      dest_image: ${{ inputs.dest_image }}
+      dest_tag: ${{ inputs.release_tag }}
+      verify_signature: true
+      fail_if_dest_exists: true
+      include_sha_tags: true
+    secrets:
+      source_token: ${{ secrets.GITHUB_TOKEN }}
+      dest_username: ${{ secrets.QUAY_ROBOT_USERNAME }}
+      dest_password: ${{ secrets.QUAY_ROBOT_TOKEN }}

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,0 +1,3 @@
+{
+  "feature_directory": "specs/001-policy-oci-publish"
+}

--- a/scripts/verify-interim-demo.sh
+++ b/scripts/verify-interim-demo.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Local static checks: org-infra-tests (gemara + sign + quay) + test Quay default.
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+WF="${ROOT}/.github/workflows/publish-policy-oci.yml"
+# sonupreetam/org-infra-tests: all three workflow_call targets use this SHA in publish-policy-oci.
+ORG_INFRA_TESTS_PIN="8ffcea997fc3026f62fc54c645974c51b42b7aa0"
+# Composite is pinned inside org-infra-tests/reusable_publish_oras.yml; optional sibling check.
+INTERIM_ACTION="sonupreetam/gemara-publish-oci"
+INTERIM_ACTION_REF="7203d6158a16208a0338cc33ea001bb077f4705c"
+QUAY_TEST_DEST="test_complytime/complytime-policies"
+TESTS_REPO="${ROOT}/../org-infra-tests/.github/workflows/reusable_publish_oras.yml"
+
+if [[ ! -f "$WF" ]]; then
+  echo "error: missing $WF" >&2
+  exit 1
+fi
+
+python3 -c "import yaml; yaml.safe_load(open('${WF}'))"
+echo "ok: publish-policy-oci.yml parses as YAML"
+
+grep -qF "$ORG_INFRA_TESTS_PIN" "$WF" || {
+  echo "error: expected org-infra-tests ref ${ORG_INFRA_TESTS_PIN} in workflow" >&2
+  exit 1
+}
+echo "ok: workflow uses org-infra-tests @ ${ORG_INFRA_TESTS_PIN}"
+grep -qF "sonupreetam/org-infra-tests" "$WF" || {
+  echo "error: expected sonupreetam/org-infra-tests in workflow" >&2
+  exit 1
+}
+
+grep -qF "$QUAY_TEST_DEST" "$WF" || {
+  echo "error: expected default dest ${QUAY_TEST_DEST} in workflow" >&2
+  exit 1
+}
+echo "ok: default dest_image matches test Quay repo (${QUAY_TEST_DEST})"
+
+grep -qF "reusable_publish_oras.yml" "$WF" || {
+  echo "error: expected publish-ghcr to use reusable_publish_oras" >&2
+  exit 1
+}
+grep -qE "oci_tag:" "$WF" && grep -qE "bundle_file:" "$WF" || {
+  echo "error: expected publish-ghcr to pass oci_tag and bundle_file" >&2
+  exit 1
+}
+grep -qE "publish_mode:\s*gemara" "$WF" || {
+  echo "error: expected publish-ghcr to set publish_mode: gemara (reusable default is oras)" >&2
+  exit 1
+}
+echo "ok: staging uses org-infra-tests/reusable_publish_oras (publish_mode: gemara)"
+if [[ -f "$TESTS_REPO" ]]; then
+  grep -qF "${INTERIM_ACTION}@${INTERIM_ACTION_REF}" "$TESTS_REPO" || {
+    echo "error: expected ${INTERIM_ACTION}@${INTERIM_ACTION_REF} in $TESTS_REPO" >&2
+    exit 1
+  }
+  echo "ok: sibling org-infra-tests oras workflow pins ${INTERIM_ACTION} @ ${INTERIM_ACTION_REF}"
+else
+  echo "skip: place org-infra-tests next to this repo to verify gemara composite pin in reusable_publish_oras.yml"
+fi
+
+echo
+echo "Interim demo run (on GitHub):"
+echo "  1) Fork or repo: Actions → Publish policy OCI → Run workflow"
+echo "  2) release_tag: e.g. demo-0.0.1 (new tag; fail_if_dest_exists: true)"
+echo "  3) allow_unprotected_ref: true on a fork or unprotected default branch"
+echo "  4) dest_image: default (${QUAY_TEST_DEST}) for test Quay; robot must push there"
+echo "  5) Quay repo URL: quay.io/${QUAY_TEST_DEST}:\$release_tag"

--- a/specs/001-policy-oci-publish/checklists/requirements.md
+++ b/specs/001-policy-oci-publish/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Published policy OCI release pipeline
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-22  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs) — *Spec states outcomes: staging, signing, promotion, thin caller, no in-repo duplicate of upstream contract. Registry namespace named as product assumption.*
+- [x] Focused on user value and business needs — *Maintainers, operators, and consumers are explicit.*
+- [x] Written for non-technical stakeholders — *Plain-language stories; some terms (Gemara, OCI) are domain vocabulary for this repo; acceptable for ComplyTime audience.*
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details) — *SC-001/003 use pipeline success and E2E demo; SC-002 is documentation/task-time focused without naming tools.*
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded — *Out-of-repo SDK/org-infra ownership explicit.*
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation: all items pass for `/speckit.clarify` or `/speckit.plan` readiness. If the default branch is not `main` or the public registry path changes, update Assumptions and FR-002/FR-006 wording only (no [NEEDS CLARIFICATION] required for planning).
+- 2026-04-22: Spec updated with explicit “publishable content” scope and issue #5 / #7–#9 traceability in `spec.md` Assumptions (council spec review).
+- 2026-04-22: Spec updated to allow batched / explicit releases (per [PR #14](https://github.com/complytime/complytime-policies/pull/14) review: not a mandatory publish on every merge to publishable paths); FR-002, User Story 1, and SC-001 aligned.

--- a/specs/001-policy-oci-publish/spec.md
+++ b/specs/001-policy-oci-publish/spec.md
@@ -1,0 +1,110 @@
+# Feature Specification: Published policy OCI release pipeline
+
+**Feature Branch**: `001-policy-oci-publish`  
+**Created**: 2026-04-22  
+**Status**: Draft  
+**Input**: User description: "Publish Gemara policy bundles and governance content as OCI artifacts: automated, controlled release to the public registry (not required on every merge to publishable paths), organization staging registries, signing and attestation, promotion to the public ComplyTime registry. Repository provides source content and a thin release caller; artifact contract and transport are defined by the SDK and shared org automation. Document how consumers obtain and verify published policy artifacts. Aligns with GitHub issue 5 and sub-issues 7-9."
+
+## Clarifications
+
+### Session 2026-04-22
+
+- Q: What is the canonical **v1** intentional release trigger for the publish pipeline? → A: **`workflow_dispatch` only** for v1 (registry version/tag strings supplied via documented workflow inputs). Tag-push or other triggers may be added later with explicit precedence rules in publish documentation.
+- Q: For **v1**, what is the default **`verify_signature`** posture when calling org-infra’s promote reusable workflow? → A: **Default strict:** `workflow_call` SHALL use **`verify_signature: true`** (org workflow default). A **`verify_signature: false`** (or equivalent) bypass is allowed **only** with the same **org-documented agreement** called out under **Promotion and signing shape** (not as a silent operational default).
+- Q: For **v1**, how should **overlapping** **`workflow_dispatch`** runs be handled? → A: **GitHub Actions `concurrency`** at workflow scope (documented group key and **`cancel-in-progress`** policy in publish docs), **plus** registry immutability checks (for example **`fail_if_dest_exists`**) as applicable.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Maintainers get reliable, automatable releases of policy content (Priority: P1)
+
+ComplyTime maintainers land vetted changes to policy bundles and governance files on the default branch, often across multiple pull requests for one logical update. They need a **controlled release**—not a separate registry publication on every individual merge to publishable paths—so incomplete series of changes are not each promoted as if they were finished releases, while still being able to produce a consistent, signable, promoted release to the organization’s public registry when the work is ready.
+
+**Why this priority**: Without a predictable, automatable way to cut a release when content is complete, policy updates do not reach consumers in a coordinated way; conversely, publishing on every small merge fragments consumers’ version expectations and can ship partial updates.
+
+**Independent Test**: Can be fully tested by landing allowed changes to publishable content on the default branch, then triggering (or simulating) a **`workflow_dispatch`** release as defined in this spec (**v1**), and confirming that a publish run completes and the resulting release is available from the public registry (with appropriate credentials where required).
+
+**Acceptance Scenarios**:
+
+1. **Given** publishable content under `governance/` and any designated bundle paths (for example `bundles/`) and required registry access configured, **When** a maintainer runs the documented **`workflow_dispatch`** release for the current default branch state (**v1**), **Then** a release pipeline runs to completion and artifacts appear at the public ComplyTime registry for that repository’s scope, reflecting the **aggregate** of publishable content at that point in time.
+2. **Given** the same content layout, **When** a merge to the default branch only touches non-publishable files (for example documentation-only paths excluded from the publish matrix), **Then** the release trigger behavior matches the defined policy (for example no unplanned full publish; integration checks only as documented).
+3. **Given** multiple merges land on the default branch in sequence, **When** a single release is cut after those merges, **Then** the published outcome corresponds to one coherent release, not a mandatory publish per merge unless the project explicitly documents that model for a path class.
+
+---
+
+### User Story 2 - Operators can trust the supply chain for published policy (Priority: P2)
+
+Security and platform operators need published policy artifacts to follow the same staging, signing, and promotion practices as other ComplyTime releases so attestations and provenance are consistent.
+
+**Why this priority**: Reduces org risk and supports audits; secondary to “something is published at all” (P1).
+
+**Independent Test**: Can be tested by reviewing pipeline outputs and attestation material for a successful run and confirming the promotion path matches the organization’s standard (staging → **cosign verify** when enabled on promote → promotion to public registry), with **`verify_signature: true`** on the org **`workflow_call`** unless a documented org exception applies (**v1**).
+
+**Acceptance Scenarios**:
+
+1. **Given** a successful release run, **When** an operator reviews the run’s outputs, **Then** signing/verification steps (including **`verify_signature: true`** behavior on the org promote **`workflow_call`** unless a documented exception applies) and promotion to the public registry are present and follow the standard organization pattern for similar artifacts.
+2. **Given** optional vulnerability-related checks the organization allows for this artifact class, **When** those checks are enabled, **Then** failed checks block promotion according to the agreed policy.
+
+---
+
+### User Story 3 - Consumers can discover, fetch, and verify published policy (Priority: P3)
+
+Engineers and automation that consume ComplyTime policies need clear instructions: where releases live, how to reference a version, and how to confirm integrity without reading internal pipeline code.
+
+**Why this priority**: Consumer documentation closes the loop after publication exists; it can follow initial pipeline delivery if necessary.
+
+**Independent Test**: A new user can follow only repository documentation to fetch and verify a published policy artifact for a known release.
+
+**Acceptance Scenarios**:
+
+1. **Given** a released version exists in the public registry, **When** a reader follows the documented steps, **Then** they can retrieve that version and perform the documented integrity checks.
+2. **Given** the documentation references examples, **When** a release is finalized, **Then** examples use real registry locations and version references that match the implemented pipeline (or are explicitly labeled as placeholders until a stable release pin exists).
+
+### Edge Cases
+
+- **Upstream contract in flux**: The canonical artifact layout and transport semantics are defined outside this repository; if they change during implementation, the caller automation must remain aligned with the agreed contract and must not define a second, competing layout in-repo.
+- **Registry or secret misconfiguration**: Failed authentication or mis-set promotion targets should fail the pipeline with a clear, actionable error without writing partial state to the public registry.
+- **Back-to-back merges before a release**: Multiple consecutive merges to the default branch may accumulate; the release process MUST define when a new published version is created (for example one per explicit **`workflow_dispatch`**). **Overlapping dispatches** for **v1** MUST be controlled with workflow-level **`concurrency`** (see **FR-002** and **Clarifications**) and documented **`cancel-in-progress`** behavior; registry-level immutability (for example **`fail_if_dest_exists`** on promote) remains complementary.
+- **No credentials / dry environments**: Documentation or process notes for forks or local validation should not require embedding secrets; credential setup is tracked as a separate operational task.
+- **Interim upstream locations**: A pipeline may pin a pre-migration **GitHub Action** (for example a fork or personal repo hosting the OCI **pack/push** step before **gemaraproj** owns the equivalent action) for **end-to-end demonstration** and **SC-003** only while the implementation is labeled **interim** per **FR-006**; the long-term home is still **gemaraproj**-released **go-gemara** and an **org-agreed** action ref, with a **tracked migration** off interim pins.
+- **Promotion and signing shape**: The organization’s standard promote workflow (for example container-oriented **crane**/**cosign** flows) may assume a particular registry reference, signature, and tag model; the pack/push step MUST produce a **reference and attestations** that the chosen reusable workflow can consume, or the spec documents a **deliberate** exception (for example **`verify_signature: false`** only when agreed with **org-infra** and recorded in publish docs with scope and sunset). **v1** default remains **`verify_signature: true`** per **FR-004** and **Clarifications**.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The project MUST keep Gemara-governed content under `governance/` (including `governance/catalogs/` and `governance/policies/`) and any additional bundle root paths the maintainers document (for example `bundles/`) consistent with the repository constitution and schema validation in force at merge time.
+- **FR-002**: For **v1**, a **release** SHALL mean a deliberate **`workflow_dispatch`** invocation of the repository’s publish workflow, with version or tag strings supplied via inputs documented in the publish matrix. Such a release whose scope includes the default branch state and publishable content MUST start a release pipeline whose successful outcome is published policy artifacts in the public ComplyTime namespace agreed for this repository, unless the publishable path set is empty by policy. The spec does **not** require a full public-registry publish on every merge to `governance/` or bundles. Additional non–`workflow_dispatch` triggers (for example semver tag push) MAY be introduced only when publish documentation defines **precedence** relative to **`workflow_dispatch`** so acceptance criteria stay unambiguous. For **v1**, the publish workflow MUST declare **`concurrency`** at workflow scope so overlapping **`workflow_dispatch`** runs are serialized or cancelled per policy; the publish matrix documentation MUST record the **concurrency group key** and the chosen **`cancel-in-progress`** (`true` or `false`) rationale.
+- **FR-003**: The repository MUST provide a “caller”-style integration that delegates layout, transport, signing, and promotion to the language SDK and shared organization automation, without redefining the OCI media types, layer structure, or manifest contract in a second, divergent way.
+- **FR-004**: The release process MUST use the organization’s standard staging, signing, attestation, and promotion flow for this artifact class, including a **staging** registry before the public ComplyTime **Quay** namespace. Promotion from staging to public MUST delegate to **shared organization automation** where the org provides it — for example `workflow_call` to [`complytime/org-infra`’s reusable `resuable_publish_quay.yml`](https://github.com/complytime/org-infra/blob/main/.github/workflows/resuable_publish_quay.yml) (or a successor path with the same role) — so this repository does **not** reimplement cross-registry promotion, signature verification, or attestation copy logic that the org has already standardized. For **v1**, the promote **`workflow_call`** MUST pass **`verify_signature: true`** unless the **Promotion and signing shape** edge case applies with an **explicit org-infra agreement** recorded in publish documentation (no silent default-off verify for production).
+- **FR-005**: Repository documentation MUST describe how external consumers find releases, how they reference a version, and how they verify what they pulled, in terms appropriate for the primary ComplyTime CLI or documented tooling where applicable.
+- **FR-006**: The implementation MUST document, in the publish or release matrix documentation, **(a)** the **GitHub Action** reference (commit SHA, semver tag, or branch) used for **OCI pack and push to staging**, **(b)** whether that reference is **interim** (for example a pin to [sonupreetam/gemara-publish-oci](https://github.com/sonupreetam/gemara-publish-oci) on branch [`001-gemara-bundle-publish-action`](https://github.com/sonupreetam/gemara-publish-oci/tree/001-gemara-bundle-publish-action) before an org-owned action exists) or **post-migration**, and **(c)** the **exit criteria** to move to a **gemaraproj**-published **go-gemara** release that includes the bundle contract and to an **org-agreed** action under **gemaraproj** or **complytime** (or equivalent), at which time **interim** pins are retired. This repository does not encode **go-gemara** `require`/`replace` for the action; the **SDK pin** remains inside the action’s `go.mod` as that upstream’s responsibility.
+- **FR-007**: Operational access for publishing (robot accounts, token scopes) MUST be configured outside the git tree; the specification of required secret *names* and *scopes* MAY be documented without storing secret values in the repository.
+- **FR-008**: If optional vulnerability or policy checks are used for this pipeline, their enable/disable behavior MUST match the organization’s reusable workflow contract (for example optional verify steps) and MUST NOT silently skip agreed blocking checks in production.
+
+### Key Entities
+
+- **Policy bundle**: A versioned set of related Gemara policy or catalog files living under a documented path (for example a directory under `bundles/`) that is included in the publish matrix.
+- **Governance artifact**: Catalogs and policies under `governance/` that are subject to the same quality bar and may be part of a published OCI object as defined by the single upstream contract.
+- **Published release**: A named or digest-addressable set of OCI objects in the public ComplyTime registry that corresponds to a given **release** event (and thus to the default-branch snapshot at that time), which may include the aggregate of several merges, consumable by downstream clients.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For every **intentional release** (**v1**: **`workflow_dispatch`** per **FR-002**) whose content is in scope for publication, the release pipeline either completes with a success status and leaves retrievable artifacts in the public ComplyTime registry, or fails with a visible, attributable failure (no silent partial publish).
+- **SC-002**: A reader who is new to this repository can, using only the usage documentation in this repository, complete one successful fetch and verification of a published release that the maintainers have labeled as “current” or by explicit version, within 30 minutes under normal network conditions.
+- **SC-003**: At least one end-to-end demonstration runs in a representative environment (as defined with maintainers) showing default-branch content at release time → published artifact in **staging** (and, when applicable, **promoted** per **FR-004**) → consumer verification before the feature is marked done for the planning epic. A demonstration using **interim** action pins and pre-release **go-gemara** bundle APIs (as bundled inside that action) satisfies this criterion if labeled per **FR-006**.
+- **SC-004**: Publish and release documentation explicitly states **interim** vs **post-migration** upstream **action** and **go-gemara** alignment, and the **tracked migration** path to a **gemaraproj** SDK release and **org-owned** action, per **FR-006**.
+
+## Assumptions
+
+- The default branch is `main` unless the repository renames it; automation triggers are described against “default branch” to stay naming-neutral.
+- The public registry scope for this project remains `quay.io/continuouscompliance/complytime-policies` (or a successor name documented in the same issue/epic) unless leadership changes the product scope.
+- The language SDK and organization automation deliver the pack/unpack/transport and reusable workflows needed for this repository; this feature does not block on re-implementing those in-tree.
+- Registry credentials and GitHub/Quay configuration are set up in parallel and may complete before or after the caller workflow, but a full end-to-end publish requires them.
+- “Thin caller” is acceptable: this repository lists what to publish (matrix of bundles) and which secrets to use, not a duplicate OCI format specification.
+- **Upstream OCI pack/push (interim)**: A working pipeline before **gemaraproj** publishes a **go-gemara** semver that includes the **bundle** APIs may use a **pinned** composite action such as [sonupreetam/gemara-publish-oci@`001-gemara-bundle-publish-action`](https://github.com/sonupreetam/gemara-publish-oci/tree/001-gemara-bundle-publish-action) (ideally a **commit SHA** for reproducibility). That action runs **`tools/publish`** with the **SDK** and any `require` / `replace` in its own [`go.mod`](https://github.com/sonupreetam/gemara-publish-oci/tree/001-gemara-bundle-publish-action) — in line with [go-gemara](https://github.com/gemaraproj/go-gemara) bundle work (for example [PR #62](https://github.com/gemaraproj/go-gemara/pull/62)) until released. **This repository** chooses only the **action** ref and the usual `with:` inputs (registry, file, tag, and so on); it does not override the **Go** module version for **go-gemara** in workflow inputs.
+- **Target state (migration)**: The desired steady state is a **gemaraproj**-released **go-gemara** with bundle support and an **org-agreed** publish action (for example under **gemaraproj** or **complytime**). The caller workflow in this repository MUST be **updated** to that action and tag strategy, and **interim** `uses:` pins MUST be **removed** as an explicit **migration** task in the same epic (or a linked follow-up) once upstream artifacts exist.
+- **Promotion to the public ComplyTime registry on Quay**: The path from a **staging** host (commonly `ghcr.io` for a package published by GitHub Actions) to `quay.io/continuouscompliance/…` reuses the organization’s **reusable** workflow in **complytime/org-infra** — for example [`.github/workflows/resuable_publish_quay.yml`](https://github.com/complytime/org-infra/blob/main/.github/workflows/resuable_publish_quay.yml) — with the **inputs** and **secrets** that workflow defines, rather than a bespoke copy script in this repository.
+- **Publishable content (for FR-002)**: the paths under `governance/` (including `governance/catalogs/` and `governance/policies/`) and, when the repository includes them, `bundles/` and any other roots the publish matrix documentation lists. These paths define *what* goes into a release when a release is cut; they do not by themselves mandate a new public release on every merge. Merges that touch only out-of-scope paths (for example meta-only documentation not in the matrix) are outside the published artifact; maintainers may extend the path set in the same documentation as the matrix. For **v1**, the **canonical** intentional release trigger is **`workflow_dispatch`** only (see **FR-002** and **Clarifications**). Future triggers (tag push, schedule, or per-merge policy for a subset) require the same publish documentation to record precedence and governance, consistent with User Story 1.
+- **Traceability:** This feature specification supports [complytime-policies#5](https://github.com/complytime/complytime-policies/issues/5) **Step 2** and related work ([#7](https://github.com/complytime/complytime-policies/issues/7)–[#9](https://github.com/complytime/complytime-policies/issues/9)). Upstream **SDK** and **org-infra** work is out of this repository’s implementation scope but is assumed available per the epic.


### PR DESCRIPTION
## Summary

Proposes the policy OCI publish pipeline (GHCR staging, keyless sign/verify, Quay promote) and related CI/docs, aligned with the spec work in-repo.

**Head branch:** `sonupreetam:001-policy-oci-publish` (commit `2ba15e8`).

**Verification:** [Publish policy OCI workflow](https://github.com/sonupreetam/complytime-policies/actions) run succeeded on the fork (e.g. commit `2ba15e8`).

## What changed
- `publish-policy-oci` and related org-infra reusable integration (org-infra-tests pin, Gemara mode, sign + promote)
- operator checklist and 001 spec docs where applicable

## Checklist
- [ ] Upstream maintainers: confirm org secrets and Quay targets for the upstream org (fork used test/demo registries for validation).

Replaces #16 (same diff; head branch renamed for fork workflow).

Made with [Cursor](https://cursor.com)