### PR TITLE
docs: add complytime.yaml configuration reference to usage.md

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -41,11 +41,11 @@ repository per bundle.
 
 ### Published bundles
 
-| Bundle | Quay repository |
-|--------|-----------------|
-| `ampel-branch-protection` | `quay.io/complytime/policies-ampel-branch-protection` |
-| `cis-fedora-l1-workstation` | `quay.io/complytime/policies-cis-fedora-l1-workstation` |
-| `cis-fedora-l1-server` | `quay.io/complytime/policies-cis-fedora-l1-server` |
+| Bundle | Quay repository | Provider |
+|--------|-----------------|----------|
+| `ampel-branch-protection` | `quay.io/complytime/policies-ampel-branch-protection` | [ampel](https://github.com/complytime/complytime-providers/tree/main/cmd/ampel-provider) |
+| `cis-fedora-l1-workstation` | `quay.io/complytime/policies-cis-fedora-l1-workstation` | [openscap](https://github.com/complytime/complytime-providers/tree/main/cmd/openscap-provider) |
+| `cis-fedora-l1-server` | `quay.io/complytime/policies-cis-fedora-l1-server` | [openscap](https://github.com/complytime/complytime-providers/tree/main/cmd/openscap-provider) |
 
 ## Tags
 
@@ -84,6 +84,11 @@ This returns the `sha256:…` digest, which you can use for immutable references
 oras pull quay.io/complytime/policies-cis-fedora-l1-workstation@sha256:<digest> -o ./output
 ```
 
+> **Note:** ORAS, cosign, and curl use standard OCI reference syntax
+> (`:tag` and `@sha256:digest`). `complyctl` uses its own `@tag` convention
+> in `complytime.yaml` — see the [Using with complyctl](#using-with-complyctl)
+> section below.
+
 ## Verifying the Cosign signature
 
 All artifacts are signed with [keyless Cosign](https://docs.sigstore.dev/cosign/signing/overview/)
@@ -103,10 +108,10 @@ tampered with since signing.
 > **Tip:** Replace `:latest` with a `@sha256:<digest>` reference for the
 > strongest verification guarantee.
 
-## Verifying via registry API
+## Verifying the artifact
 
-Quay's package UI may appear sparse for custom OCI media types. The API
-and CLI checks below are authoritative.
+Quay's package UI may appear sparse for custom OCI media types. The ORAS
+CLI checks below are authoritative.
 
 ### Fetch the manifest
 
@@ -127,34 +132,50 @@ oras manifest fetch quay.io/complytime/policies-cis-fedora-l1-workstation:latest
     done
 ```
 
-If the API checks pass but the Quay UI still looks sparse, treat the artifact
+If these checks pass but the Quay UI still looks sparse, treat the artifact
 as valid.
 
 ## Using with complyctl
 
 [complyctl](https://github.com/complytime/complyctl) can consume Gemara
-bundles directly from the OCI registry. Point the policy source at the
-published artifact:
+bundles directly from the OCI registry. Point the policy source at a
+published bundle in `complytime.yaml`:
 
 ```yaml
 # complytime.yaml
 policies:
-  - url: quay.io/complytime/policies-cis-fedora-l1-workstation@latest
-    id: cis-fedora-l1
+  - url: quay.io/complytime/policies-ampel-branch-protection@latest
+    id: ampel-bp
 ```
 
-Then run:
+Then fetch and scan:
 
 ```bash
 complyctl get
+complyctl scan --policy-id ampel-bp
 ```
 
-`complyctl` resolves the OCI reference, pulls the bundle layers via the Go
-ORAS library, and makes the policy, catalog, and guidance available for
-scanning.
+See the
+[complyctl Quick Start](https://github.com/complytime/complyctl/blob/main/docs/QUICK_START.md)
+for installation, full `complytime.yaml` reference, and output formats.
+
+### Bundle providers
+
+Each provider has its own prerequisites, `complytime.yaml` variables, and
+setup instructions:
+
+| Bundle | Provider | What it evaluates |
+|--------|----------|-------------------|
+| `ampel-branch-protection` | [ampel](https://github.com/complytime/complytime-providers/tree/main/cmd/ampel-provider) | GitHub / GitLab branch protection rules |
+| `cis-fedora-l1-workstation` | [openscap](https://github.com/complytime/complytime-providers/tree/main/cmd/openscap-provider) | CIS Fedora L1 Workstation benchmark |
+| `cis-fedora-l1-server` | [openscap](https://github.com/complytime/complytime-providers/tree/main/cmd/openscap-provider) | CIS Fedora L1 Server benchmark |
 
 ## Further reading
 
+- [complyctl Quick Start](https://github.com/complytime/complyctl/blob/main/docs/QUICK_START.md) — installation, `complytime.yaml` reference, output formats
+- [ampel provider docs](https://github.com/complytime/complytime-providers/blob/main/cmd/ampel-provider/docs/configuration.md) — variables, token auth, granular policies
+- [openscap provider docs](https://github.com/complytime/complytime-providers/blob/main/cmd/openscap-provider/docs/configuration.md) — variables, profiles, prerequisites
+- [complytime-demos](https://github.com/complytime/complytime-demos) — automated VM setup with sample policies
 - [Quickstart for maintainers](../specs/001-policy-oci-publish/quickstart.md) — how to run the publish workflow
 - [Pipeline contract](../specs/001-policy-oci-publish/contracts/publish-pipeline.md) — action inputs, secrets, and outputs
 - [gemara-registry-cli](https://github.com/gemaraproj/gemara-registry-cli) — the composite action that produces the artifact


### PR DESCRIPTION
## Summary

- Adds a Provider column to the published bundles table with links to provider configuration docs
- Adds a "Bundle providers" table mapping bundles to providers and what they evaluate
- Expands "Using with complyctl" section with `complytime.yaml` example and scan commands
- Adds a note clarifying OCI reference syntax difference between ORAS/cosign (`:tag`) and complyctl (`@tag`)
- Adds "Further reading" links to complyctl Quick Start, provider docs, and complytime-demos
- Updates verification section heading and description to use ORAS CLI terminology

Rebased on main after [#36](https://github.com/complytime/complytime-policies/pull/36) merge. All references use the per-bundle naming convention.

## Merge order

| Order | Repo | PR | Purpose | Depends on |
|-------|------|----|---------|------------|
| 1 | org-infra | [#277](https://github.com/complytime/org-infra/pull/277) | Fix reusable compliance workflow + Quay direct fetch | — |
| 2 | complytime-providers | [#22](https://github.com/complytime/complytime-providers/pull/22) | OpenSCAP configuration docs | — |
| 3 | complyctl | [#525](https://github.com/complytime/complyctl/pull/525) | Update policy URLs in QUICK_START + complytime.yaml | #277 merged (for CI) |
| **4** | **complytime-policies** | **#33 (this)** | **Usage docs with provider table + further reading** | #22 merged (for doc links to resolve) |

## Test plan

- [ ] Verify all markdown renders correctly on GitHub
- [ ] Verify all cross-reference links resolve (complyctl, complytime-providers, complytime-demos)
- [ ] Provider doc links work after complytime-providers#22 merges

Relates to - https://github.com/complytime/complytime-policies/issues/5
Closes https://github.com/complytime/complytime-policies/issues/9