### PR TITLE
fix(ci): address PR #34 review feedback

### DIFF
--- a/.github/workflows/publish-policy-oci.yml
+++ b/.github/workflows/publish-policy-oci.yml
@@ -153,7 +153,6 @@ jobs:
       - name: Publish bundle, sign, verify, and promote
         id: publish
         if: steps.gate.outputs.proceed == 'true'
-        # yamllint disable-line rule:line-length
         uses: gemaraproj/gemara-registry-cli@f4f1cc6f03dbe9d8d80005eae1335b8f85f8bae7  # v0.1.0
         with:
           registry: ghcr.io
@@ -188,7 +187,6 @@ jobs:
 
       - name: Install ORAS
         if: steps.gate.outputs.proceed == 'true'
-        # yamllint disable-line rule:line-length
         uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3  # v2.0.0
 
       - name: Verify destination manifest and layer retrievability
@@ -233,6 +231,9 @@ jobs:
             echo "::warning::Destination manifest has zero layers."
           fi
 
+          printf '%s' "${manifest_json}" | jq -r \
+            '.layers[] | "layer: mediaType=\(.mediaType) digest=\(.digest) size=\(.size)"'
+
           verify_dir="$(mktemp -d)"
           oras pull "${digest_ref}" -o "${verify_dir}"
           echo "pulled_files:"
@@ -250,6 +251,8 @@ jobs:
             fi
             echo "- layer_count: \`${layer_count}\`"
           } >> "${GITHUB_STEP_SUMMARY}"
+
+          oras logout "${QUAY_REGISTRY}"
 
       - name: Write last published content hash for next run
         if: success() && steps.gate.outputs.proceed == 'true' && steps.publish.conclusion == 'success'


### PR DESCRIPTION
## Summary

Follow-up to #34 addressing review feedback from @marcusburghardt.

### Changes

| Comment | Severity | Change |
|---------|----------|--------|
| [Reduced per-layer observability](https://github.com/complytime/complytime-policies/pull/34#discussion_r3267441544) | MEDIUM | Add per-layer OCI metadata logging (`mediaType`, `digest`, `size`) by parsing `manifest_json` with `jq` before `oras pull` |
| [Redundant yamllint disable](https://github.com/complytime/complytime-policies/pull/34#discussion_r3267441554) | LOW | Remove two redundant `# yamllint disable-line rule:line-length` comments superseded by the file-level disable on line 3 |
| [No oras logout after login](https://github.com/complytime/complytime-policies/pull/34#discussion_r3267441559) | LOW | Add `oras logout` after verification block for defense-in-depth credential hygiene |

### Testing

- [ ] Fork `workflow_dispatch` with all 3 bundles — verify per-layer metadata appears in logs
- [ ] Confirm `oras logout` does not cause step failure

Refs: #34