### PR TITLE
refactor!: rename ampel policy IDs to semantic slugs

### DIFF
--- a/governance/catalogs/ampel-branch-protection-catalog.yaml
+++ b/governance/catalogs/ampel-branch-protection-catalog.yaml
@@ -12,52 +12,52 @@ families:
       title: Source Code Protection
       description: Controls for protecting source code repositories via branch protection rules
 controls:
-    - id: BP-1
+    - id: pull-request-enforcement
       title: Require Pull Request Reviews
       objective: Ensure changes to protected branches go through a pull request process
       family: source-code
       assessment-requirements:
-          - id: BP-1.01
+          - id: require-pull-request
             text: Direct pushes to protected branches MUST be blocked
             applicability:
                 - GitHub repositories
                 - GitLab repositories
-    - id: BP-2
+    - id: approval-requirements
       title: Require Minimum Approvals
       objective: Pull requests to protected branches must have a minimum number of approvals
       family: source-code
       assessment-requirements:
-          - id: BP-2.01
+          - id: minimum-approvals
             text: Pull requests must require a minimum number of approvals
             applicability:
                 - GitHub repositories
                 - GitLab repositories
-    - id: BP-3
+    - id: force-push-restriction
       title: Restrict Force Pushes
       objective: Force pushes to protected branches must be blocked
       family: source-code
       assessment-requirements:
-          - id: BP-3.01
+          - id: block-force-push
             text: Force pushes to protected branches must be blocked
             applicability:
                 - GitHub repositories
                 - GitLab repositories
-    - id: BP-4
+    - id: admin-bypass-prevention
       title: Prevent Admin Bypass
       objective: Admin bypass of branch protection rules must be prevented
       family: source-code
       assessment-requirements:
-          - id: BP-4.01
+          - id: prevent-admin-bypass
             text: Admin bypass prevention must be enabled on protected branches
             applicability:
                 - GitHub repositories
                 - GitLab repositories
-    - id: BP-5
+    - id: code-owner-enforcement
       title: Require Code Owner Review
       objective: Code owner review must be required when CODEOWNERS file exists
       family: source-code
       assessment-requirements:
-          - id: BP-5.01
+          - id: require-code-owner-review
             text: Code owner review requirements must be enabled
             applicability:
                 - GitHub repositories

--- a/governance/policies/ampel-branch-protection-policy.yaml
+++ b/governance/policies/ampel-branch-protection-policy.yaml
@@ -30,7 +30,7 @@ imports:
         - reference-id: repo-branch-protection
 adherence:
     evaluation-methods:
-        - id: ampel-gate
+        - id: ampel-automated-evaluation
           type: Gate
           mode: Automated
           description: AMPEL automated branch protection evaluation
@@ -43,34 +43,34 @@ adherence:
           requirement-id: require-pull-request
           frequency: on-demand
           evaluation-methods:
-              - id: ampel-gate
+              - id: ampel-automated-evaluation
                 type: Gate
                 mode: Automated
         - id: minimum-approvals
           requirement-id: minimum-approvals
           frequency: on-demand
           evaluation-methods:
-              - id: ampel-gate
+              - id: ampel-automated-evaluation
                 type: Gate
                 mode: Automated
         - id: block-force-push
           requirement-id: block-force-push
           frequency: on-demand
           evaluation-methods:
-              - id: ampel-gate
+              - id: ampel-automated-evaluation
                 type: Gate
                 mode: Automated
         - id: prevent-admin-bypass
           requirement-id: prevent-admin-bypass
           frequency: on-demand
           evaluation-methods:
-              - id: ampel-gate
+              - id: ampel-automated-evaluation
                 type: Gate
                 mode: Automated
         - id: require-code-owner-review
           requirement-id: require-code-owner-review
           frequency: on-demand
           evaluation-methods:
-              - id: ampel-gate
+              - id: ampel-automated-evaluation
                 type: Gate
                 mode: Automated

--- a/governance/policies/ampel-branch-protection-policy.yaml
+++ b/governance/policies/ampel-branch-protection-policy.yaml
@@ -39,36 +39,36 @@ adherence:
               name: AMPEL
               type: Software
     assessment-plans:
