### PR TITLE
chore: add release workflow and update complytime.yaml for v0.1.0

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+
+category-template: |
+  ### $TITLE
+
+template: |
+  ## complytime-policies $RESOLVED_VERSION
+
+  Centralized [Gemara](https://github.com/gemaraproj/gemara) policies for
+  [ComplyTime](https://github.com/complytime) tooling. Content is published
+  as OCI artifacts to **Quay.io** and consumed with `complyctl get`.
+
+  #### After this release
+
+  - Run the **Publish policy OCI** workflow to push updated bundles to GHCR and Quay.
+  - Consumers: update `complytime.yaml` references to the new OCI tag or digest.
+
+  **[View full diff: `$PREVIOUS_TAG` → `v$RESOLVED_VERSION`](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION)**
+
+  ## Changes
+
+  $CHANGES
+
+  ---
+
+  **Compare:** [`$PREVIOUS_TAG`…`v$RESOLVED_VERSION`](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION)
+
+  **Thanks** to $CONTRIBUTORS for this release.
+
+change-template: "- $TITLE — [#$NUMBER]($URL) · @$AUTHOR"
+no-changes-template: |
+  *No pull requests are included in this release since the previous tag. If that's unexpected, check that PRs are merged to the default branch and not labeled `skip-changelog`.*
+sort-by: merged_at
+sort-direction: ascending
+
+categories:
+  - title: "Breaking changes"
+    labels:
+      - "breaking"
+      - "major"
+  - title: "Policy & governance content"
+    labels:
+      - "policy"
+      - "catalog"
+      - "guidance"
+    collapse-after: 12
+  - title: "Bundles & OCI publishing"
+    labels:
+      - "bundles"
+      - "publishing"
+      - "workflows"
+    collapse-after: 12
+  - title: "Features"
+    labels:
+      - "feature"
+      - "enhancement"
+  - title: "Bug fixes"
+    labels:
+      - "fix"
+      - "bugfix"
+      - "bug"
+  - title: "Maintenance"
+    labels:
+      - "infrastructure"
+      - "automation"
+      - "documentation"
+      - "dependencies"
+      - "maintenance"
+      - "revert"
+
+exclude-labels:
+  - "skip-changelog"
+
+exclude-contributors:
+  - "github-actions[bot]"
+  - "dependabot[bot]"
+
+version-resolver:
+  major:
+    labels:
+      - "breaking"
+      - "major"
+  minor:
+    labels:
+      - "feature"
+      - "enhancement"
+      - "minor"
+  patch:
+    labels:
+      - "fix"
+      - "documentation"
+      - "maintenance"
+      - "patch"
+      - "policy"
+      - "catalog"
+      - "guidance"
+      - "bundles"
+      - "publishing"
+      - "workflows"
+  default: patch
+
+autolabeler:
+  - label: "workflows"
+    files:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+  - label: "policy"
+    files:
+      - "governance/policies/**"
+  - label: "catalog"
+    files:
+      - "governance/catalogs/**"
+  - label: "guidance"
+    files:
+      - "governance/guidance/**"
+  - label: "bundles"
+    files:
+      - "bundles/**"
+  - label: "automation"
+    title:
+      - "/^(build|ci|refactor|test).*/i"
+  - label: "documentation"
+    title:
+      - "/^(docs).*/i"
+  - label: "feature"
+    title:
+      - "/^(feat).*/i"
+  - label: "fix"
+    title:
+      - "/^(fix).*/i"
+  - label: "maintenance"
+    title:
+      - "/^(chore|maintenance).*/i"
+  - label: "revert"
+    title:
+      - "/^(revert).*/i"

--- a/.github/workflows/cue-validate.yaml
+++ b/.github/workflows/cue-validate.yaml
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+# yamllint disable rule:line-length
+# Validates governance artifacts against the official Gemara CUE schemas.
+#
+# Reference: https://github.com/ossf/security-baseline/blob/main/.github/workflows/cue-validate.yaml
+# Related to: https://github.com/complytime/complytime-policies/issues/31
+
+name: Validate Gemara Schemas
+
+on:
+  pull_request:
+    paths:
+      - 'governance/**'
+      - 'bundles/**'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  validate-schemas:
+    name: "${{ matrix.name }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Control Catalogs
+            dir: governance/catalogs
+            definition: "#ControlCatalog"
+          - name: Guidance Catalogs
+            dir: governance/guidance
+            definition: "#GuidanceCatalog"
+          - name: Policies
+            dir: governance/policies
+            definition: "#Policy"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup CUE
+        uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1  # v1.0.1
+        with:
+          version: latest
+
+      - name: Validate against CUE schema
+        run: |
+          failed=0
+          for f in ${{ matrix.dir }}/*.yaml; do
+            [ -f "$f" ] || continue
+            if ! output=$(cue vet -c -d '${{ matrix.definition }}' github.com/gemaraproj/gemara@latest "$f" 2>&1); then
+              echo "::error file=$f::CUE validation failed"
+              if [ "$failed" -eq 0 ]; then
+                echo "### Failed: ${{ matrix.name }} (\`${{ matrix.definition }}\`)" >> "${GITHUB_STEP_SUMMARY}"
+                echo "" >> "${GITHUB_STEP_SUMMARY}"
+              fi
+              echo "<details><summary><code>$f</code></summary>" >> "${GITHUB_STEP_SUMMARY}"
+              echo "" >> "${GITHUB_STEP_SUMMARY}"
+              echo '```' >> "${GITHUB_STEP_SUMMARY}"
+              echo "$output" >> "${GITHUB_STEP_SUMMARY}"
+              echo '```' >> "${GITHUB_STEP_SUMMARY}"
+              echo "</details>" >> "${GITHUB_STEP_SUMMARY}"
+              echo "" >> "${GITHUB_STEP_SUMMARY}"
+              failed=1
+            fi
+          done
+          exit $failed
+
+  validate-bundles:
+    name: Bundle Manifests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Validate layer existence
+        run: |
+          failed=0
+          for bundle_file in bundles/*.yaml; do
+            [ -f "${bundle_file}" ] || continue
+            while IFS= read -r layer; do
+              layer="$(echo "${layer}" | sed 's/^[[:space:]]*-[[:space:]]*//')"
+              if [ ! -f "${layer}" ]; then
+                echo "::error file=${bundle_file}::Layer file not found: ${layer}"
+                if [ "$failed" -eq 0 ]; then
+                  echo "### Failed: Bundle Manifests" >> "${GITHUB_STEP_SUMMARY}"
+                  echo "" >> "${GITHUB_STEP_SUMMARY}"
+                fi
+                echo "- \`${bundle_file}\`: missing layer \`${layer}\`" >> "${GITHUB_STEP_SUMMARY}"
+                failed=1
+              fi
+            done < <(grep -E '^\s*-\s+' "${bundle_file}")
+          done
+          exit $failed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# --------------------------------------------------------------------------
+# Creates a GitHub Release from a semver tag. If the tag does not exist yet,
+# the workflow creates it on the selected branch before publishing.
+#
+# Usage:
+#   - From the Actions tab: select this workflow, choose the branch, enter the tag.
+#   - From the CLI: gh workflow run release.yml --ref main -f tag=v0.1.0
+# --------------------------------------------------------------------------
+---
+# yamllint disable rule:line-length
+
+name: Release
+
+"on":
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Semver tag to release (e.g., v0.1.0)'
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  release:
+    name: Publish Release
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Validate tag format
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          if [[ ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Tag must match semver format: vMAJOR.MINOR.PATCH"
+            exit 1
+          fi
+
+      - name: Verify release is from default branch
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          if [[ "${REF}" != "refs/heads/main" ]]; then
+            echo "::error::Releases MUST be created from the main branch. Current ref: ${REF}"
+            exit 1
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Create tag if it does not exist
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          if git rev-parse "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists — skipping creation."
+          else
+            git tag "${TAG}"
+            git push origin "${TAG}"
+            echo "Created and pushed tag ${TAG}."
+          fi
+
+      - name: Publish GitHub release
+        uses: release-drafter/release-drafter@693d20e7c1ce1a81d3a41962f85914253b518449  # v7.3.1
+        with:
+          publish: true
+          tag: ${{ inputs.tag }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/complytime.yaml
+++ b/complytime.yaml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+# complytime.yaml - workspace configuration for consume-side checks.
+#
+# Each bundle is published to its own Quay repository under the
+# complytime namespace (one repo per bundle, see docs/adr/0001).
+#
+# Quay tags (web UI):
+#   https://quay.io/repository/complytime/policies-ampel-branch-protection?tab=tags
+# List tags:
+#   curl -sS https://quay.io/v2/complytime/policies-ampel-branch-protection/tags/list
+#
+# Policy `url`: optional scheme; @suffix = tag or sha256:…
+#   (complyctl tag/digest resolution, complytime/complyctl main+).
+
+policies:
+  - id: ampel-branch-protection
+    url: quay.io/complytime/policies-ampel-branch-protection@latest
+  - id: cis-fedora-l1-workstation
+    url: quay.io/complytime/policies-cis-fedora-l1-workstation@latest
+  - id: cis-fedora-l1-server
+    url: quay.io/complytime/policies-cis-fedora-l1-server@latest
+
+targets:
+  - id: default
+    policies:
+      - ampel-branch-protection
+    variables:
+      url: https://github.com/complytime/complytime-policies
+      specs: "builtin:github/branch-rules.yaml"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -41,11 +41,11 @@ repository per bundle.
 
 ### Published bundles
 
-| Bundle | Quay repository |
-|--------|-----------------|
-| `ampel-branch-protection` | `quay.io/complytime/policies-ampel-branch-protection` |
-| `cis-fedora-l1-workstation` | `quay.io/complytime/policies-cis-fedora-l1-workstation` |
-| `cis-fedora-l1-server` | `quay.io/complytime/policies-cis-fedora-l1-server` |
+| Bundle | Quay repository | Provider |
+|--------|-----------------|----------|
+| `ampel-branch-protection` | `quay.io/complytime/policies-ampel-branch-protection` | [ampel](https://github.com/complytime/complytime-providers/tree/main/cmd/ampel-provider) |
+| `cis-fedora-l1-workstation` | `quay.io/complytime/policies-cis-fedora-l1-workstation` | [openscap](https://github.com/complytime/complytime-providers/tree/main/cmd/openscap-provider) |
+| `cis-fedora-l1-server` | `quay.io/complytime/policies-cis-fedora-l1-server` | [openscap](https://github.com/complytime/complytime-providers/tree/main/cmd/openscap-provider) |
 
 ## Tags
 
@@ -84,6 +84,11 @@ This returns the `sha256:…` digest, which you can use for immutable references
 oras pull quay.io/complytime/policies-cis-fedora-l1-workstation@sha256:<digest> -o ./output
 ```
 
+> **Note:** ORAS, cosign, and curl use standard OCI reference syntax
+> (`:tag` and `@sha256:digest`). `complyctl` uses its own `@tag` convention
+> in `complytime.yaml` — see the [Using with complyctl](#using-with-complyctl)
+> section below.
+
 ## Verifying the Cosign signature
 
 All artifacts are signed with [keyless Cosign](https://docs.sigstore.dev/cosign/signing/overview/)
@@ -103,10 +108,10 @@ tampered with since signing.
 > **Tip:** Replace `:latest` with a `@sha256:<digest>` reference for the
 > strongest verification guarantee.
 
-## Verifying via registry API
+## Verifying the artifact
 
-Quay's package UI may appear sparse for custom OCI media types. The API
-and CLI checks below are authoritative.
+Quay's package UI may appear sparse for custom OCI media types. The ORAS
+CLI checks below are authoritative.
 
 ### Fetch the manifest
 
@@ -127,34 +132,50 @@ oras manifest fetch quay.io/complytime/policies-cis-fedora-l1-workstation:latest
     done
 ```
 
-If the API checks pass but the Quay UI still looks sparse, treat the artifact
+If these checks pass but the Quay UI still looks sparse, treat the artifact
 as valid.
 
 ## Using with complyctl
 
 [complyctl](https://github.com/complytime/complyctl) can consume Gemara
-bundles directly from the OCI registry. Point the policy source at the
-published artifact:
+bundles directly from the OCI registry. Point the policy source at a
+published bundle in `complytime.yaml`:
 
 ```yaml
 # complytime.yaml
 policies:
-  - url: quay.io/complytime/policies-cis-fedora-l1-workstation@latest
-    id: cis-fedora-l1
+  - url: quay.io/complytime/policies-ampel-branch-protection@latest
+    id: ampel-bp
 ```
 
-Then run:
+Then fetch and scan:
 
 ```bash
 complyctl get
+complyctl scan --policy-id ampel-bp
 ```
 
-`complyctl` resolves the OCI reference, pulls the bundle layers via the Go
-ORAS library, and makes the policy, catalog, and guidance available for
-scanning.
+See the
+[complyctl Quick Start](https://github.com/complytime/complyctl/blob/main/docs/QUICK_START.md)
+for installation, full `complytime.yaml` reference, and output formats.
+
+### Bundle providers
+
+Each provider has its own prerequisites, `complytime.yaml` variables, and
+setup instructions:
+
+| Bundle | Provider | What it evaluates |
+|--------|----------|-------------------|
+| `ampel-branch-protection` | [ampel](https://github.com/complytime/complytime-providers/tree/main/cmd/ampel-provider) | GitHub / GitLab branch protection rules |
+| `cis-fedora-l1-workstation` | [openscap](https://github.com/complytime/complytime-providers/tree/main/cmd/openscap-provider) | CIS Fedora L1 Workstation benchmark |
+| `cis-fedora-l1-server` | [openscap](https://github.com/complytime/complytime-providers/tree/main/cmd/openscap-provider) | CIS Fedora L1 Server benchmark |
 
 ## Further reading
 
+- [complyctl Quick Start](https://github.com/complytime/complyctl/blob/main/docs/QUICK_START.md) — installation, `complytime.yaml` reference, output formats
+- [ampel provider docs](https://github.com/complytime/complytime-providers/blob/main/cmd/ampel-provider/docs/configuration.md) — variables, token auth, granular policies
+- [openscap provider docs](https://github.com/complytime/complytime-providers/blob/main/cmd/openscap-provider/docs/configuration.md) — variables, profiles, prerequisites
+- [complytime-demos](https://github.com/complytime/complytime-demos) — automated VM setup with sample policies
 - [Quickstart for maintainers](../specs/001-policy-oci-publish/quickstart.md) — how to run the publish workflow
 - [Pipeline contract](../specs/001-policy-oci-publish/contracts/publish-pipeline.md) — action inputs, secrets, and outputs
 - [gemara-registry-cli](https://github.com/gemaraproj/gemara-registry-cli) — the composite action that produces the artifact


### PR DESCRIPTION
## Summary

Pre-release cleanup ahead of cutting `v0.1.0`:

- **`release.yml`**: adds `workflow_dispatch` release workflow using release-drafter v7.3.1 (aligned with org-infra convention). Validates semver, guards main-only, creates tag if needed, publishes GitHub Release with auto-generated changelog.
- **`release-drafter.yml`**: changelog categories (policy, catalog, guidance, bundles, publishing), autolabeler rules by file path and PR title, version-resolver for major/minor/patch bumps.
- **`complytime.yaml`**: updated from the old test namespace (`quay.io/test_complytime/complytime-policies`) to the production per-bundle namespace (`quay.io/complytime/policies-ampel-branch-protection@latest`).

### Context

All 3 bundles (`ampel-branch-protection`, `cis-fedora-l1-server`, `cis-fedora-l1-workstation`) are already publishing successfully to Quay via the existing `publish-policy-oci.yml` workflow. This PR adds the missing release infrastructure so we can cut tagged releases.

### After merge

1. Run **Release** workflow with `tag=v0.1.0` to create the GitHub Release
2. Run **Publish policy OCI** workflow with `version=v0.1.0` to apply the semver tag to OCI artifacts on GHCR and Quay

## Test plan

- [ ] `release.yml` syntax is valid (yamllint / Actions lint)
- [ ] `release-drafter.yml` categories match existing PR labels
- [ ] `complytime.yaml` references resolve: `oras manifest fetch quay.io/complytime/policies-ampel-branch-protection:latest`


Made with [Cursor](https://cursor.com)