### PR TITLE
refactor(ci): replace grep/sed bundle parsing with yq

### DIFF
--- a/.github/workflows/cue-validate.yml
+++ b/.github/workflows/cue-validate.yml
@@ -11,6 +11,8 @@ on:
     paths:
       - 'governance/**'
       - 'bundles/**'
+      - '.github/workflows/**'
+      - 'scripts/**'
   workflow_dispatch: {}
 
 permissions:
@@ -132,3 +134,15 @@ jobs:
           done
           echo "" >> "${GITHUB_STEP_SUMMARY}"
           exit $failed
+
+  test-bundle-parsing:
+    name: Bundle Parsing
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run bundle parsing tests
+        run: make test-bundle-parsing

--- a/.github/workflows/cue-validate.yml
+++ b/.github/workflows/cue-validate.yml
@@ -111,7 +111,7 @@ jobs:
             layer_count=0
             missing_count=0
             while IFS= read -r layer; do
-              layer="$(echo "${layer}" | sed 's/^[[:space:]]*-[[:space:]]*//')"
+              [ -z "${layer}" ] && continue
               layer_count=$((layer_count + 1))
               if [ ! -f "${layer}" ]; then
                 echo "::error file=${bundle_file}::Layer file not found: ${layer}"
@@ -123,7 +123,7 @@ jobs:
                 missing_count=$((missing_count + 1))
                 failed=1
               fi
-            done < <(grep -E '^\s*-\s+' "${bundle_file}")
+            done < <(yq -r '(.layers // [])[]' "${bundle_file}")
             if [ "$missing_count" -eq 0 ]; then
               echo "✓ ${bundle_name}: ${layer_count} layer(s) present"
             else

--- a/.github/workflows/publish-policy-oci.yml
+++ b/.github/workflows/publish-policy-oci.yml
@@ -66,7 +66,7 @@ jobs:
             [ -f "${bundle_file}" ] || continue
             bundle_name="$(basename "${bundle_file}" .yaml)"
             # The root policy file is the last layer entry (type: Policy)
-            root_file="$(grep -E '^\s*-\s+' "${bundle_file}" | tail -1 | sed 's/^[[:space:]]*-[[:space:]]*//')"
+            root_file="$(yq '.layers[-1]' "${bundle_file}")"
             if [ -z "${root_file}" ]; then
               echo "::warning::No layers found in ${bundle_file}, skipping."
               continue
@@ -121,9 +121,8 @@ jobs:
           {
             sha256sum "${BUNDLE_FILE}"
             while IFS= read -r layer; do
-              layer="$(echo "${layer}" | sed 's/^[[:space:]]*-[[:space:]]*//')"
               [ -f "${layer}" ] && sha256sum "${layer}" || true
-            done < <(grep -E '^\s*-\s+' "${BUNDLE_FILE}")
+            done < <(yq -r '.layers[]' "${BUNDLE_FILE}")
           } | sha256sum - | awk '{print "hash=" $1}' >> "$GITHUB_OUTPUT"
 
       - name: Skip publish if content unchanged

--- a/.github/workflows/publish-policy-oci.yml
+++ b/.github/workflows/publish-policy-oci.yml
@@ -66,7 +66,7 @@ jobs:
             [ -f "${bundle_file}" ] || continue
             bundle_name="$(basename "${bundle_file}" .yaml)"
             # The root policy file is the last layer entry (type: Policy)
-            root_file="$(yq '.layers[-1]' "${bundle_file}")"
+            root_file="$(yq -r '(.layers // []) | select(length > 0) | .[-1]' "${bundle_file}")"
             if [ -z "${root_file}" ]; then
               echo "::warning::No layers found in ${bundle_file}, skipping."
               continue
@@ -122,7 +122,7 @@ jobs:
             sha256sum "${BUNDLE_FILE}"
             while IFS= read -r layer; do
               [ -f "${layer}" ] && sha256sum "${layer}" || true
-            done < <(yq -r '.layers[]' "${BUNDLE_FILE}")
+            done < <(yq -r '(.layers // [])[]' "${BUNDLE_FILE}")
           } | sha256sum - | awk '{print "hash=" $1}' >> "$GITHUB_OUTPUT"
 
       - name: Skip publish if content unchanged

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+
+.PHONY: test test-bundle-parsing lint
+
+test: test-bundle-parsing
+
+test-bundle-parsing:
+	@./scripts/test-bundle-parsing.sh
+
+lint:
+	@echo "TODO: wire yamllint"

