### PR TITLE
refactor(ci): one Quay repository per policy bundle

### DIFF
--- a/.github/workflows/publish-policy-oci.yml
+++ b/.github/workflows/publish-policy-oci.yml
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 # yamllint disable rule:line-length
-# Publishes each bundle in bundles/ as a tagged artifact in a single OCI repository.
-# Tags use the bundle name directly (e.g., ampel-branch-protection, cis-fedora-l1-workstation).
+# Publishes each bundle in bundles/ to its own OCI repository under the destination
+# namespace (e.g., quay.io/complytime/ampel-branch-protection:latest).
+# See docs/adr/0001-one-quay-repo-per-bundle.md for rationale.
 
 name: Publish policy OCI
 
@@ -14,11 +15,17 @@ name: Publish policy OCI
       - 'governance/**'
   workflow_dispatch:
     inputs:
-      dest_image:
-        description: "Quay path (namespace/repository) without registry host."
+      dest_namespace:
+        description: "Quay namespace prefix (each bundle gets its own repo under this namespace)."
         required: false
         type: string
-        default: complytime/complytime-policies
+        default: complytime
+      version:
+        description: >-
+          Semver tag to apply (e.g., v1.0.0). Immutable: fails if the tag already exists.
+          When omitted, only :latest is published.
+        required: false
+        type: string
       trust_mode:
         description: "Destination trust mode: resign (re-sign on Quay), copy-only, or copy-referrers"
         required: false
@@ -142,13 +149,13 @@ jobs:
         if: steps.gate.outputs.proceed == 'true'
         env:
           BUNDLE_NAME: ${{ matrix.bundle.name }}
-          DEST_IMAGE: ${{ inputs.dest_image || 'complytime/complytime-policies' }}
+          DEST_NS: ${{ inputs.dest_namespace || 'complytime' }}
         run: |
           set -euo pipefail
           r='${{ github.repository }}'
-          echo "ghcr_repo=${r,,}" >> "$GITHUB_OUTPUT"
-          echo "dest_repo=${DEST_IMAGE}" >> "$GITHUB_OUTPUT"
-          echo "bundle_tag=${BUNDLE_NAME}" >> "$GITHUB_OUTPUT"
+          echo "ghcr_repo=${r,,}/${BUNDLE_NAME}" >> "$GITHUB_OUTPUT"
+          echo "dest_repo=${DEST_NS}/${BUNDLE_NAME}" >> "$GITHUB_OUTPUT"
+          echo "bundle_tag=latest" >> "$GITHUB_OUTPUT"
 
       - name: Publish bundle, sign, verify, and promote
         id: publish
@@ -253,6 +260,56 @@ jobs:
           } >> "${GITHUB_STEP_SUMMARY}"
 
           oras logout "${QUAY_REGISTRY}"
