### PR TITLE
feat: adds complytime-content directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,30 @@ Centralized repository for Gemara policies used by [ComplyTime](https://github.c
 
 ## Overview
 
-This repository contains governance artifacts used to define and enforce security controls across supported platforms (GitHub, GitLab, etc.). The governance content follows the [Gemara](https://github.com/gemaraproj/gemara) framework and is organized into catalogs and policies.
+This repository contains governance artifacts used to define and enforce security controls across supported platforms (GitHub, GitLab, etc.). The governance content follows the [Gemara](https://github.com/gemaraproj/gemara) framework and is organized into catalogs, guidance, and policies.
 
 ## Repository Structure
 
 ```
-complytime-policies/
-├── governance/
-│   ├── catalogs/    # Security control catalogs and definitions
-│   └── policies/    # Implementation policies and technical controls
+complytime-policies
+├── AGENTS.md
+├── bundles # Declarative manifests defining which layers compose each OCI artifact
+├── complytime-content  # Mapping documents expressing relationships to external frameworks
+├── governance
+│   ├── catalogs    # Security control catalogs and definitions
+│   ├── guidance    # Guidance catalogs documenting best practices and standards
+│   └── policies    # Implementation policies and technical controls
 ├── LICENSE
 └── README.md
 ```
 
 ## Governance Content
+
+### Guidance
+
+Guidance catalogs are a structured set of guidelines — recommendations, requirements, or best practices — that help readers achieve desired outcomes. Guidelines are grouped into groups. 
+
+- [CIS Fedora Linux Level 1 Benchmark Guidance](governance/guidance/cis-fedora-l1-guidance.yaml)
 
 ### Catalogs
 

--- a/complytime-content/README.md
+++ b/complytime-content/README.md
@@ -1,0 +1,1 @@
+# ComplyTime Content


### PR DESCRIPTION
## Description

This PR adds the `complytime-content/` directory. The `README.md` is updated to reflect the current structure of the governance content. The `complytime-content/` directory is for the current effort to produce Gemara content and will store Mapping Documents and Catalogs.

We could add more directories once the plan is organized.

## Related Issues

- N/A

## Review Hints

- [ ] Ensure the directory is present. The `complytime-content/README.md` is a placeholder. 