### PR TITLE
ci(validate): add CUE schema validation workflow for Gemara policies

### DIFF
--- a/.github/workflows/cue-validate.yaml
+++ b/.github/workflows/cue-validate.yaml
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+# yamllint disable rule:line-length
+# Validates all governance artifacts (policies, control catalogs, guidance catalogs)
+# against the official Gemara CUE schemas via a two-phase approach:
+#   1. Build a Go tool that loads YAML through go-gemara SDK (validates + normalizes)
+#   2. CUE-validate the SDK-produced output against gemaraproj/gemara schemas
+#
+# Modeled after: https://github.com/ossf/security-baseline/blob/main/.github/workflows/cue-validate.yaml
+# Resolves: https://github.com/complytime/complytime-policies/issues/31
+
+name: Validate Gemara Schemas
+
+on:
+  pull_request:
+    paths:
+      - 'governance/**'
+      - 'bundles/**'
+      - 'cmd/validate/**'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate Governance Artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        with:
+          go-version-file: cmd/validate/go.mod
+          check-latest: true
+          cache: true
+
+      - name: Setup CUE
+        uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1  # v1.0.1
+        with:
+          version: latest
+
+      - name: Build validator
+        run: go build -C cmd/validate/ -o ../../gemara-validate .
+
+      - name: Generate Gemara output
+        run: ./gemara-validate -governance-dir governance/ -output-dir generated/
+
+      - name: Validate control catalogs against CUE schema
+        run: |
+          set -euo pipefail
+          for f in generated/catalogs/*.yaml; do
+            [ -f "$f" ] || continue
+            echo "::group::Validating $f"
+            cue vet -c -d '#ControlCatalog' github.com/gemaraproj/gemara@latest "$f"
+            echo "::endgroup::"
+          done
+
+      - name: Validate guidance catalogs against CUE schema
+        run: |
+          set -euo pipefail
+          for f in generated/guidance/*.yaml; do
+            [ -f "$f" ] || continue
+            echo "::group::Validating $f"
+            cue vet -c -d '#GuidanceCatalog' github.com/gemaraproj/gemara@latest "$f"
+            echo "::endgroup::"
+          done
+
+      - name: Validate policies against CUE schema
+        run: |
+          set -euo pipefail
+          for f in generated/policies/*.yaml; do
+            [ -f "$f" ] || continue
+            echo "::group::Validating $f"
+            cue vet -c -d '#Policy' github.com/gemaraproj/gemara@latest "$f"
+            echo "::endgroup::"
+          done
+
+      - name: Validate bundle manifests
+        run: |
+          set -euo pipefail
+          for bundle_file in bundles/*.yaml; do
+            [ -f "${bundle_file}" ] || continue
+            echo "::group::Checking bundle ${bundle_file}"
+            while IFS= read -r layer; do
+              layer="$(echo "${layer}" | sed 's/^[[:space:]]*-[[:space:]]*//')"
+              if [ ! -f "${layer}" ]; then
+                echo "::error file=${bundle_file}::Layer file not found: ${layer}"
+                exit 1
+              fi
+              echo "  layer exists: ${layer}"
+            done < <(grep -E '^\s*-\s+' "${bundle_file}")
+            echo "::endgroup::"
+          done
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## Gemara Schema Validation Results"
+            echo ""
+            echo "| Phase | Description |"
+            echo "|-------|-------------|"
+            echo "| Go SDK | \`gemara.Load[T]\` via go-gemara v0.5.0 — validates structure, resolves references, normalizes output |"
+            echo "| CUE Schema | \`cue vet -c\` against \`github.com/gemaraproj/gemara@latest\` — authoritative schema conformance |"
+            echo ""
+            echo "| Type | Files | CUE Definition |"
+            echo "|------|-------|----------------|"
+            echo "| Control Catalogs | $(ls generated/catalogs/*.yaml 2>/dev/null | wc -l | tr -d ' ') | \`#ControlCatalog\` |"
+            echo "| Guidance Catalogs | $(ls generated/guidance/*.yaml 2>/dev/null | wc -l | tr -d ' ') | \`#GuidanceCatalog\` |"
+            echo "| Policies | $(ls generated/policies/*.yaml 2>/dev/null | wc -l | tr -d ' ') | \`#Policy\` |"
+            echo "| Bundle Manifests | $(ls bundles/*.yaml 2>/dev/null | wc -l | tr -d ' ') | layer-existence |"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# CI build artifacts
+generated/
+gemara-validate
+cmd/validate/vendor/
+
+# Unbound Force — managed by uf init
+# Runtime data under .uf/ (databases, caches, locks, logs)
+.uf/workflows/
+.uf/artifacts/
+.uf/dewey/graph.db
+.uf/dewey/graph.db-shm
+.uf/dewey/graph.db-wal
+.uf/dewey/*.lock
+.uf/dewey/cache/
+.uf/dewey/dewey.log
+.uf/replicator/*.db
+.uf/replicator/*.db-shm
+.uf/replicator/*.db-wal
+.uf/replicator/*.lock
+.uf/muti-mind/artifacts/
+.uf/mx-f/data/
+# Legacy tool directories (renamed to .uf/ in Spec 025)
+.dewey/
+.hive/
+.unbound-force/
+.muti-mind/
+.mx-f/

--- a/cmd/validate/go.mod
+++ b/cmd/validate/go.mod
@@ -1,0 +1,8 @@
+module github.com/complytime/complytime-policies/cmd/validate
+
+go 1.25.0
+
+require (
+	github.com/gemaraproj/go-gemara v0.5.0
+	github.com/goccy/go-yaml v1.19.2
+)

--- a/cmd/validate/go.sum
+++ b/cmd/validate/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
+github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gemaraproj/go-gemara v0.5.0 h1:sKDj3R7fX8tdlksShWGCLUl/sLvo+tGh1xAFs1JaoHU=
+github.com/gemaraproj/go-gemara v0.5.0/go.mod h1:knXQmQ4f7vB18eb6TcUCP2A3dqQpn+oZdyz74Qe1+ac=
+github.com/goccy/go-yaml v1.19.2 h1:PmFC1S6h8ljIz6gMRBopkjP1TVT7xuwrButHID66PoM=
+github.com/goccy/go-yaml v1.19.2/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/cmd/validate/main.go
+++ b/cmd/validate/main.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Command gemara-validate loads all Gemara governance YAML files through the
+// go-gemara SDK (validate + normalize) and re-emits them as normalized YAML.
+// Modeled after grc's validateRoot in gemara-registry-cli.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gemaraproj/go-gemara"
+	"github.com/gemaraproj/go-gemara/fetcher"
+	goyaml "github.com/goccy/go-yaml"
+)
+
+func main() {
+	governanceDir := flag.String("governance-dir", "governance", "Root directory containing Gemara YAML files")
+	outputDir := flag.String("output-dir", "generated", "Output directory for normalized YAML")
+	flag.Parse()
+
+	ctx := context.Background()
+
+	files, err := findYAMLFiles(*governanceDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "find yaml files: %v\n", err)
+		os.Exit(1)
+	}
+
+	if len(files) == 0 {
+		fmt.Fprintf(os.Stderr, "no YAML files found in %s\n", *governanceDir)
+		os.Exit(1)
+	}
+
+	var errors int
+	var processed int
+
+	for _, path := range files {
+		relPath, err := filepath.Rel(*governanceDir, path)
+		if err != nil {
+			relPath = path
+		}
+
+		normalized, typeName, err := loadAndMarshal(ctx, path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "FAIL %s: %v\n", path, err)
+			errors++
+			continue
+		}
+
+		outPath := filepath.Join(*outputDir, relPath)
+		if err := writeFile(outPath, normalized); err != nil {
+			fmt.Fprintf(os.Stderr, "FAIL write %s: %v\n", outPath, err)
+			errors++
+			continue
+		}
+
+		fmt.Printf("OK   %-16s %s -> %s\n", typeName, path, outPath)
+		processed++
+	}
+
+	fmt.Printf("\n%d file(s) processed, %d error(s)\n", processed, errors)
+	if errors > 0 {
+		os.Exit(1)
+	}
+}
+
+func findYAMLFiles(root string) ([]string, error) {
+	var files []string
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && (strings.HasSuffix(path, ".yaml") || strings.HasSuffix(path, ".yml")) {
+			files = append(files, path)
+		}
+		return nil
+	})
+	return files, err
+}
+
+// loadAndMarshal reads a Gemara YAML file, detects its type, loads it through
+// the go-gemara SDK (which validates the structure), and re-marshals the typed
+// struct back to YAML. Returns the normalized YAML bytes and the detected type name.
+func loadAndMarshal(ctx context.Context, filePath string) ([]byte, string, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, "", fmt.Errorf("read: %w", err)
+	}
+
+	t, err := gemara.DetectType(data)
+	if err != nil {
+		return nil, "", fmt.Errorf("detect type: %w", err)
+	}
+
+	f := &fetcher.File{}
+	var out any
+	var typeName string
+
+	switch t {
+	case gemara.PolicyArtifact:
+		typeName = "Policy"
+		out, err = gemara.Load[gemara.Policy](ctx, f, filePath)
+	case gemara.GuidanceCatalogArtifact:
+		typeName = "GuidanceCatalog"
+		out, err = gemara.Load[gemara.GuidanceCatalog](ctx, f, filePath)
+	default:
+		typeName = "ControlCatalog"
+		out, err = gemara.Load[gemara.ControlCatalog](ctx, f, filePath)
+	}
+	if err != nil {
+		return nil, typeName, fmt.Errorf("load %s: %w", typeName, err)
+	}
+
+	normalized, err := goyaml.Marshal(out)
+	if err != nil {
+		return nil, typeName, fmt.Errorf("marshal %s: %w", typeName, err)
+	}
+
+	return normalized, typeName, nil
+}
+
+func writeFile(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}


### PR DESCRIPTION
## Summary

- Adds a two-phase CUE schema validation workflow (`.github/workflows/cue-validate.yaml`) that runs on PRs touching `governance/**`, `bundles/**`, or `cmd/validate/**`
- Phase 1: Go tool (`cmd/validate/`) loads each governance YAML through `go-gemara` v0.5.0 (`gemara.DetectType` + `gemara.Load[T]`) to validate structure and re-emit normalized output
- Phase 2: `cue vet -c` validates the normalized output against the authoritative CUE definitions from `github.com/gemaraproj/gemara@latest`

## Motivation

Related to #31 — adds automated schema validation tests for Gemara policies. This surfaces schema drift between older policies and the current Gemara CUE spec (e.g. AMPEL catalog using deprecated `families`/`family` fields, policies using `type: Gate` which is not in the v1.1.0 enum).

See also: [gemaraproj/gemara-registry-cli#6](https://github.com/gemaraproj/gemara-registry-cli/issues/6) (upstream proposal to add CUE validation to the publish action).

## Key findings (local testing)

| Document | Go SDK | CUE | Issue |
|----------|--------|-----|-------|
| AMPEL catalog | PASS | FAIL | `families`/`family` vs required `groups`/`group` |
| CIS catalogs | PASS | PASS | Correct schema |
| CIS guidance | PASS | PASS | Correct schema |
| All policies | PASS | FAIL | `type: Gate` not in CUE `MethodType` enum (v1.1.0) |

## Files changed

- `.github/workflows/cue-validate.yaml` — PR gate workflow
- `cmd/validate/main.go` — Go validation tool
- `cmd/validate/go.mod` / `go.sum` — isolated Go module
- `.gitignore` — excludes `generated/` and `gemara-validate` binary

## Test plan

- [ ] Verify workflow triggers on PR events in CI
- [ ] Confirm Go SDK phase passes for all 7 governance files
- [ ] Confirm CUE phase correctly flags AMPEL catalog and policy schema drift
- [ ] Validate bundle manifest layer-existence check


Made with [Cursor](https://cursor.com)