+
+      - name: Apply semver tag
+        if: >-
+          steps.gate.outputs.proceed == 'true'
+          && inputs.version != ''
+        env:
+          QUAY_REGISTRY: quay.io
+          QUAY_USER: ${{ secrets.QUAY_ROBOT_USERNAME }}
+          QUAY_TOKEN: ${{ secrets.QUAY_ROBOT_TOKEN }}
+          GHCR_REGISTRY: ghcr.io
+          VERSION: ${{ inputs.version }}
+          DEST_REPO: ${{ steps.repos.outputs.dest_repo }}
+          GHCR_REPO: ${{ steps.repos.outputs.ghcr_repo }}
+          DEST_REF: ${{ steps.publish.outputs.destination_ref }}
+          SOURCE_REF: ${{ steps.publish.outputs.source_ref }}
+          BUNDLE_NAME: ${{ matrix.bundle.name }}
+        run: |
+          set -euo pipefail
+
+          # Validate semver format
+          if [[ ! "${VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Version '${VERSION}' is not valid semver (expected vX.Y.Z)."
+            exit 1
+          fi
+
+          # Check tag does not already exist on destination (immutable)
+          echo "${QUAY_TOKEN}" | oras login "${QUAY_REGISTRY}" -u "${QUAY_USER}" --password-stdin
+          dest_base="${QUAY_REGISTRY}/${DEST_REPO}"
+          if oras resolve "${dest_base}:${VERSION}" >/dev/null 2>&1; then
+            echo "::error::Tag ${VERSION} already exists on ${dest_base}. Semver tags are immutable."
+            exit 1
+          fi
+
+          # Tag destination
+          oras tag "${DEST_REF}" "${VERSION}"
+          echo "tagged_destination=${dest_base}:${VERSION}"
+
+          # Tag source (GHCR)
+          oras tag "${SOURCE_REF}" "${VERSION}"
+          echo "tagged_source=${GHCR_REGISTRY}/${GHCR_REPO}:${VERSION}"
+
+          oras logout "${QUAY_REGISTRY}"
+
+          {
+            echo "### ${BUNDLE_NAME} — Semver Tag"
+            echo
+            echo "- version: \`${VERSION}\`"
+            echo "- destination: \`${dest_base}:${VERSION}\`"
+            echo "- source: \`${GHCR_REGISTRY}/${GHCR_REPO}:${VERSION}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Write last published content hash for next run
         if: success() && steps.gate.outputs.proceed == 'true' && steps.publish.conclusion == 'success'

--- a/.github/workflows/publish-policy-oci.yml
+++ b/.github/workflows/publish-policy-oci.yml
@@ -153,8 +153,9 @@ jobs:
         run: |
           set -euo pipefail
           r='${{ github.repository }}'
-          echo "ghcr_repo=${r,,}/${BUNDLE_NAME}" >> "$GITHUB_OUTPUT"
-          echo "dest_repo=${DEST_NS}/${BUNDLE_NAME}" >> "$GITHUB_OUTPUT"
+          repo_name="policies-${BUNDLE_NAME}"
+          echo "ghcr_repo=${r,,}/${repo_name}" >> "$GITHUB_OUTPUT"
+          echo "dest_repo=${DEST_NS}/${repo_name}" >> "$GITHUB_OUTPUT"
           echo "bundle_tag=latest" >> "$GITHUB_OUTPUT"
 
       - name: Publish bundle, sign, verify, and promote

--- a/README.md
+++ b/README.md
@@ -49,14 +49,14 @@ See **[docs/usage.md](docs/usage.md)** for full consumer documentation: how to p
 Quick start:
 
 ```bash
-# Pull a bundle (each bundle has its own Quay repo)
-oras pull quay.io/complytime/cis-fedora-l1-workstation:latest -o ./output
+# Pull a bundle (each bundle has its own Quay repo, prefixed with "policies-")
+oras pull quay.io/complytime/policies-cis-fedora-l1-workstation:latest -o ./output
 
 # Verify the signature
 cosign verify \
   --certificate-identity-regexp="https://github.com/complytime/complytime-policies/.github/workflows/" \
   --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
-  quay.io/complytime/cis-fedora-l1-workstation:latest
+  quay.io/complytime/policies-cis-fedora-l1-workstation:latest
 
 # Or use complyctl directly
 complyctl get

--- a/README.md
+++ b/README.md
@@ -49,14 +49,14 @@ See **[docs/usage.md](docs/usage.md)** for full consumer documentation: how to p
 Quick start:
 
 ```bash
-# Pull the artifact
-oras pull quay.io/complytime/complytime-policies:<tag> -o ./output
+# Pull a bundle (each bundle has its own Quay repo)
+oras pull quay.io/complytime/cis-fedora-l1-workstation:latest -o ./output
 
 # Verify the signature
 cosign verify \
   --certificate-identity-regexp="https://github.com/complytime/complytime-policies/.github/workflows/" \
   --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
-  quay.io/complytime/complytime-policies:<tag>
+  quay.io/complytime/cis-fedora-l1-workstation:latest
 
 # Or use complyctl directly
 complyctl get

--- a/docs/adr/0001-one-quay-repo-per-bundle.md
+++ b/docs/adr/0001-one-quay-repo-per-bundle.md
@@ -1,0 +1,104 @@
+# ADR-0001: One Quay Repository Per Policy Bundle
+
+- **Status:** Accepted
+- **Date:** 2026-05-20
+- **Deciders:** gvauter, jpower432, sonupreetam
+- **PR Context:** [complytime-policies#33](https://github.com/complytime/complytime-policies/pull/33)
+
+## Context
+
+The initial CI implementation published all Gemara policy bundles to a
+single OCI repository (`quay.io/complytime/complytime-policies`) using
+the bundle name as the tag (e.g., `:ampel-branch-protection`,
+`:cis-fedora-l1-workstation`). This overloads the tag field as both
+an artifact selector and a version identifier, preventing standard
+version tagging per bundle.
+
+Three alternatives were evaluated:
+
+1. **Single repo, bundle-name tags (status quo)** — no version history.
+2. **Single repo, compound tags** (e.g., `ampel-branch-protection-v1.0.0`)
+   — enables versioning but is non-standard and breaks tooling assumptions.
+3. **One Quay repo per bundle** — each bundle gets its own repository with
+   standard version tags.
+
+## Decision
+
+Adopt **one Quay repository per policy bundle** under the `complytime`
+namespace. Each bundle published from `bundles/*.yaml` will be pushed to
+its own repository (e.g., `quay.io/complytime/ampel-branch-protection`)
+with standard version tags (`latest`, semver).
+
+## Rationale
+
+- **Standard OCI semantics.** Tags mean "version" — consistent with Helm,
+  Tekton, Wolfi, and other OCI-native ecosystems.
+- **Independent release cadence.** Each bundle can version independently
+  without coordinating across unrelated policies.
+- **Tooling compatibility.** Cosign, Renovate, Dependabot, and ORAS all
+  assume `tag = version of one artifact`.
+- **Cleaner Quay UI.** Each repo shows version history for exactly one
+  bundle.
+- **Per-bundle access control.** Quay permissions can be scoped per
+  repository if needed in the future.
+- **Consumer clarity.** `complytime.yaml` references become self-describing:
+  `url: quay.io/complytime/ampel-branch-protection@v1.0.0`.
+- **complyctl is agnostic.** The consumer CLI treats the URL as an opaque
+  OCI reference — both single-repo and multi-repo references work without
+  code changes (verified in `internal/registry/client.go` and
+  `internal/complytime/config.go`).
+
+## Consequences
+
+### CI Workflow (complytime-policies)
+
+- The `publish-policy-oci.yml` workflow must compute
+  `destination_repository` per matrix entry as
+  `complytime/${BUNDLE_NAME}` instead of a single shared repo.
+- Tag strategy: `latest` on main-branch pushes; semver on release
+  (via `workflow_dispatch` input or Git tag trigger).
+- Quay repos will be auto-created on first push if the org robot
+  account has org-level repository-create permissions. No manual
+  repo creation required.
+- Content-hash caching keys must include the per-bundle repo name
+  (already does via `matrix.bundle.name`).
+
+### Consumer (complyctl)
+
+- No code changes required. `ParsePolicyRef` handles any valid OCI
+  reference.
+- `complytime.yaml` examples and `QUICK_START.md` must be updated to
+  use per-bundle repository paths.
+
+### Documentation
+
+- `docs/usage.md` must be updated with new reference format.
+- This ADR is the canonical record of the decision.
+- A cross-reference to this ADR should exist in `complyctl/docs/`.
+
+### Migration
+
+- Existing tags in the single repo remain available until deprecated.
+- New publishes will target per-bundle repos immediately.
+- No breaking change to consumers who pin by digest.
+
+## Alternatives Considered
+
+### Single repo with compound tags
+
+```
+quay.io/complytime/complytime-policies:ampel-branch-protection-v1.0.0
+```
+
+**Rejected because:** Non-standard tag format breaks automated version
+detection tooling. Tag listing grows noisy with bundles x versions.
+Functionally equivalent to multi-repo but without the ecosystem benefits.
+
+### Status quo (bundle name as sole tag)
+
+```
+quay.io/complytime/complytime-policies:ampel-branch-protection
+```
+
+**Rejected because:** No version history per bundle. Cannot roll back
+to a previous version. Overwrites on every publish.

--- a/docs/adr/0001-one-quay-repo-per-bundle.md
+++ b/docs/adr/0001-one-quay-repo-per-bundle.md
@@ -25,9 +25,11 @@ Three alternatives were evaluated:
 ## Decision
 
 Adopt **one Quay repository per policy bundle** under the `complytime`
-namespace. Each bundle published from `bundles/*.yaml` will be pushed to
-its own repository (e.g., `quay.io/complytime/ampel-branch-protection`)
-with standard version tags (`latest`, semver).
+namespace with a `policies-` prefix. Each bundle published from
+`bundles/*.yaml` will be pushed to its own repository (e.g.,
+`quay.io/complytime/policies-ampel-branch-protection`) with standard
+version tags (`latest`, semver). The prefix distinguishes policy
+artifacts from other project repositories in the same namespace.
 
 ## Rationale
 
@@ -42,7 +44,7 @@ with standard version tags (`latest`, semver).
 - **Per-bundle access control.** Quay permissions can be scoped per
   repository if needed in the future.
 - **Consumer clarity.** `complytime.yaml` references become self-describing:
-  `url: quay.io/complytime/ampel-branch-protection@v1.0.0`.
+  `url: quay.io/complytime/policies-ampel-branch-protection@v1.0.0`.
 - **complyctl is agnostic.** The consumer CLI treats the URL as an opaque
   OCI reference — both single-repo and multi-repo references work without
   code changes (verified in `internal/registry/client.go` and
@@ -54,7 +56,7 @@ with standard version tags (`latest`, semver).
 
 - The `publish-policy-oci.yml` workflow must compute
   `destination_repository` per matrix entry as
-  `complytime/${BUNDLE_NAME}` instead of a single shared repo.
+  `complytime/policies-${BUNDLE_NAME}` instead of a single shared repo.
 - Tag strategy: `latest` on main-branch pushes; semver on release
   (via `workflow_dispatch` input or Git tag trigger).
 - Quay repos will be auto-created on first push if the org robot

--- a/docs/adr/0001-one-quay-repo-per-bundle.md
+++ b/docs/adr/0001-one-quay-repo-per-bundle.md
@@ -60,6 +60,13 @@ with standard version tags (`latest`, semver).
 - Quay repos will be auto-created on first push if the org robot
   account has org-level repository-create permissions. No manual
   repo creation required.
+- Quay.io defaults auto-created repositories to private on first push.
+  An org admin must manually set each new repo to public after its
+  initial publish (one-time step per bundle). The Quay REST API for
+  visibility changes requires an OAuth application token, which is
+  incompatible with the robot account used for registry push/pull.
+- The namespace is configurable (`dest_namespace` input); migrating
+  to a dedicated org requires only changing this value.
 - Content-hash caching keys must include the per-bundle repo name
   (already does via `matrix.bundle.name`).
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -29,28 +29,45 @@ the policy and all of its resolved dependencies:
 
 ### Registries
 
+Each bundle is published to its own repository under the organization namespace.
+
 | Registry | Purpose | Example reference |
 |----------|---------|-------------------|
-| `ghcr.io` | Staging (internal) | `ghcr.io/complytime/complytime-policies:<tag>` |
-| `quay.io` | Public destination | `quay.io/complytime/complytime-policies:<tag>` |
+| `ghcr.io` | Staging (internal) | `ghcr.io/complytime/complytime-policies/cis-fedora-l1-workstation:latest` |
+| `quay.io` | Public destination | `quay.io/complytime/cis-fedora-l1-workstation:latest` |
+
+See [ADR-0001](adr/0001-one-quay-repo-per-bundle.md) for the rationale behind one
+repository per bundle.
+
+### Published bundles
+
+| Bundle | Quay repository |
+|--------|-----------------|
+| `ampel-branch-protection` | `quay.io/complytime/ampel-branch-protection` |
+| `cis-fedora-l1-workstation` | `quay.io/complytime/cis-fedora-l1-workstation` |
+| `cis-fedora-l1-server` | `quay.io/complytime/cis-fedora-l1-server` |
 
 ## Tags
 
-Tags are assigned by maintainers at release time via `workflow_dispatch`.
-Common tag formats:
+Publishing happens automatically on push to `main` (when `bundles/` or
+`governance/` files change) and can also be triggered manually via
+`workflow_dispatch`.
 
-- **Semver** — `v0.1.0`, `v1.0.0`
-- **SHA-prefixed** — `sha-abc123de` (derived from the repository commit)
+| Tag | Mutability | Use case |
+|-----|------------|----------|
+| `latest` | Mutable | Tracks the most recent publish from `main` |
+| `v1.0.0` (semver) | Immutable | Versioned releases via `workflow_dispatch` with `version` input |
+| `@sha256:...` (digest) | Immutable | Strongest guarantee — always returns exact bytes |
 
-There is no `latest` tag by default. Always use an explicit tag or
-digest-pinned reference.
+For production and compliance use cases, prefer a digest-pinned or
+semver-pinned reference over `latest`.
 
 ## Pulling the artifact
 
 Use [ORAS CLI](https://oras.land/docs/installation) (v1.2+):
 
 ```bash
-oras pull quay.io/complytime/complytime-policies:<tag> -o ./output
+oras pull quay.io/complytime/cis-fedora-l1-workstation:latest -o ./output
 ```
 
 The extracted files are the raw Gemara YAML layers (policy, catalog, guidance).
@@ -58,13 +75,13 @@ The extracted files are the raw Gemara YAML layers (policy, catalog, guidance).
 ### Resolving the digest
 
 ```bash
-oras resolve quay.io/complytime/complytime-policies:<tag>
+oras resolve quay.io/complytime/cis-fedora-l1-workstation:latest
 ```
 
 This returns the `sha256:…` digest, which you can use for immutable references:
 
 ```bash
-oras pull quay.io/complytime/complytime-policies@sha256:<digest> -o ./output
+oras pull quay.io/complytime/cis-fedora-l1-workstation@sha256:<digest> -o ./output
 ```
 
 ## Verifying the Cosign signature
@@ -76,14 +93,14 @@ via GitHub Actions OIDC. Verify with:
 cosign verify \
   --certificate-identity-regexp="https://github.com/complytime/complytime-policies/.github/workflows/" \
   --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
-  quay.io/complytime/complytime-policies:<tag>
+  quay.io/complytime/cis-fedora-l1-workstation:latest
 ```
 
 A successful output confirms the artifact was produced by the
 `complytime/complytime-policies` GitHub Actions workflow and has not been
 tampered with since signing.
 
-> **Tip:** Replace `<tag>` with a `@sha256:<digest>` reference for the
+> **Tip:** Replace `:latest` with a `@sha256:<digest>` reference for the
 > strongest verification guarantee.
 
 ## Verifying via registry API
@@ -94,23 +111,19 @@ and CLI checks below are authoritative.
 ### Fetch the manifest
 
 ```bash
-curl -sS \
-  -H 'Accept: application/vnd.oci.image.manifest.v1+json' \
-  "https://quay.io/v2/complytime/complytime-policies/manifests/<tag>" \
+oras manifest fetch quay.io/complytime/cis-fedora-l1-workstation:latest \
   | jq '{mediaType, artifactType, layers: [.layers[] | {mediaType, digest, size}]}'
 ```
 
 ### Verify each layer blob is retrievable
 
 ```bash
-curl -sS \
-  -H 'Accept: application/vnd.oci.image.manifest.v1+json' \
-  "https://quay.io/v2/complytime/complytime-policies/manifests/<tag>" \
+oras manifest fetch quay.io/complytime/cis-fedora-l1-workstation:latest \
   | jq -r '.layers[].digest' \
   | while read -r d; do
       echo "checking $d"
-      curl -fsSIL "https://quay.io/v2/complytime/complytime-policies/blobs/$d" \
-        >/dev/null && echo "  ok" || echo "  FAILED"
+      oras blob fetch quay.io/complytime/cis-fedora-l1-workstation@"$d" --output /dev/null \
+        && echo "  ok" || echo "  FAILED"
     done
 ```
 
@@ -126,7 +139,7 @@ published artifact:
 ```yaml
 # complytime.yaml
 policies:
-  - url: quay.io/complytime/complytime-policies:<tag>
+  - url: quay.io/complytime/cis-fedora-l1-workstation@latest
     id: cis-fedora-l1
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -33,8 +33,8 @@ Each bundle is published to its own repository under the organization namespace.
 
 | Registry | Purpose | Example reference |
 |----------|---------|-------------------|
-| `ghcr.io` | Staging (internal) | `ghcr.io/complytime/complytime-policies/cis-fedora-l1-workstation:latest` |
-| `quay.io` | Public destination | `quay.io/complytime/cis-fedora-l1-workstation:latest` |
+| `ghcr.io` | Staging (internal) | `ghcr.io/complytime/complytime-policies/policies-cis-fedora-l1-workstation:latest` |
+| `quay.io` | Public destination | `quay.io/complytime/policies-cis-fedora-l1-workstation:latest` |
 
 See [ADR-0001](adr/0001-one-quay-repo-per-bundle.md) for the rationale behind one
 repository per bundle.
@@ -43,9 +43,9 @@ repository per bundle.
 
 | Bundle | Quay repository |
 |--------|-----------------|
-| `ampel-branch-protection` | `quay.io/complytime/ampel-branch-protection` |
-| `cis-fedora-l1-workstation` | `quay.io/complytime/cis-fedora-l1-workstation` |
-| `cis-fedora-l1-server` | `quay.io/complytime/cis-fedora-l1-server` |
+| `ampel-branch-protection` | `quay.io/complytime/policies-ampel-branch-protection` |
+| `cis-fedora-l1-workstation` | `quay.io/complytime/policies-cis-fedora-l1-workstation` |
+| `cis-fedora-l1-server` | `quay.io/complytime/policies-cis-fedora-l1-server` |
 
 ## Tags
 
@@ -67,7 +67,7 @@ semver-pinned reference over `latest`.
 Use [ORAS CLI](https://oras.land/docs/installation) (v1.2+):
 
 ```bash
-oras pull quay.io/complytime/cis-fedora-l1-workstation:latest -o ./output
+oras pull quay.io/complytime/policies-cis-fedora-l1-workstation:latest -o ./output
 ```
 
 The extracted files are the raw Gemara YAML layers (policy, catalog, guidance).
@@ -75,13 +75,13 @@ The extracted files are the raw Gemara YAML layers (policy, catalog, guidance).
 ### Resolving the digest
 
 ```bash
-oras resolve quay.io/complytime/cis-fedora-l1-workstation:latest
+oras resolve quay.io/complytime/policies-cis-fedora-l1-workstation:latest
 ```
 
 This returns the `sha256:…` digest, which you can use for immutable references:
 
 ```bash
-oras pull quay.io/complytime/cis-fedora-l1-workstation@sha256:<digest> -o ./output
+oras pull quay.io/complytime/policies-cis-fedora-l1-workstation@sha256:<digest> -o ./output
 ```
 
 ## Verifying the Cosign signature
@@ -93,7 +93,7 @@ via GitHub Actions OIDC. Verify with:
 cosign verify \
   --certificate-identity-regexp="https://github.com/complytime/complytime-policies/.github/workflows/" \
   --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
-  quay.io/complytime/cis-fedora-l1-workstation:latest
+  quay.io/complytime/policies-cis-fedora-l1-workstation:latest
 ```
 
 A successful output confirms the artifact was produced by the
@@ -111,18 +111,18 @@ and CLI checks below are authoritative.
 ### Fetch the manifest
 
 ```bash
-oras manifest fetch quay.io/complytime/cis-fedora-l1-workstation:latest \
+oras manifest fetch quay.io/complytime/policies-cis-fedora-l1-workstation:latest \
   | jq '{mediaType, artifactType, layers: [.layers[] | {mediaType, digest, size}]}'
 ```
 
 ### Verify each layer blob is retrievable
 
 ```bash
-oras manifest fetch quay.io/complytime/cis-fedora-l1-workstation:latest \
+oras manifest fetch quay.io/complytime/policies-cis-fedora-l1-workstation:latest \
   | jq -r '.layers[].digest' \
   | while read -r d; do
       echo "checking $d"
-      oras blob fetch quay.io/complytime/cis-fedora-l1-workstation@"$d" --output /dev/null \
+      oras blob fetch quay.io/complytime/policies-cis-fedora-l1-workstation@"$d" --output /dev/null \
         && echo "  ok" || echo "  FAILED"
     done
 ```
@@ -139,7 +139,7 @@ published artifact:
 ```yaml
 # complytime.yaml
 policies:
-  - url: quay.io/complytime/cis-fedora-l1-workstation@latest
+  - url: quay.io/complytime/policies-cis-fedora-l1-workstation@latest
     id: cis-fedora-l1
 ```
 


### PR DESCRIPTION
## Summary

Implements the repo-per-bundle OCI layout proposed by @gvauter in [#33 (review comment)](https://github.com/complytime/complytime-policies/pull/33#pullrequestreview-4322871082), based on discussion with @jpower432.

**Before (single repo, tag = bundle selector):**
```
quay.io/complytime/complytime-policies:ampel-branch-protection
quay.io/complytime/complytime-policies:cis-fedora-l1-workstation
quay.io/complytime/complytime-policies:cis-fedora-l1-server
```

**After (repo per bundle, tag = version):**
```
quay.io/complytime/ampel-branch-protection:latest
quay.io/complytime/cis-fedora-l1-workstation:latest
quay.io/complytime/cis-fedora-l1-server:latest
```

See **ADR-0001** (`docs/adr/0001-one-quay-repo-per-bundle.md`) included in this PR for full rationale.

### What changed

| Area | Change |
|------|--------|
| Workflow input | `dest_image` renamed to `dest_namespace` (default: `complytime`) |
| GHCR staging | Per-bundle repos: `ghcr.io/complytime/complytime-policies/<bundle>:latest` |
| Quay destination | Per-bundle repos: `quay.io/complytime/<bundle>:latest` |
| Tag strategy | `:latest` on push to main; semver via `workflow_dispatch` with `version` input |
| Semver tagging | Validates `vX.Y.Z` format, checks immutability (fails if tag exists), applies to both GHCR and Quay |
| `docs/usage.md` | Per-bundle references, bundle table, tag mutability guidance, `oras` CLI examples |
| `README.md` | Quick start updated with concrete per-bundle examples |
| ADR-0001 | New decision record documenting the migration rationale |

### Tag strategy

| Tag | Mutability | Trigger | Status |
|-----|------------|---------|--------|
| `:latest` | Mutable | Push to `main` | **This PR** |
| `:v1.0.0` (semver) | Immutable | `workflow_dispatch` with `version` input | **This PR** |
| `@sha256:...` | Immutable | Always (inherent) | Always available |

### Prerequisites

- Quay org robot account needs repository-create permission under the `complytime` namespace (repos are auto-created on first push)
- **Post-deploy (one-time):** An org admin must manually set each new repo to public in the Quay UI after its initial publish. The Quay REST API for visibility requires an OAuth app token incompatible with robot accounts.
- No `complyctl` code changes needed — `ParsePolicyRef` handles any valid OCI reference

### Verification run

Successful fork `workflow_dispatch` against `test_complytime` namespace:
- **Run:** https://github.com/sonupreetam/complytime-policies/actions/runs/26178801269
- **Result:** All 3 bundles published, signed (cosign keyless), verified, and promoted to Quay
- **Per-bundle repos created:**
  - `quay.io/test_complytime/ampel-branch-protection:latest`
  - `quay.io/test_complytime/cis-fedora-l1-server:latest`
  - `quay.io/test_complytime/cis-fedora-l1-workstation:latest`
- **Note:** Repos are created as private by default; toggle to public manually in Quay UI

### Testing checklist

- [x] Fork `workflow_dispatch` with `dest_namespace=test_complytime` — per-bundle repos created and `:latest` tagged
- [x] GHCR staging repos created per-bundle (`ghcr.io/sonupreetam/complytime-policies/<bundle>:latest`)
- [x] Cosign keyless sign + verify passed on all bundles (source and destination)
- [x] ORAS manifest fetch + pull verified destination artifacts retrievable
- [ ] Semver tag via `workflow_dispatch` with `version=v0.1.0` (deferred — requires public repos for full verification)

### Follow-ups

- PR #33 (docs/usage.md) will need to be rebased on this change
- Per-bundle independent versioning via dedicated `release-bundle.yml` workflow (separate PR — current semver step applies same version to all bundles)
- Quay namespace decision: `complytime` vs dedicated `complytime-policies` org (pending team input)

Refs: #33