### PR TITLE
ci(validate): add CUE schema validation workflow for Gemara policies

### DIFF
--- a/.github/workflows/cue-validate.yaml
+++ b/.github/workflows/cue-validate.yaml
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+# yamllint disable rule:line-length
+# Validates governance artifacts against the official Gemara CUE schemas.
+#
+# Reference: https://github.com/ossf/security-baseline/blob/main/.github/workflows/cue-validate.yaml
+# Related to: https://github.com/complytime/complytime-policies/issues/31
+
+name: Validate Gemara Schemas
+
+on:
+  pull_request:
+    paths:
+      - 'governance/**'
+      - 'bundles/**'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  validate-schemas:
+    name: "${{ matrix.name }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Control Catalogs
+            dir: governance/catalogs
+            definition: "#ControlCatalog"
+          - name: Guidance Catalogs
+            dir: governance/guidance
+            definition: "#GuidanceCatalog"
+          - name: Policies
+            dir: governance/policies
+            definition: "#Policy"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup CUE
+        uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1  # v1.0.1
+        with:
+          version: latest
+
+      - name: Validate against CUE schema
+        run: |
+          failed=0
+          for f in ${{ matrix.dir }}/*.yaml; do
+            [ -f "$f" ] || continue
+            if ! output=$(cue vet -c -d '${{ matrix.definition }}' github.com/gemaraproj/gemara@latest "$f" 2>&1); then
+              echo "::error file=$f::CUE validation failed"
+              if [ "$failed" -eq 0 ]; then
+                echo "### Failed: ${{ matrix.name }} (\`${{ matrix.definition }}\`)" >> "${GITHUB_STEP_SUMMARY}"
+                echo "" >> "${GITHUB_STEP_SUMMARY}"
+              fi
+              echo "<details><summary><code>$f</code></summary>" >> "${GITHUB_STEP_SUMMARY}"
+              echo "" >> "${GITHUB_STEP_SUMMARY}"
+              echo '```' >> "${GITHUB_STEP_SUMMARY}"
+              echo "$output" >> "${GITHUB_STEP_SUMMARY}"
+              echo '```' >> "${GITHUB_STEP_SUMMARY}"
+              echo "</details>" >> "${GITHUB_STEP_SUMMARY}"
+              echo "" >> "${GITHUB_STEP_SUMMARY}"
+              failed=1
+            fi
+          done
+          exit $failed
+
+  validate-bundles:
+    name: Bundle Manifests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Validate layer existence
+        run: |
+          failed=0
+          for bundle_file in bundles/*.yaml; do
+            [ -f "${bundle_file}" ] || continue
+            while IFS= read -r layer; do
+              layer="$(echo "${layer}" | sed 's/^[[:space:]]*-[[:space:]]*//')"
+              if [ ! -f "${layer}" ]; then
+                echo "::error file=${bundle_file}::Layer file not found: ${layer}"
+                if [ "$failed" -eq 0 ]; then
+                  echo "### Failed: Bundle Manifests" >> "${GITHUB_STEP_SUMMARY}"
+                  echo "" >> "${GITHUB_STEP_SUMMARY}"
+                fi
+                echo "- \`${bundle_file}\`: missing layer \`${layer}\`" >> "${GITHUB_STEP_SUMMARY}"
+                failed=1
+              fi
+            done < <(grep -E '^\s*-\s+' "${bundle_file}")
+          done
+          exit $failed

--- a/.github/workflows/cue-validate.yml
+++ b/.github/workflows/cue-validate.yml
@@ -2,9 +2,6 @@
 ---
 # yamllint disable rule:line-length
 # Validates governance artifacts against the official Gemara CUE schemas.
-#
-# Reference: https://github.com/ossf/security-baseline/blob/main/.github/workflows/cue-validate.yaml
-# Related to: https://github.com/complytime/complytime-policies/issues/31
 
 name: Validate Gemara Schemas
 
@@ -17,6 +14,10 @@ on:
 
 permissions:
   contents: read