-        - id: BP-1.01
-          requirement-id: BP-1.01
+        - id: require-pull-request
+          requirement-id: require-pull-request
           frequency: on-demand
           evaluation-methods:
               - id: ampel-gate
                 type: Gate
                 mode: Automated
-        - id: BP-2.01
-          requirement-id: BP-2.01
+        - id: minimum-approvals
+          requirement-id: minimum-approvals
           frequency: on-demand
           evaluation-methods:
               - id: ampel-gate
                 type: Gate
                 mode: Automated
-        - id: BP-3.01
-          requirement-id: BP-3.01
+        - id: block-force-push
+          requirement-id: block-force-push
           frequency: on-demand
           evaluation-methods:
               - id: ampel-gate
                 type: Gate
                 mode: Automated
-        - id: BP-4.01
-          requirement-id: BP-4.01
+        - id: prevent-admin-bypass
+          requirement-id: prevent-admin-bypass
           frequency: on-demand
           evaluation-methods:
               - id: ampel-gate
                 type: Gate
                 mode: Automated
-        - id: BP-5.01
-          requirement-id: BP-5.01
+        - id: require-code-owner-review
+          requirement-id: require-code-owner-review
           frequency: on-demand
           evaluation-methods:
               - id: ampel-gate


### PR DESCRIPTION
## Summary

Replace opaque positional IDs (`BP-X` / `BP-X.YY`) with self-documenting semantic slugs in the Gemara catalog and policy YAML files for the `ampel-branch-protection` bundle.

This is the **complytime-policies** leg of the coordinated rename across three repositories. The naming convention follows the Gemara semantic model: control IDs use **noun-phrases** (safeguard area), requirement IDs use **verb-phrases** (verifiable condition).

| Old Control ID | New Control ID | Old Requirement ID | New Requirement ID |
|---|---|---|---|
| `BP-1` | `pull-request-enforcement` | `BP-1.01` | `require-pull-request` |
| `BP-2` | `approval-requirements` | `BP-2.01` | `minimum-approvals` |
| `BP-3` | `force-push-restriction` | `BP-3.01` | `block-force-push` |
| `BP-4` | `admin-bypass-prevention` | `BP-4.01` | `prevent-admin-bypass` |
| `BP-5` | `code-owner-enforcement` | `BP-5.01` | `require-code-owner-review` |

| File | Changes |
|---|---|
| `governance/catalogs/ampel-branch-protection-catalog.yaml` | Control `id` and assessment-requirement `id` fields renamed |
| `governance/policies/ampel-branch-protection-policy.yaml` | Assessment plan `id` and `requirement-id` fields renamed |

No changes to titles, objectives, descriptions, applicability, or bundle structure.

**BREAKING CHANGE:** All control and assessment-requirement IDs in the `ampel-branch-protection` OCI bundle change. After this is merged and the bundle republished, consumers must use the new semantic IDs for policy matching.

## Related Issues

- Companion to [complytime/org-infra#296](https://github.com/complytime/org-infra/pull/296) (granular ampel policy JSON renames and directory restructuring -- merged)
- Companion to [complytime/complytime-providers#32](https://github.com/complytime/complytime-providers/pull/32) (testdata fixtures and `LoadGranularPolicies` recursive walking -- merged)

## Review Hints

- The change is purely an ID rename across two YAML files -- no structural, schema, or content changes. A side-by-side diff is the most efficient review approach.

- Validated the full `complyctl` pipeline (`get` -> `generate` -> `scan`) locally using the complyctl mock OCI registry with the updated Gemara YAML and the 5 granular policy JSON files from the org-infra branch:
  1. `complyctl get` -- fetched the updated bundle from the mock registry successfully.
  2. `complyctl generate` -- resolved all 5 requirements, matched all 5 granular policies by semantic ID, and produced the merged policy bundle. Execution plan confirmed: `Provider: ampel (healthy), Requirements: 5`.
  3. `complyctl scan` -- invoked the ampel provider correctly. Produced an expected `scan-error` due to the absence of a `GITHUB_TOKEN` (snappy needs it to call the GitHub API), but the policy matching and provider invocation worked end-to-end.

- For an alternative local testing approach, once [complytime/complyctl#538](https://github.com/complytime/complyctl/pull/538) is merged, the complyctl devcontainer will pre-populate its cache with local OCI Layout bundles, making it possible to test updated policies without a mock registry.