--- a/scripts/test-bundle-parsing.sh
+++ b/scripts/test-bundle-parsing.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tests the yq expressions used by publish-policy-oci.yml and cue-validate.yml
+# to parse bundle manifest layers. Validates correct behaviour under pipefail
+# for both real bundles and synthetic edge cases.
+#
+# Usage: ./scripts/test-bundle-parsing.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR_TEST}"' EXIT
+
+passed=0
+failed=0
+
+pass() {
+  passed=$((passed + 1))
+  echo "  PASS: $1"
+}
+
+fail() {
+  failed=$((failed + 1))
+  echo "  FAIL: $1"
+}
+
+# --- Expressions under test (must match the workflows) ---
+# publish-policy-oci.yml discover job: extract last layer (root policy file)
+yq_root_file() { yq -r '(.layers // []) | select(length > 0) | .[-1]' "$1"; }
+
+# publish-policy-oci.yml hash step + cue-validate.yml layer existence: iterate all layers
+yq_all_layers() { yq -r '(.layers // [])[]' "$1"; }
+
+# ============================================================
+# Part 1: Synthetic edge cases
+# ============================================================
+echo "=== Synthetic edge-case tests ==="
+
+# --- Case: no layers key ---
+echo "other_key: value" > "${TMPDIR_TEST}/no-layers.yaml"
+
+result="$(yq_root_file "${TMPDIR_TEST}/no-layers.yaml")"
+[ -z "${result}" ] && pass "no-layers: root_file is empty" || fail "no-layers: root_file should be empty, got '${result}'"
+
+result="$(yq_all_layers "${TMPDIR_TEST}/no-layers.yaml")"
+[ -z "${result}" ] && pass "no-layers: all_layers is empty" || fail "no-layers: all_layers should be empty, got '${result}'"
+
+# --- Case: empty array ---
+echo "layers: []" > "${TMPDIR_TEST}/empty-layers.yaml"
+
+result="$(yq_root_file "${TMPDIR_TEST}/empty-layers.yaml")"
+[ -z "${result}" ] && pass "empty-layers: root_file is empty" || fail "empty-layers: root_file should be empty, got '${result}'"
+
+result="$(yq_all_layers "${TMPDIR_TEST}/empty-layers.yaml")"
+[ -z "${result}" ] && pass "empty-layers: all_layers is empty" || fail "empty-layers: all_layers should be empty, got '${result}'"
+
+# --- Case: null value ---
+printf "layers:\n" > "${TMPDIR_TEST}/null-layers.yaml"
+
+result="$(yq_root_file "${TMPDIR_TEST}/null-layers.yaml")"
+[ -z "${result}" ] && pass "null-layers: root_file is empty" || fail "null-layers: root_file should be empty, got '${result}'"
+
+result="$(yq_all_layers "${TMPDIR_TEST}/null-layers.yaml")"
+[ -z "${result}" ] && pass "null-layers: all_layers is empty" || fail "null-layers: all_layers should be empty, got '${result}'"
+
+# --- Case: valid bundle (happy path) ---
+cat > "${TMPDIR_TEST}/valid.yaml" <<'YAML'
+layers:
+  - governance/catalogs/test-catalog.yaml
+  - governance/policies/test-policy.yaml
+YAML
+
+result="$(yq_root_file "${TMPDIR_TEST}/valid.yaml")"
+[ "${result}" = "governance/policies/test-policy.yaml" ] \
+  && pass "valid: root_file is last layer" \
+  || fail "valid: root_file expected 'governance/policies/test-policy.yaml', got '${result}'"
+
+count="$(yq_all_layers "${TMPDIR_TEST}/valid.yaml" | wc -l | tr -d ' ')"
+[ "${count}" = "2" ] \
+  && pass "valid: all_layers returns 2 entries" \
+  || fail "valid: all_layers expected 2 entries, got ${count}"
+
+# --- Case: single layer ---
+cat > "${TMPDIR_TEST}/single.yaml" <<'YAML'
+layers:
+  - governance/policies/only-policy.yaml
+YAML
+
+result="$(yq_root_file "${TMPDIR_TEST}/single.yaml")"
+[ "${result}" = "governance/policies/only-policy.yaml" ] \
+  && pass "single: root_file is the only layer" \
+  || fail "single: root_file expected 'governance/policies/only-policy.yaml', got '${result}'"
+
+count="$(yq_all_layers "${TMPDIR_TEST}/single.yaml" | wc -l | tr -d ' ')"
+[ "${count}" = "1" ] \
+  && pass "single: all_layers returns 1 entry" \
+  || fail "single: all_layers expected 1 entry, got ${count}"
+
+# ============================================================
+# Part 2: Real bundles in bundles/
+# ============================================================
+echo ""
+echo "=== Real bundle tests ==="
+
+bundle_count=0
+for bundle_file in "${REPO_ROOT}"/bundles/*.yaml; do
+  [ -f "${bundle_file}" ] || continue
+  bundle_name="$(basename "${bundle_file}" .yaml)"
+  bundle_count=$((bundle_count + 1))
+
+  root="$(yq_root_file "${bundle_file}")"
+  if [ -z "${root}" ]; then
+    fail "${bundle_name}: root_file is empty"
+  elif [ ! -f "${REPO_ROOT}/${root}" ]; then
+    fail "${bundle_name}: root_file '${root}' does not exist"
+  else
+    pass "${bundle_name}: root_file '${root}' exists"
+  fi
+
+  layer_ok=0
+  layer_total=0
+  while IFS= read -r layer; do
+    [ -z "${layer}" ] && continue
+    layer_total=$((layer_total + 1))
+    if [ -f "${REPO_ROOT}/${layer}" ]; then
+      layer_ok=$((layer_ok + 1))
+    else
+      fail "${bundle_name}: layer '${layer}' does not exist"
+    fi
+  done < <(yq_all_layers "${bundle_file}")
+
+  if [ "${layer_ok}" -eq "${layer_total}" ] && [ "${layer_total}" -gt 0 ]; then
+    pass "${bundle_name}: all ${layer_total} layer(s) exist"
+  elif [ "${layer_total}" -eq 0 ]; then
+    fail "${bundle_name}: no layers found"
+  fi
+done
+
+if [ "${bundle_count}" -eq 0 ]; then
+  fail "no bundle files found in bundles/"
+fi
+
+# ============================================================
+# Summary
+# ============================================================
+echo ""
+echo "=== Results: ${passed} passed, ${failed} failed ==="
+if [ "${failed}" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Replaces fragile `grep -E '^\s*-\s+'` + `sed` bundle layer extraction with proper `yq` queries
- Guards all `yq` expressions against missing/empty/null `layers` using yq's alternative operator (`//`), preventing non-zero exits under `pipefail`
- Adds automated test infrastructure (`scripts/test-bundle-parsing.sh`, `Makefile`, CI job) covering edge cases and real bundles
- Affects two locations in `publish-policy-oci.yml`: the discover job (root file extraction) and the content hashing step
- Affects one location in `cue-validate.yml`: the bundle layer existence check
- `yq` is pre-installed on `ubuntu-latest` runners — no additional setup needed

## Motivation

Raised in [PR #41 review](https://github.com/complytime/complytime-policies/pull/41#discussion_r3319064753) (LOW priority). The `grep` pattern works for the current simple bundle format but would silently break if bundles ever include comments, multi-line values, or non-standard whitespace.

## Changes

### `publish-policy-oci.yml`
- **Discover job**: `grep | tail | sed` → `yq -r '(.layers // []) | select(length > 0) | .[-1]'`
- **Hash step**: `grep | sed` → `yq -r '(.layers // [])[]'`

### `cue-validate.yml`
- **Layer existence check**: `grep | sed` → `yq -r '(.layers // [])[]'`
- **New CI job**: `test-bundle-parsing` runs `make test-bundle-parsing` on PRs
- **Path triggers**: expanded to include `.github/workflows/**` and `scripts/**`

### New files
- `scripts/test-bundle-parsing.sh` — 16 tests (synthetic edge cases + real bundles) under `pipefail`
- `Makefile` — `test-bundle-parsing` and `test` targets

## Pipefail safety

The raw `yq '.layers[-1]'` expression exits non-zero when `layers` is missing, null, or empty:

| Scenario | `.layers[-1]` (old) | `(.layers // []) \| select(length > 0) \| .[-1]` (fixed) |
|---|---|---|
| No `layers` key | exit 1 — crashes | exit 0, empty string |
| `layers: []` | exit 1 — crashes | exit 0, empty string |
| `layers:` (null) | exit 1 — crashes | exit 0, empty string |
| Valid layers | exit 0, correct | exit 0, correct |

## Test plan

- [x] Verify `yq -r '(.layers // []) | select(length > 0) | .[-1]' bundles/ampel-branch-protection.yaml` returns the correct root file
- [x] Verify `yq -r '(.layers // [])[]' bundles/ampel-branch-protection.yaml` returns all layer paths
- [x] All 3 expressions return empty/exit 0 for missing, null, and empty `layers` under `pipefail`
- [x] `make test-bundle-parsing` passes locally (16/16 tests)
- [ ] CI passes on the CUE validation workflow (includes new test-bundle-parsing job)