+
+env:
+  CUE_VERSION: v0.16.1
+  GEMARA_VERSION: v1.2.0
 
 jobs:
   validate-schemas:
@@ -44,17 +45,21 @@ jobs:
       - name: Setup CUE
         uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1  # v1.0.1
         with:
-          version: latest
+          version: ${{ env.CUE_VERSION }}
 
       - name: Validate against CUE schema
+        env:
+          SCHEMA_DIR: ${{ matrix.dir }}
+          SCHEMA_DEF: ${{ matrix.definition }}
+          SCHEMA_NAME: ${{ matrix.name }}
         run: |
           failed=0
-          for f in ${{ matrix.dir }}/*.yaml; do
+          for f in "${SCHEMA_DIR}"/*.yaml; do
             [ -f "$f" ] || continue
-            if ! output=$(cue vet -c -d '${{ matrix.definition }}' github.com/gemaraproj/gemara@latest "$f" 2>&1); then
+            if ! output=$(cue vet -c -d "${SCHEMA_DEF}" "github.com/gemaraproj/gemara@${GEMARA_VERSION}" "$f" 2>&1); then
               echo "::error file=$f::CUE validation failed"
               if [ "$failed" -eq 0 ]; then
-                echo "### Failed: ${{ matrix.name }} (\`${{ matrix.definition }}\`)" >> "${GITHUB_STEP_SUMMARY}"
+                echo "### Failed: ${SCHEMA_NAME} (\`${SCHEMA_DEF}\`)" >> "${GITHUB_STEP_SUMMARY}"
                 echo "" >> "${GITHUB_STEP_SUMMARY}"
               fi
               echo "<details><summary><code>$f</code></summary>" >> "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
## Summary

- Adds a `cue-validate` workflow that runs `cue vet` directly on governance YAML against the authoritative CUE schemas from `github.com/gemaraproj/gemara@latest`
- Uses a matrix strategy to validate control catalogs (`#ControlCatalog`), guidance catalogs (`#GuidanceCatalog`), and policies (`#Policy`) as independent parallel jobs
- Bundle manifest layer-existence check runs as a separate job
- Only failures appear in the GitHub Step Summary with collapsible error details
- Triggers on PRs touching `governance/**` or `bundles/**`, and via manual dispatch

## Design decision

This is a CUE-only approach modeled after the [ossf/security-baseline cue-validate workflow](https://github.com/ossf/security-baseline/blob/main/.github/workflows/cue-validate.yaml). The earlier investigation branch (`investigate/ossf-cue-validate`) included a Go SDK validation tool (`cmd/validate/`), but that work is better suited upstream — see [gemaraproj/gemara-registry-cli#6](https://github.com/gemaraproj/gemara-registry-cli/issues/6) for the proposal to add SDK + CUE validation to the publish action.

## Files changed

- `.github/workflows/cue-validate.yaml` — PR gate workflow (1 file, ~97 lines)

## Known CUE schema drift (expected failures)

| Document | Issue |
|----------|-------|
| AMPEL catalog | Uses `families`/`family` — CUE schema requires `groups`/`group` |
| All policies | `type: Gate` in evaluation-methods — CUE enum only allows `Behavioral` and `Intent` in v1.1.0 |

These failures are expected and confirm the workflow is working. Fixing the schema drift is separate follow-up work.

## CI verification (fork)

Workflow verified end-to-end on [sonupreetam/complytime-policies PR #3](https://github.com/sonupreetam/complytime-policies/pull/3) — [run #26453220883](https://github.com/sonupreetam/complytime-policies/actions/runs/26453220883).

## Test plan

- [x] Verify workflow triggers on PR events
- [x] Confirm CIS guidance passes `cue vet`
- [x] Confirm AMPEL catalog fails with expected schema drift errors (`families`/`family`)
- [x] Confirm all 3 policies fail with expected `type: Gate` drift
- [x] Validate bundle manifest layer-existence check
- [x] Verify file-level failure details in GitHub Step Summary

Related to #31
Closes #38 