### PR TITLE
fix(governance): conform catalogs and policies to Gemara v1.2.0 CUE schema

### DIFF
--- a/.github/workflows/publish-policy-oci.yml
+++ b/.github/workflows/publish-policy-oci.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Publish bundle, sign, verify, and promote
         id: publish
         if: steps.gate.outputs.proceed == 'true'
-        uses: gemaraproj/gemara-registry-cli@f4f1cc6f03dbe9d8d80005eae1335b8f85f8bae7  # v0.1.0
+        uses: gemaraproj/gemara-publish-action@027e6093fc8f8f968f9cde814ebbae8c25add166  # v0.1.1
         with:
           registry: ghcr.io
           repository: ${{ steps.repos.outputs.ghcr_repo }}

--- a/governance/catalogs/ampel-branch-protection-catalog.yaml
+++ b/governance/catalogs/ampel-branch-protection-catalog.yaml
@@ -2,12 +2,20 @@ title: Branch Protection Controls
 metadata:
     id: repo-branch-protection
     type: ControlCatalog
+    gemara-version: "1.2.0"
     description: Branch protection controls for GitHub/GitLab repositories
     author:
         id: complytime
         name: ComplyTime
         type: Software Assisted
-families:
+    applicability-groups:
+        - id: github-repos
+          title: GitHub Repositories
+          description: GitHub-hosted repositories with branch protection support
+        - id: gitlab-repos
+          title: GitLab Repositories
+          description: GitLab-hosted repositories with branch protection support
+groups:
     - id: source-code
       title: Source Code Protection
       description: Controls for protecting source code repositories via branch protection rules
@@ -15,50 +23,60 @@ controls:
     - id: pull-request-enforcement
       title: Require Pull Request Reviews
       objective: Ensure changes to protected branches go through a pull request process
-      family: source-code
+      group: source-code
+      state: Active
       assessment-requirements:
           - id: require-pull-request
+            state: Active
             text: Direct pushes to protected branches MUST be blocked
             applicability:
-                - GitHub repositories
-                - GitLab repositories
+                - github-repos
+                - gitlab-repos
     - id: approval-requirements
       title: Require Minimum Approvals
       objective: Pull requests to protected branches must have a minimum number of approvals
-      family: source-code
+      group: source-code
+      state: Active
       assessment-requirements:
           - id: minimum-approvals
+            state: Active
             text: Pull requests must require a minimum number of approvals
             applicability:
-                - GitHub repositories
-                - GitLab repositories
+                - github-repos
+                - gitlab-repos
     - id: force-push-restriction
       title: Restrict Force Pushes
       objective: Force pushes to protected branches must be blocked
-      family: source-code
+      group: source-code
+      state: Active
       assessment-requirements:
           - id: block-force-push
+            state: Active
             text: Force pushes to protected branches must be blocked
             applicability:
-                - GitHub repositories
-                - GitLab repositories
+                - github-repos
+                - gitlab-repos
     - id: admin-bypass-prevention
       title: Prevent Admin Bypass
       objective: Admin bypass of branch protection rules must be prevented
-      family: source-code
+      group: source-code
+      state: Active
       assessment-requirements:
           - id: prevent-admin-bypass
+            state: Active
             text: Admin bypass prevention must be enabled on protected branches
             applicability:
-                - GitHub repositories
-                - GitLab repositories
+                - github-repos
+                - gitlab-repos
     - id: code-owner-enforcement
       title: Require Code Owner Review
       objective: Code owner review must be required when CODEOWNERS file exists
-      family: source-code
+      group: source-code
+      state: Active
       assessment-requirements:
           - id: require-code-owner-review
+            state: Active
             text: Code owner review requirements must be enabled
             applicability:
-                - GitHub repositories
-                - GitLab repositories
+                - github-repos
+                - gitlab-repos

--- a/governance/catalogs/cis-fedora-l1-server-catalog.yaml
+++ b/governance/catalogs/cis-fedora-l1-server-catalog.yaml
@@ -42,8 +42,10 @@ controls:
     title: Ensure Cramfs Kernel Module Is Not Available
     objective: Ensure Cramfs Kernel Module Is Not Available
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: kernel_module_cramfs_disabled
+        state: Active
         text: Cramfs Kernel Module Is Not Available MUST be verified
         applicability:
           - fedora-linux
@@ -51,8 +53,10 @@ controls:
     title: Ensure IEEE 1394 (FireWire) Kernel Module Is Not Available
     objective: Ensure IEEE 1394 (FireWire) Kernel Module Is Not Available
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: kernel_module_firewire-core_disabled
+        state: Active
         text: IEEE 1394 (FireWire) Kernel Module Is Not Available MUST be verified
         applicability:
           - fedora-linux
@@ -60,8 +64,10 @@ controls:
     title: Ensure USB Storage Driver Is Not Available
     objective: Ensure USB Storage Driver Is Not Available
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: kernel_module_usb-storage_disabled
+        state: Active
         text: USB Storage Driver Is Not Available MUST be verified
         applicability:
           - fedora-linux
@@ -69,8 +75,10 @@ controls:
     title: Ensure Freevxfs Kernel Module Is Not Available
     objective: Ensure Freevxfs Kernel Module Is Not Available
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: kernel_module_freevxfs_disabled
+        state: Active
         text: Freevxfs Kernel Module Is Not Available MUST be verified
         applicability:
           - fedora-linux
@@ -78,8 +86,10 @@ controls:
     title: Ensure Hfs Kernel Module Is Not Available
     objective: Ensure Hfs Kernel Module Is Not Available
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: kernel_module_hfs_disabled
+        state: Active
         text: Hfs Kernel Module Is Not Available MUST be verified
         applicability:
           - fedora-linux
@@ -87,8 +97,10 @@ controls:
     title: Ensure Hfsplus Kernel Module Is Not Available
     objective: Ensure Hfsplus Kernel Module Is Not Available
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: kernel_module_hfsplus_disabled
+        state: Active
         text: Hfsplus Kernel Module Is Not Available MUST be verified
         applicability:
           - fedora-linux
@@ -96,8 +108,10 @@ controls:
     title: Ensure Jffs2 Kernel Module Is Not Available
     objective: Ensure Jffs2 Kernel Module Is Not Available
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: kernel_module_jffs2_disabled
+        state: Active
         text: Jffs2 Kernel Module Is Not Available MUST be verified
         applicability:
           - fedora-linux
@@ -105,8 +119,10 @@ controls:
     title: CIS Fedora 1 - 1.2.1.1
     objective: CIS Fedora 1 - 1.2.1.1
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: partition_for_tmp
+        state: Active
         text: CIS Fedora 1 - 1.2.1.1 MUST be verified
         applicability:
           - fedora-linux
@@ -114,8 +130,10 @@ controls:
     title: CIS Fedora 1 - 1.2.1.2
     objective: CIS Fedora 1 - 1.2.1.2
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: mount_option_tmp_nodev
+        state: Active
         text: CIS Fedora 1 - 1.2.1.2 MUST be verified
         applicability:
           - fedora-linux
@@ -123,8 +141,10 @@ controls:
     title: CIS Fedora 1 - 1.2.1.3
     objective: CIS Fedora 1 - 1.2.1.3
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: mount_option_tmp_nosuid
+        state: Active
         text: CIS Fedora 1 - 1.2.1.3 MUST be verified
         applicability:
           - fedora-linux
@@ -132,8 +152,10 @@ controls:
     title: CIS Fedora 1 - 1.2.1.4
     objective: CIS Fedora 1 - 1.2.1.4
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: mount_option_tmp_noexec
+        state: Active
         text: CIS Fedora 1 - 1.2.1.4 MUST be verified
         applicability:
           - fedora-linux
@@ -141,8 +163,10 @@ controls:
     title: CIS Fedora 1 - 1.2.2.1
     objective: CIS Fedora 1 - 1.2.2.1
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: partition_for_dev_shm
+        state: Active
         text: CIS Fedora 1 - 1.2.2.1 MUST be verified
         applicability:
           - fedora-linux
@@ -150,8 +174,10 @@ controls:
     title: CIS Fedora 1 - 1.2.2.2
     objective: CIS Fedora 1 - 1.2.2.2
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: mount_option_dev_shm_nodev
+        state: Active
         text: CIS Fedora 1 - 1.2.2.2 MUST be verified
         applicability:
           - fedora-linux
@@ -159,8 +185,10 @@ controls:
     title: CIS Fedora 1 - 1.2.2.3
     objective: CIS Fedora 1 - 1.2.2.3
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: mount_option_dev_shm_nosuid
+        state: Active
         text: CIS Fedora 1 - 1.2.2.3 MUST be verified
         applicability:
           - fedora-linux
@@ -168,8 +196,10 @@ controls:
     title: CIS Fedora 1 - 1.2.2.4
     objective: CIS Fedora 1 - 1.2.2.4
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: mount_option_dev_shm_noexec
+        state: Active
         text: CIS Fedora 1 - 1.2.2.4 MUST be verified
         applicability:
           - fedora-linux
@@ -177,8 +207,10 @@ controls:
     title: CIS Fedora 1 - 1.2.3.2
     objective: CIS Fedora 1 - 1.2.3.2
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: mount_option_home_nodev
+        state: Active
         text: CIS Fedora 1 - 1.2.3.2 MUST be verified
         applicability:
           - fedora-linux
@@ -186,8 +218,10 @@ controls:
     title: CIS Fedora 1 - 1.2.3.3
     objective: CIS Fedora 1 - 1.2.3.3
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: mount_option_home_nosuid
+        state: Active
         text: CIS Fedora 1 - 1.2.3.3 MUST be verified
         applicability:
           - fedora-linux
@@ -195,8 +229,10 @@ controls:
     title: CIS Fedora 1 - 1.2.4.2
     objective: CIS Fedora 1 - 1.2.4.2
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: mount_option_var_nodev
+        state: Active
         text: CIS Fedora 1 - 1.2.4.2 MUST be verified
         applicability:
           - fedora-linux
@@ -204,8 +240,10 @@ controls:
     title: CIS Fedora 1 - 1.2.4.3
     objective: CIS Fedora 1 - 1.2.4.3
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: mount_option_var_nosuid
+        state: Active
         text: CIS Fedora 1 - 1.2.4.3 MUST be verified
         applicability:
           - fedora-linux
@@ -213,8 +251,10 @@ controls:
     title: CIS Fedora 1 - 1.2.5.2
     objective: CIS Fedora 1 - 1.2.5.2
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: mount_option_var_tmp_nodev
+        state: Active
         text: CIS Fedora 1 - 1.2.5.2 MUST be verified
         applicability:
           - fedora-linux
@@ -222,8 +262,10 @@ controls:
     title: CIS Fedora 1 - 1.2.5.3
     objective: CIS Fedora 1 - 1.2.5.3
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: mount_option_var_tmp_nosuid
+        state: Active
         text: CIS Fedora 1 - 1.2.5.3 MUST be verified
         applicability:
           - fedora-linux
@@ -231,8 +273,10 @@ controls:
     title: CIS Fedora 1 - 1.2.5.4
     objective: CIS Fedora 1 - 1.2.5.4
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: mount_option_var_tmp_noexec
+        state: Active
         text: CIS Fedora 1 - 1.2.5.4 MUST be verified
         applicability:
           - fedora-linux
@@ -240,8 +284,10 @@ controls:
     title: CIS Fedora 1 - 1.2.6.2
     objective: CIS Fedora 1 - 1.2.6.2
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: mount_option_var_log_nodev
+        state: Active
         text: CIS Fedora 1 - 1.2.6.2 MUST be verified
         applicability:
           - fedora-linux
@@ -249,8 +295,10 @@ controls:
     title: CIS Fedora 1 - 1.2.6.3
     objective: CIS Fedora 1 - 1.2.6.3
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: mount_option_var_log_nosuid
+        state: Active
         text: CIS Fedora 1 - 1.2.6.3 MUST be verified
         applicability:
           - fedora-linux
@@ -258,8 +306,10 @@ controls:
     title: CIS Fedora 1 - 1.2.6.4
     objective: CIS Fedora 1 - 1.2.6.4
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: mount_option_var_log_noexec
+        state: Active
         text: CIS Fedora 1 - 1.2.6.4 MUST be verified
         applicability:
           - fedora-linux
@@ -267,8 +317,10 @@ controls:
     title: CIS Fedora 1 - 1.2.7.2
     objective: CIS Fedora 1 - 1.2.7.2
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: mount_option_var_log_audit_nodev
+        state: Active
         text: CIS Fedora 1 - 1.2.7.2 MUST be verified
         applicability:
           - fedora-linux
@@ -276,8 +328,10 @@ controls:
     title: CIS Fedora 1 - 1.2.7.3
     objective: CIS Fedora 1 - 1.2.7.3
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: mount_option_var_log_audit_nosuid
+        state: Active
         text: CIS Fedora 1 - 1.2.7.3 MUST be verified
         applicability:
           - fedora-linux
@@ -285,8 +339,10 @@ controls:
     title: CIS Fedora 1 - 1.2.7.4
     objective: CIS Fedora 1 - 1.2.7.4
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: mount_option_var_log_audit_noexec
+        state: Active
         text: CIS Fedora 1 - 1.2.7.4 MUST be verified
         applicability:
           - fedora-linux
@@ -294,8 +350,10 @@ controls:
     title: Ensure Gpgcheck Is Configured
     objective: Ensure Gpgcheck Is Configured
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: ensure_gpgcheck_globally_activated
+        state: Active
         text: Gpgcheck Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -303,8 +361,10 @@ controls:
     title: Ensure Selinux Is Installed
     objective: Ensure Selinux Is Installed
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: package_libselinux_installed
+        state: Active
         text: Selinux Is Installed MUST be verified
         applicability:
           - fedora-linux
@@ -312,8 +372,10 @@ controls:
     title: Ensure Selinux Is Not Disabled In Bootloader Configuration
     objective: Ensure Selinux Is Not Disabled In Bootloader Configuration
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: grub2_enable_selinux
+        state: Active
         text: Selinux Is Not Disabled In Bootloader Configuration MUST be verified
         applicability:
           - fedora-linux
@@ -321,8 +383,10 @@ controls:
     title: Ensure Selinux Policy Is Configured
     objective: Ensure Selinux Policy Is Configured
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: selinux_policytype
+        state: Active
         text: Selinux Policy Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -330,8 +394,10 @@ controls:
     title: Ensure The Selinux Mode Is Not Disabled
     objective: Ensure The Selinux Mode Is Not Disabled
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: selinux_not_disabled
+        state: Active
         text: The Selinux Mode Is Not Disabled MUST be verified
         applicability:
           - fedora-linux
@@ -339,8 +405,10 @@ controls:
     title: Ensure The Setroubleshoot Package Is Not Installed
     objective: Ensure The Setroubleshoot Package Is Not Installed
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: package_setroubleshoot_removed
+        state: Active
         text: The Setroubleshoot Package Is Not Installed MUST be verified
         applicability:
           - fedora-linux
@@ -348,8 +416,10 @@ controls:
     title: Ensure The Mcs Translation Service (Mcstrans) Is Not Installed
     objective: Ensure The Mcs Translation Service (Mcstrans) Is Not Installed
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: package_mcstrans_removed
+        state: Active
         text: The Mcs Translation Service (Mcstrans) Is Not Installed MUST be verified
         applicability:
           - fedora-linux
@@ -357,8 +427,10 @@ controls:
     title: Ensure Bootloader Password Is Set
     objective: Ensure Bootloader Password Is Set
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: grub2_password
+        state: Active
         text: Bootloader Password Is Set MUST be verified
         applicability:
           - fedora-linux
@@ -366,8 +438,10 @@ controls:
     title: Ensure Core File Size Is Configured
     objective: Ensure Core File Size Is Configured
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: disable_users_coredumps
+        state: Active
         text: Core File Size Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -375,8 +449,10 @@ controls:
     title: Ensure Fs.Protected_Hardlinks Is Configured
     objective: Ensure Fs.Protected_Hardlinks Is Configured
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: sysctl_fs_protected_hardlinks
+        state: Active
         text: Fs.Protected_Hardlinks Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -384,8 +460,10 @@ controls:
     title: Ensure Fs.Protected_Symlinks Is Configured
     objective: Ensure Fs.Protected_Symlinks Is Configured
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: sysctl_fs_protected_symlinks
+        state: Active
         text: Fs.Protected_Symlinks Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -393,8 +471,10 @@ controls:
     title: Ensure Fs.Suid_Dumpable Is Configured
     objective: Ensure Fs.Suid_Dumpable Is Configured
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: sysctl_fs_suid_dumpable
+        state: Active
         text: Fs.Suid_Dumpable Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -402,8 +482,10 @@ controls:
     title: Ensure Kernel.Dmesg_Restrict Is Configured
     objective: Ensure Kernel.Dmesg_Restrict Is Configured
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: sysctl_kernel_dmesg_restrict
+        state: Active
         text: Kernel.Dmesg_Restrict Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -411,8 +493,10 @@ controls:
     title: Ensure Kernel.Kptr_Restrict Is Configured
     objective: Ensure Kernel.Kptr_Restrict Is Configured
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: sysctl_kernel_kptr_restrict
+        state: Active
         text: Kernel.Kptr_Restrict Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -420,8 +504,10 @@ controls:
     title: Ensure Kernel.Yama.Ptrace_Scope Is Configured
     objective: Ensure Kernel.Yama.Ptrace_Scope Is Configured
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: sysctl_kernel_yama_ptrace_scope
+        state: Active
         text: Kernel.Yama.Ptrace_Scope Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -429,8 +515,10 @@ controls:
     title: Ensure Kernel.Randomize_Va_Space Is Configured
     objective: Ensure Kernel.Randomize_Va_Space Is Configured
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: sysctl_kernel_randomize_va_space
+        state: Active
         text: Kernel.Randomize_Va_Space Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -438,8 +526,10 @@ controls:
     title: Ensure Systemd-Coredump Processsizemax Is Configured
     objective: Ensure Systemd-Coredump Processsizemax Is Configured
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: coredump_disable_backtraces
+        state: Active
         text: Systemd-Coredump Processsizemax Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -447,8 +537,10 @@ controls:
     title: Ensure Systemd-Coredump Storage Is Configured
     objective: Ensure Systemd-Coredump Storage Is Configured
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: coredump_disable_storage
+        state: Active
         text: Systemd-Coredump Storage Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -456,8 +548,10 @@ controls:
     title: Ensure System Wide Crypto Policy Disables Sha1 Hash And Signature Support
     objective: Ensure System Wide Crypto Policy Disables Sha1 Hash And Signature Support
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: cis_fedora_1-6.2-ar
+        state: Active
         text: System Wide Crypto Policy Disables Sha1 Hash And Signature Support MUST be verified
         applicability:
           - fedora-linux
@@ -465,8 +559,10 @@ controls:
     title: Ensure System Wide Crypto Policy Macs Are Configured
     objective: Ensure System Wide Crypto Policy Macs Are Configured
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: cis_fedora_1-6.3-ar
+        state: Active
         text: System Wide Crypto Policy Macs Are Configured MUST be verified
         applicability:
           - fedora-linux
@@ -474,8 +570,10 @@ controls:
     title: Ensure System Wide Crypto Policy Disables Cbc For Ssh
     objective: Ensure System Wide Crypto Policy Disables Cbc For Ssh
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: cis_fedora_1-6.4-ar
+        state: Active
         text: System Wide Crypto Policy Disables Cbc For Ssh MUST be verified
         applicability:
           - fedora-linux
@@ -483,8 +581,10 @@ controls:
     title: Ensure /Etc/Motd Is Configured
     objective: Ensure /Etc/Motd Is Configured
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: banner_etc_motd_cis
+        state: Active
         text: /Etc/Motd Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -492,8 +592,10 @@ controls:
     title: Ensure /Etc/Issue Is Configured
     objective: Ensure /Etc/Issue Is Configured
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: banner_etc_issue_cis
+        state: Active
         text: /Etc/Issue Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -501,8 +603,10 @@ controls:
     title: Ensure /Etc/Issue.Net Is Configured
     objective: Ensure /Etc/Issue.Net Is Configured
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: banner_etc_issue_net_cis
+        state: Active
         text: /Etc/Issue.Net Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -510,16 +614,20 @@ controls:
     title: Ensure Access To /Etc/Motd Is Configured
     objective: Ensure Access To /Etc/Motd Is Configured
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: file_groupowner_etc_motd
+        state: Active
         text: Access To /Etc/Motd Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_owner_etc_motd
+        state: Active
         text: Access To /Etc/Motd Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_permissions_etc_motd
+        state: Active
         text: Access To /Etc/Motd Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -527,16 +635,20 @@ controls:
     title: Ensure Access To /Etc/Issue Is Configured
     objective: Ensure Access To /Etc/Issue Is Configured
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: file_groupowner_etc_issue
+        state: Active
         text: Access To /Etc/Issue Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_owner_etc_issue
+        state: Active
         text: Access To /Etc/Issue Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_permissions_etc_issue
+        state: Active
         text: Access To /Etc/Issue Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -544,16 +656,20 @@ controls:
     title: Ensure Access To /Etc/Issue.Net Is Configured
     objective: Ensure Access To /Etc/Issue.Net Is Configured
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: file_groupowner_etc_issue_net
+        state: Active
         text: Access To /Etc/Issue.Net Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_owner_etc_issue_net
+        state: Active
         text: Access To /Etc/Issue.Net Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_permissions_etc_issue_net
+        state: Active
         text: Access To /Etc/Issue.Net Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -561,12 +677,15 @@ controls:
     title: Ensure Gdm Login Banner Is Configured
     objective: Ensure Gdm Login Banner Is Configured
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: dconf_gnome_banner_enabled
+        state: Active
         text: Gdm Login Banner Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: dconf_gnome_login_banner_text
+        state: Active
         text: Gdm Login Banner Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -574,8 +693,10 @@ controls:
     title: Ensure Gdm Disable-User-List Is Configured
     objective: Ensure Gdm Disable-User-List Is Configured
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: dconf_gnome_disable_user_list
+        state: Active
         text: Gdm Disable-User-List Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -583,20 +704,25 @@ controls:
     title: Ensure Gdm Screen Lock Is Configured
     objective: Ensure Gdm Screen Lock Is Configured
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: dconf_gnome_screensaver_idle_delay
+        state: Active
         text: Gdm Screen Lock Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: dconf_gnome_screensaver_lock_delay
+        state: Active
         text: Gdm Screen Lock Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: dconf_gnome_screensaver_user_locks
+        state: Active
         text: Gdm Screen Lock Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: dconf_gnome_session_idle_user_locks
+        state: Active
         text: Gdm Screen Lock Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -604,12 +730,15 @@ controls:
     title: Ensure GDM Automount Is Disabled
     objective: Ensure GDM Automount Is Disabled
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: dconf_gnome_disable_automount
+        state: Active
         text: GDM Automount Is Disabled MUST be verified
         applicability:
           - fedora-linux
       - id: dconf_gnome_disable_automount_open
+        state: Active
         text: GDM Automount Opening Is Disabled MUST be verified
         applicability:
           - fedora-linux
@@ -617,8 +746,10 @@ controls:
     title: Ensure Gdm Autorun-Never Is Configured
     objective: Ensure Gdm Autorun-Never Is Configured
     group: initial-setup
+    state: Active
     assessment-requirements:
       - id: dconf_gnome_disable_autorun
+        state: Active
         text: Gdm Autorun-Never Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -626,8 +757,10 @@ controls:
     title: Ensure Autofs Services Are Not In Use
     objective: Ensure Autofs Services Are Not In Use
     group: services
+    state: Active
     assessment-requirements:
       - id: service_autofs_disabled
+        state: Active
         text: Autofs Services Are Not In Use MUST be verified
         applicability:
           - fedora-linux
@@ -635,8 +768,10 @@ controls:
     title: Ensure Avahi Server Services Are Not In Use
     objective: Ensure Avahi Server Services Are Not In Use
     group: services
+    state: Active
     assessment-requirements:
       - id: service_avahi-daemon_disabled
+        state: Active
         text: Avahi Server Services Are Not In Use MUST be verified
         applicability:
           - fedora-linux
@@ -644,8 +779,10 @@ controls:
     title: Ensure Bluetooth Services Are Not In Use
     objective: Ensure Bluetooth Services Are Not In Use
     group: services
+    state: Active
     assessment-requirements:
       - id: service_bluetooth_disabled
+        state: Active
         text: Bluetooth Services Are Not In Use MUST be verified
         applicability:
           - fedora-linux
@@ -653,8 +790,10 @@ controls:
     title: Ensure Dhcp Server Services Are Not In Use
     objective: Ensure Dhcp Server Services Are Not In Use
     group: services
+    state: Active
     assessment-requirements:
       - id: package_kea_removed
+        state: Active
         text: Dhcp Server Services Are Not In Use MUST be verified
         applicability:
           - fedora-linux
@@ -662,8 +801,10 @@ controls:
     title: Ensure Dns Server Services Are Not In Use
     objective: Ensure Dns Server Services Are Not In Use
     group: services
+    state: Active
     assessment-requirements:
       - id: package_bind_removed
+        state: Active
         text: Dns Server Services Are Not In Use MUST be verified
         applicability:
           - fedora-linux
@@ -671,8 +812,10 @@ controls:
     title: Ensure Dnsmasq Services Are Not In Use
     objective: Ensure Dnsmasq Services Are Not In Use
     group: services
+    state: Active
     assessment-requirements:
       - id: package_dnsmasq_removed
+        state: Active
         text: Dnsmasq Services Are Not In Use MUST be verified
         applicability:
           - fedora-linux
@@ -680,8 +823,10 @@ controls:
     title: Ensure Ftp Server Services Are Not In Use
     objective: Ensure Ftp Server Services Are Not In Use
     group: services
+    state: Active
     assessment-requirements:
       - id: package_vsftpd_removed
+        state: Active
         text: Ftp Server Services Are Not In Use MUST be verified
         applicability:
           - fedora-linux
@@ -689,12 +834,15 @@ controls:
     title: Ensure Message Access Server Services Are Not In Use
     objective: Ensure Message Access Server Services Are Not In Use
     group: services
+    state: Active
     assessment-requirements:
       - id: package_cyrus-imapd_removed
+        state: Active
         text: Message Access Server Services Are Not In Use MUST be verified
         applicability:
           - fedora-linux
       - id: package_dovecot_removed
+        state: Active
         text: Message Access Server Services Are Not In Use MUST be verified
         applicability:
           - fedora-linux
@@ -702,8 +850,10 @@ controls:
     title: Ensure Network File System Services Are Not In Use
     objective: Ensure Network File System Services Are Not In Use
     group: services
+    state: Active
     assessment-requirements:
       - id: service_nfs_disabled
+        state: Active
         text: Network File System Services Are Not In Use MUST be verified
         applicability:
           - fedora-linux
@@ -711,8 +861,10 @@ controls:
     title: Ensure CUPS Services Are Not In Use
     objective: Ensure CUPS Services Are Not In Use
     group: services
+    state: Active
     assessment-requirements:
       - id: service_cups_disabled
+        state: Active
         text: CUPS Services Are Not In Use MUST be verified
         applicability:
           - fedora-linux
@@ -720,8 +872,10 @@ controls:
     title: Ensure Rpcbind Services Are Not In Use
     objective: Ensure Rpcbind Services Are Not In Use
     group: services
+    state: Active
     assessment-requirements:
       - id: service_rpcbind_disabled
+        state: Active
         text: Rpcbind Services Are Not In Use MUST be verified
         applicability:
           - fedora-linux
@@ -729,8 +883,10 @@ controls:
     title: Ensure Rsync Services Are Not In Use
     objective: Ensure Rsync Services Are Not In Use
     group: services
+    state: Active
     assessment-requirements:
       - id: package_rsync_removed
+        state: Active
         text: Rsync Services Are Not In Use MUST be verified
         applicability:
           - fedora-linux
@@ -738,8 +894,10 @@ controls:
     title: Ensure Samba File Server Services Are Not In Use
     objective: Ensure Samba File Server Services Are Not In Use
     group: services
+    state: Active
     assessment-requirements:
       - id: package_samba_removed
+        state: Active
         text: Samba File Server Services Are Not In Use MUST be verified
         applicability:
           - fedora-linux
@@ -747,8 +905,10 @@ controls:
     title: Ensure Snmp Services Are Not In Use
     objective: Ensure Snmp Services Are Not In Use
     group: services
+    state: Active
     assessment-requirements:
       - id: package_net-snmp_removed
+        state: Active
         text: Snmp Services Are Not In Use MUST be verified
         applicability:
           - fedora-linux
@@ -756,8 +916,10 @@ controls:
     title: Ensure Telnet Server Services Are Not In Use
     objective: Ensure Telnet Server Services Are Not In Use
     group: services
+    state: Active
     assessment-requirements:
       - id: package_telnet-server_removed
+        state: Active
         text: Telnet Server Services Are Not In Use MUST be verified
         applicability:
           - fedora-linux
@@ -765,8 +927,10 @@ controls:
     title: Ensure Tftp Server Services Are Not In Use
     objective: Ensure Tftp Server Services Are Not In Use
     group: services
+    state: Active
     assessment-requirements:
       - id: package_tftp-server_removed
+        state: Active
         text: Tftp Server Services Are Not In Use MUST be verified
         applicability:
           - fedora-linux
@@ -774,8 +938,10 @@ controls:
     title: Ensure Web Proxy Server Services Are Not In Use
     objective: Ensure Web Proxy Server Services Are Not In Use
     group: services
+    state: Active
     assessment-requirements:
       - id: package_squid_removed
+        state: Active
         text: Web Proxy Server Services Are Not In Use MUST be verified
         applicability:
           - fedora-linux
@@ -783,12 +949,15 @@ controls:
     title: Ensure Web Server Services Are Not In Use
     objective: Ensure Web Server Services Are Not In Use
     group: services
+    state: Active
     assessment-requirements:
       - id: package_httpd_removed
+        state: Active
         text: Web Server Services Are Not In Use MUST be verified
         applicability:
           - fedora-linux
       - id: package_nginx_removed
+        state: Active
         text: Web Server Services Are Not In Use MUST be verified
         applicability:
           - fedora-linux
@@ -796,12 +965,15 @@ controls:
     title: Ensure Mail Transfer Agents Are Configured For Local-Only Mode
     objective: Ensure Mail Transfer Agents Are Configured For Local-Only Mode
     group: services
+    state: Active
     assessment-requirements:
       - id: has_nonlocal_mta
+        state: Active
         text: Mail Transfer Agents Are Configured For Local-Only Mode MUST be verified
         applicability:
           - fedora-linux
       - id: postfix_network_listening_disabled
+        state: Active
         text: Mail Transfer Agents Are Configured For Local-Only Mode MUST be verified
         applicability:
           - fedora-linux
@@ -809,8 +981,10 @@ controls:
     title: Ensure Ftp Client Is Not Installed
     objective: Ensure Ftp Client Is Not Installed
     group: services
+    state: Active
     assessment-requirements:
       - id: package_ftp_removed
+        state: Active
         text: Ftp Client Is Not Installed MUST be verified
         applicability:
           - fedora-linux
@@ -818,8 +992,10 @@ controls:
     title: Ensure Telnet Client Is Not Installed
     objective: Ensure Telnet Client Is Not Installed
     group: services
+    state: Active
     assessment-requirements:
       - id: package_telnet_removed
+        state: Active
         text: Telnet Client Is Not Installed MUST be verified
         applicability:
           - fedora-linux
@@ -827,8 +1003,10 @@ controls:
     title: Ensure Tftp Client Is Not Installed
     objective: Ensure Tftp Client Is Not Installed
     group: services
+    state: Active
     assessment-requirements:
       - id: package_tftp_removed
+        state: Active
         text: Tftp Client Is Not Installed MUST be verified
         applicability:
           - fedora-linux
@@ -836,8 +1014,10 @@ controls:
     title: Ensure Chrony Is Configured
     objective: Ensure Chrony Is Configured
     group: services
+    state: Active
     assessment-requirements:
       - id: chronyd_specify_remote_server
+        state: Active
         text: Chrony Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -845,8 +1025,10 @@ controls:
     title: Ensure Chrony Is Not Run As The Root User
     objective: Ensure Chrony Is Not Run As The Root User
     group: services
+    state: Active
     assessment-requirements:
       - id: chronyd_run_as_chrony_user
+        state: Active
         text: Chrony Is Not Run As The Root User MUST be verified
         applicability:
           - fedora-linux
@@ -854,12 +1036,15 @@ controls:
     title: Ensure Cron Daemon Is Enabled And Active
     objective: Ensure Cron Daemon Is Enabled And Active
     group: services
+    state: Active
     assessment-requirements:
       - id: package_cron_installed
+        state: Active
         text: Cron Daemon Is Enabled And Active MUST be verified
         applicability:
           - fedora-linux
       - id: service_crond_enabled
+        state: Active
         text: Cron Daemon Is Enabled And Active MUST be verified
         applicability:
           - fedora-linux
@@ -867,16 +1052,20 @@ controls:
     title: Ensure Access To /Etc/Crontab Is Configured
     objective: Ensure Access To /Etc/Crontab Is Configured
     group: services
+    state: Active
     assessment-requirements:
       - id: file_groupowner_crontab
+        state: Active
         text: Access To /Etc/Crontab Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_owner_crontab
+        state: Active
         text: Access To /Etc/Crontab Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_permissions_crontab
+        state: Active
         text: Access To /Etc/Crontab Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -884,16 +1073,20 @@ controls:
     title: Ensure Access To /Etc/Cron.Hourly Is Configured
     objective: Ensure Access To /Etc/Cron.Hourly Is Configured
     group: services
+    state: Active
     assessment-requirements:
       - id: file_groupowner_cron_hourly
+        state: Active
         text: Access To /Etc/Cron.Hourly Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_owner_cron_hourly
+        state: Active
         text: Access To /Etc/Cron.Hourly Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_permissions_cron_hourly
+        state: Active
         text: Access To /Etc/Cron.Hourly Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -901,16 +1094,20 @@ controls:
     title: Ensure Access To /Etc/Cron.Daily Is Configured
     objective: Ensure Access To /Etc/Cron.Daily Is Configured
     group: services
+    state: Active
     assessment-requirements:
       - id: file_groupowner_cron_daily
+        state: Active
         text: Access To /Etc/Cron.Daily Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_owner_cron_daily
+        state: Active
         text: Access To /Etc/Cron.Daily Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_permissions_cron_daily
+        state: Active
         text: Access To /Etc/Cron.Daily Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -918,16 +1115,20 @@ controls:
     title: Ensure Access To /Etc/Cron.Weekly Is Configured
     objective: Ensure Access To /Etc/Cron.Weekly Is Configured
     group: services
+    state: Active
     assessment-requirements:
       - id: file_groupowner_cron_weekly
+        state: Active
         text: Access To /Etc/Cron.Weekly Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_owner_cron_weekly
+        state: Active
         text: Access To /Etc/Cron.Weekly Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_permissions_cron_weekly
+        state: Active
         text: Access To /Etc/Cron.Weekly Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -935,16 +1136,20 @@ controls:
     title: Ensure Access To /Etc/Cron.Monthly Is Configured
     objective: Ensure Access To /Etc/Cron.Monthly Is Configured
     group: services
+    state: Active
     assessment-requirements:
       - id: file_groupowner_cron_monthly
+        state: Active
         text: Access To /Etc/Cron.Monthly Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_owner_cron_monthly
+        state: Active
         text: Access To /Etc/Cron.Monthly Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_permissions_cron_monthly
+        state: Active
         text: Access To /Etc/Cron.Monthly Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -952,16 +1157,20 @@ controls:
     title: Ensure Access To /Etc/Cron.D Is Configured
     objective: Ensure Access To /Etc/Cron.D Is Configured
     group: services
+    state: Active
     assessment-requirements:
       - id: file_groupowner_cron_d
+        state: Active
         text: Access To /Etc/Cron.D Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_owner_cron_d
+        state: Active
         text: Access To /Etc/Cron.D Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_permissions_cron_d
+        state: Active
         text: Access To /Etc/Cron.D Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -969,24 +1178,30 @@ controls:
     title: Ensure Access To Crontab Is Configured
     objective: Ensure Access To Crontab Is Configured
     group: services
+    state: Active
     assessment-requirements:
       - id: file_cron_allow_exists
+        state: Active
         text: Access To Crontab Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_cron_deny_not_exist
+        state: Active
         text: Access To Crontab Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_groupowner_cron_allow
+        state: Active
         text: Access To Crontab Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_owner_cron_allow
+        state: Active
         text: Access To Crontab Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_permissions_cron_allow
+        state: Active
         text: Access To Crontab Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -994,20 +1209,25 @@ controls:
     title: Ensure Access To At Is Configured
     objective: Ensure Access To At Is Configured
     group: services
+    state: Active
     assessment-requirements:
       - id: file_at_deny_not_exist
+        state: Active
         text: Access To At Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_groupowner_at_allow
+        state: Active
         text: Access To At Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_owner_at_allow
+        state: Active
         text: Access To At Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_permissions_at_allow
+        state: Active
         text: Access To At Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1015,8 +1235,10 @@ controls:
     title: Ensure Wireless Interfaces Are Disabled
     objective: Ensure Wireless Interfaces Are Disabled
     group: network
+    state: Active
     assessment-requirements:
       - id: wireless_disable_interfaces
+        state: Active
         text: Wireless Interfaces Are Disabled MUST be verified
         applicability:
           - fedora-linux
@@ -1024,8 +1246,10 @@ controls:
     title: Ensure Atm Kernel Module Is Not Available
     objective: Ensure Atm Kernel Module Is Not Available
     group: network
+    state: Active
     assessment-requirements:
       - id: kernel_module_atm_disabled
+        state: Active
         text: Atm Kernel Module Is Not Available MUST be verified
         applicability:
           - fedora-linux
@@ -1033,8 +1257,10 @@ controls:
     title: Ensure Can Kernel Module Is Not Available
     objective: Ensure Can Kernel Module Is Not Available
     group: network
+    state: Active
     assessment-requirements:
       - id: kernel_module_can_disabled
+        state: Active
         text: Can Kernel Module Is Not Available MUST be verified
         applicability:
           - fedora-linux
@@ -1042,8 +1268,10 @@ controls:
     title: Ensure Dccp Kernel Module Is Not Available
     objective: Ensure Dccp Kernel Module Is Not Available
     group: network
+    state: Active
     assessment-requirements:
       - id: kernel_module_dccp_disabled
+        state: Active
         text: Dccp Kernel Module Is Not Available MUST be verified
         applicability:
           - fedora-linux
@@ -1051,8 +1279,10 @@ controls:
     title: Ensure Tipc Kernel Module Is Not Available
     objective: Ensure Tipc Kernel Module Is Not Available
     group: network
+    state: Active
     assessment-requirements:
       - id: kernel_module_tipc_disabled
+        state: Active
         text: Tipc Kernel Module Is Not Available MUST be verified
         applicability:
           - fedora-linux
@@ -1060,8 +1290,10 @@ controls:
     title: Ensure Rds Kernel Module Is Not Available
     objective: Ensure Rds Kernel Module Is Not Available
     group: network
+    state: Active
     assessment-requirements:
       - id: kernel_module_rds_disabled
+        state: Active
         text: Rds Kernel Module Is Not Available MUST be verified
         applicability:
           - fedora-linux
@@ -1069,8 +1301,10 @@ controls:
     title: Ensure Net.Ipv4.Conf.All.Send_Redirects Is Configured
     objective: Ensure Net.Ipv4.Conf.All.Send_Redirects Is Configured
     group: network
+    state: Active
     assessment-requirements:
       - id: sysctl_net_ipv4_conf_all_send_redirects
+        state: Active
         text: Net.Ipv4.Conf.All.Send_Redirects Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1078,8 +1312,10 @@ controls:
     title: Ensure Net.Ipv4.Conf.Default.Send_Redirects Is Configured
     objective: Ensure Net.Ipv4.Conf.Default.Send_Redirects Is Configured
     group: network
+    state: Active
     assessment-requirements:
       - id: sysctl_net_ipv4_conf_default_send_redirects
+        state: Active
         text: Net.Ipv4.Conf.Default.Send_Redirects Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1087,8 +1323,10 @@ controls:
     title: Ensure Net.Ipv4.Icmp_Ignore_Bogus_Error_Responses Is Configured
     objective: Ensure Net.Ipv4.Icmp_Ignore_Bogus_Error_Responses Is Configured
     group: network
+    state: Active
     assessment-requirements:
       - id: sysctl_net_ipv4_icmp_ignore_bogus_error_responses
+        state: Active
         text: Net.Ipv4.Icmp_Ignore_Bogus_Error_Responses Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1096,8 +1334,10 @@ controls:
     title: Ensure Net.Ipv4.Icmp_Echo_Ignore_Broadcasts Is Configured
     objective: Ensure Net.Ipv4.Icmp_Echo_Ignore_Broadcasts Is Configured
     group: network
+    state: Active
     assessment-requirements:
       - id: sysctl_net_ipv4_icmp_echo_ignore_broadcasts
+        state: Active
         text: Net.Ipv4.Icmp_Echo_Ignore_Broadcasts Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1105,8 +1345,10 @@ controls:
     title: Ensure Net.Ipv4.Conf.All.Accept_Redirects Is Configured
     objective: Ensure Net.Ipv4.Conf.All.Accept_Redirects Is Configured
     group: network
+    state: Active
     assessment-requirements:
       - id: sysctl_net_ipv4_conf_all_accept_redirects
+        state: Active
         text: Net.Ipv4.Conf.All.Accept_Redirects Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1114,8 +1356,10 @@ controls:
     title: Ensure Net.Ipv4.Conf.Default.Accept_Redirects Is Configured
     objective: Ensure Net.Ipv4.Conf.Default.Accept_Redirects Is Configured
     group: network
+    state: Active
     assessment-requirements:
       - id: sysctl_net_ipv4_conf_default_accept_redirects
+        state: Active
         text: Net.Ipv4.Conf.Default.Accept_Redirects Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1123,8 +1367,10 @@ controls:
     title: Ensure Net.Ipv4.Conf.All.Secure_Redirects Is Configured
     objective: Ensure Net.Ipv4.Conf.All.Secure_Redirects Is Configured
     group: network
+    state: Active
     assessment-requirements:
       - id: sysctl_net_ipv4_conf_all_secure_redirects
+        state: Active
         text: Net.Ipv4.Conf.All.Secure_Redirects Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1132,8 +1378,10 @@ controls:
     title: Ensure Net.Ipv4.Conf.Default.Secure_Redirects Is Configured
     objective: Ensure Net.Ipv4.Conf.Default.Secure_Redirects Is Configured
     group: network
+    state: Active
     assessment-requirements:
       - id: sysctl_net_ipv4_conf_default_secure_redirects
+        state: Active
         text: Net.Ipv4.Conf.Default.Secure_Redirects Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1141,8 +1389,10 @@ controls:
     title: Ensure Net.Ipv4.Conf.All.Rp_Filter Is Configured
     objective: Ensure Net.Ipv4.Conf.All.Rp_Filter Is Configured
     group: network
+    state: Active
     assessment-requirements:
       - id: sysctl_net_ipv4_conf_all_rp_filter
+        state: Active
         text: Net.Ipv4.Conf.All.Rp_Filter Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1150,8 +1400,10 @@ controls:
     title: Ensure Net.Ipv4.Conf.Default.Rp_Filter Is Configured
     objective: Ensure Net.Ipv4.Conf.Default.Rp_Filter Is Configured
     group: network
+    state: Active
     assessment-requirements:
       - id: sysctl_net_ipv4_conf_default_rp_filter
+        state: Active
         text: Net.Ipv4.Conf.Default.Rp_Filter Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1159,8 +1411,10 @@ controls:
     title: Ensure Net.Ipv4.Conf.All.Accept_Source_Route Is Configured
     objective: Ensure Net.Ipv4.Conf.All.Accept_Source_Route Is Configured
     group: network
+    state: Active
     assessment-requirements:
       - id: sysctl_net_ipv4_conf_all_accept_source_route
+        state: Active
         text: Net.Ipv4.Conf.All.Accept_Source_Route Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1168,8 +1422,10 @@ controls:
     title: Ensure Net.Ipv4.Conf.Default.Accept_Source_Route Is Configured
     objective: Ensure Net.Ipv4.Conf.Default.Accept_Source_Route Is Configured
     group: network
+    state: Active
     assessment-requirements:
       - id: sysctl_net_ipv4_conf_default_accept_source_route
+        state: Active
         text: Net.Ipv4.Conf.Default.Accept_Source_Route Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1177,8 +1433,10 @@ controls:
     title: Ensure Net.Ipv4.Conf.All.Log_Martians Is Configured
     objective: Ensure Net.Ipv4.Conf.All.Log_Martians Is Configured
     group: network
+    state: Active
     assessment-requirements:
       - id: sysctl_net_ipv4_conf_all_log_martians
+        state: Active
         text: Net.Ipv4.Conf.All.Log_Martians Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1186,8 +1444,10 @@ controls:
     title: Ensure Net.Ipv4.Conf.Default.Log_Martians Is Configured
     objective: Ensure Net.Ipv4.Conf.Default.Log_Martians Is Configured
     group: network
+    state: Active
     assessment-requirements:
       - id: sysctl_net_ipv4_conf_default_log_martians
+        state: Active
         text: Net.Ipv4.Conf.Default.Log_Martians Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1195,8 +1455,10 @@ controls:
     title: Ensure Net.Ipv4.Tcp_Syncookies Is Configured
     objective: Ensure Net.Ipv4.Tcp_Syncookies Is Configured
     group: network
+    state: Active
     assessment-requirements:
       - id: sysctl_net_ipv4_tcp_syncookies
+        state: Active
         text: Net.Ipv4.Tcp_Syncookies Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1204,8 +1466,10 @@ controls:
     title: Ensure Net.Ipv6.Conf.All.Forwarding Is Configured
     objective: Ensure Net.Ipv6.Conf.All.Forwarding Is Configured
     group: network
+    state: Active
     assessment-requirements:
       - id: sysctl_net_ipv6_conf_all_forwarding
+        state: Active
         text: Net.Ipv6.Conf.All.Forwarding Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1213,8 +1477,10 @@ controls:
     title: Ensure Net.Ipv6.Conf.All.Accept_Redirects Is Configured
     objective: Ensure Net.Ipv6.Conf.All.Accept_Redirects Is Configured
     group: network
+    state: Active
     assessment-requirements:
       - id: sysctl_net_ipv6_conf_all_accept_redirects
+        state: Active
         text: Net.Ipv6.Conf.All.Accept_Redirects Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1222,8 +1488,10 @@ controls:
     title: Ensure Net.Ipv6.Conf.Default.Accept_Redirects Is Configured
     objective: Ensure Net.Ipv6.Conf.Default.Accept_Redirects Is Configured
     group: network
+    state: Active
     assessment-requirements:
       - id: sysctl_net_ipv6_conf_default_accept_redirects
+        state: Active
         text: Net.Ipv6.Conf.Default.Accept_Redirects Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1231,8 +1499,10 @@ controls:
     title: Ensure Net.Ipv6.Conf.All.Accept_Source_Route Is Configured
     objective: Ensure Net.Ipv6.Conf.All.Accept_Source_Route Is Configured
     group: network
+    state: Active
     assessment-requirements:
       - id: sysctl_net_ipv6_conf_all_accept_source_route
+        state: Active
         text: Net.Ipv6.Conf.All.Accept_Source_Route Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1240,8 +1510,10 @@ controls:
     title: Ensure Net.Ipv6.Conf.Default.Accept_Source_Route Is Configured
     objective: Ensure Net.Ipv6.Conf.Default.Accept_Source_Route Is Configured
     group: network
+    state: Active
     assessment-requirements:
       - id: sysctl_net_ipv6_conf_default_accept_source_route
+        state: Active
         text: Net.Ipv6.Conf.Default.Accept_Source_Route Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1249,8 +1521,10 @@ controls:
     title: Ensure Net.Ipv6.Conf.All.Accept_Ra Is Configured
     objective: Ensure Net.Ipv6.Conf.All.Accept_Ra Is Configured
     group: network
+    state: Active
     assessment-requirements:
       - id: sysctl_net_ipv6_conf_all_accept_ra
+        state: Active
         text: Net.Ipv6.Conf.All.Accept_Ra Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1258,8 +1532,10 @@ controls:
     title: Ensure Net.Ipv6.Conf.Default.Accept_Ra Is Configured
     objective: Ensure Net.Ipv6.Conf.Default.Accept_Ra Is Configured
     group: network
+    state: Active
     assessment-requirements:
       - id: sysctl_net_ipv6_conf_default_accept_ra
+        state: Active
         text: Net.Ipv6.Conf.Default.Accept_Ra Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1267,8 +1543,10 @@ controls:
     title: Ensure Nftables Is Installed
     objective: Ensure Nftables Is Installed
     group: firewall
+    state: Active
     assessment-requirements:
       - id: package_nftables_installed
+        state: Active
         text: Nftables Is Installed MUST be verified
         applicability:
           - fedora-linux
@@ -1276,16 +1554,20 @@ controls:
     title: Ensure A Single Firewall Configuration Utility Is In Use
     objective: Ensure A Single Firewall Configuration Utility Is In Use
     group: firewall
+    state: Active
     assessment-requirements:
       - id: package_firewalld_installed
+        state: Active
         text: A Single Firewall Configuration Utility Is In Use MUST be verified
         applicability:
           - fedora-linux
       - id: service_firewalld_enabled
+        state: Active
         text: A Single Firewall Configuration Utility Is In Use MUST be verified
         applicability:
           - fedora-linux
       - id: service_nftables_disabled
+        state: Active
         text: A Single Firewall Configuration Utility Is In Use MUST be verified
         applicability:
           - fedora-linux
@@ -1293,12 +1575,15 @@ controls:
     title: Ensure Firewalld Loopback Traffic Is Configured
     objective: Ensure Firewalld Loopback Traffic Is Configured
     group: firewall
+    state: Active
     assessment-requirements:
       - id: firewalld_loopback_traffic_restricted
+        state: Active
         text: Firewalld Loopback Traffic Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: firewalld_loopback_traffic_trusted
+        state: Active
         text: Firewalld Loopback Traffic Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1306,16 +1591,20 @@ controls:
     title: Ensure Access To /Etc/Ssh/Sshd_Config Is Configured
     objective: Ensure Access To /Etc/Ssh/Sshd_Config Is Configured
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: file_groupowner_sshd_config
+        state: Active
         text: Access To /Etc/Ssh/Sshd_Config Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_owner_sshd_config
+        state: Active
         text: Access To /Etc/Ssh/Sshd_Config Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_permissions_sshd_config
+        state: Active
         text: Access To /Etc/Ssh/Sshd_Config Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1323,16 +1612,20 @@ controls:
     title: Ensure Access To Ssh Private Host Key Files Is Configured
     objective: Ensure Access To Ssh Private Host Key Files Is Configured
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: file_groupownership_sshd_private_key
+        state: Active
         text: Access To Ssh Private Host Key Files Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_ownership_sshd_private_key
+        state: Active
         text: Access To Ssh Private Host Key Files Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_permissions_sshd_private_key
+        state: Active
         text: Access To Ssh Private Host Key Files Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1340,16 +1633,20 @@ controls:
     title: Ensure Access To Ssh Public Host Key Files Is Configured
     objective: Ensure Access To Ssh Public Host Key Files Is Configured
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: file_groupownership_sshd_pub_key
+        state: Active
         text: Access To Ssh Public Host Key Files Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_ownership_sshd_pub_key
+        state: Active
         text: Access To Ssh Public Host Key Files Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_permissions_sshd_pub_key
+        state: Active
         text: Access To Ssh Public Host Key Files Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1357,8 +1654,10 @@ controls:
     title: Ensure Sshd Ciphers Are Configured
     objective: Ensure Sshd Ciphers Are Configured
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: cis_fedora_5-1.4-ar
+        state: Active
         text: Sshd Ciphers Are Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1366,8 +1665,10 @@ controls:
     title: Ensure Sshd Kexalgorithms Is Configured
     objective: Ensure Sshd Kexalgorithms Is Configured
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: cis_fedora_5-1.5-ar
+        state: Active
         text: Sshd Kexalgorithms Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1375,8 +1676,10 @@ controls:
     title: Ensure Sshd Macs Are Configured
     objective: Ensure Sshd Macs Are Configured
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: cis_fedora_5-1.6-ar
+        state: Active
         text: Sshd Macs Are Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1384,8 +1687,10 @@ controls:
     title: Ensure Sshd Access Is Configured
     objective: Ensure Sshd Access Is Configured
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: sshd_limit_user_access
+        state: Active
         text: Sshd Access Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1393,8 +1698,10 @@ controls:
     title: Ensure Sshd Banner Is Configured
     objective: Ensure Sshd Banner Is Configured
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: sshd_enable_warning_banner_net
+        state: Active
         text: Sshd Banner Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1402,12 +1709,15 @@ controls:
     title: Ensure Sshd Clientaliveinterval And Clientalivecountmax Are Configured
     objective: Ensure Sshd Clientaliveinterval And Clientalivecountmax Are Configured
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: sshd_set_idle_timeout
+        state: Active
         text: Sshd Clientaliveinterval And Clientalivecountmax Are Configured MUST be verified
         applicability:
           - fedora-linux
       - id: sshd_set_keepalive
+        state: Active
         text: Sshd Clientaliveinterval And Clientalivecountmax Are Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1415,8 +1725,10 @@ controls:
     title: Ensure Sshd Hostbasedauthentication Is Disabled
     objective: Ensure Sshd Hostbasedauthentication Is Disabled
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: disable_host_auth
+        state: Active
         text: Sshd Hostbasedauthentication Is Disabled MUST be verified
         applicability:
           - fedora-linux
@@ -1424,8 +1736,10 @@ controls:
     title: Ensure Sshd Ignorerhosts Is Enabled
     objective: Ensure Sshd Ignorerhosts Is Enabled
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: sshd_disable_rhosts
+        state: Active
         text: Sshd Ignorerhosts Is Enabled MUST be verified
         applicability:
           - fedora-linux
@@ -1433,8 +1747,10 @@ controls:
     title: Ensure Sshd Logingracetime Is Configured
     objective: Ensure Sshd Logingracetime Is Configured
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: sshd_set_login_grace_time
+        state: Active
         text: Sshd Logingracetime Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1442,8 +1758,10 @@ controls:
     title: Ensure Sshd Loglevel Is Configured
     objective: Ensure Sshd Loglevel Is Configured
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: sshd_set_loglevel_verbose
+        state: Active
         text: Sshd Loglevel Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1451,8 +1769,10 @@ controls:
     title: Ensure Sshd Maxauthtries Is Configured
     objective: Ensure Sshd Maxauthtries Is Configured
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: sshd_set_max_auth_tries
+        state: Active
         text: Sshd Maxauthtries Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1460,8 +1780,10 @@ controls:
     title: Ensure Sshd Maxstartups Is Configured
     objective: Ensure Sshd Maxstartups Is Configured
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: sshd_set_maxstartups
+        state: Active
         text: Sshd Maxstartups Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1469,8 +1791,10 @@ controls:
     title: Ensure Sshd Maxsessions Is Configured
     objective: Ensure Sshd Maxsessions Is Configured
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: sshd_set_max_sessions
+        state: Active
         text: Sshd Maxsessions Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1478,8 +1802,10 @@ controls:
     title: Ensure Sshd Permitemptypasswords Is Disabled
     objective: Ensure Sshd Permitemptypasswords Is Disabled
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: sshd_disable_empty_passwords
+        state: Active
         text: Sshd Permitemptypasswords Is Disabled MUST be verified
         applicability:
           - fedora-linux
@@ -1487,8 +1813,10 @@ controls:
     title: Ensure Sshd Permitrootlogin Is Disabled
     objective: Ensure Sshd Permitrootlogin Is Disabled
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: sshd_disable_root_login
+        state: Active
         text: Sshd Permitrootlogin Is Disabled MUST be verified
         applicability:
           - fedora-linux
@@ -1496,8 +1824,10 @@ controls:
     title: Ensure Sshd Permituserenvironment Is Disabled
     objective: Ensure Sshd Permituserenvironment Is Disabled
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: sshd_do_not_permit_user_env
+        state: Active
         text: Sshd Permituserenvironment Is Disabled MUST be verified
         applicability:
           - fedora-linux
@@ -1505,8 +1835,10 @@ controls:
     title: Ensure Sshd Usepam Is Enabled
     objective: Ensure Sshd Usepam Is Enabled
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: sshd_enable_pam
+        state: Active
         text: Sshd Usepam Is Enabled MUST be verified
         applicability:
           - fedora-linux
@@ -1514,8 +1846,10 @@ controls:
     title: Ensure Sudo Is Installed
     objective: Ensure Sudo Is Installed
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: package_sudo_installed
+        state: Active
         text: Sudo Is Installed MUST be verified
         applicability:
           - fedora-linux
@@ -1523,8 +1857,10 @@ controls:
     title: Ensure Sudo Commands Use Pty
     objective: Ensure Sudo Commands Use Pty
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: sudo_add_use_pty
+        state: Active
         text: Sudo Commands Use Pty MUST be verified
         applicability:
           - fedora-linux
@@ -1532,8 +1868,10 @@ controls:
     title: Ensure Sudo Log File Exists
     objective: Ensure Sudo Log File Exists
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: sudo_custom_logfile
+        state: Active
         text: Sudo Log File Exists MUST be verified
         applicability:
           - fedora-linux
@@ -1541,8 +1879,10 @@ controls:
     title: Ensure Re-Authentication For Privilege Escalation Is Not Disabled Globally
     objective: Ensure Re-Authentication For Privilege Escalation Is Not Disabled Globally
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: sudo_remove_no_authenticate
+        state: Active
         text: Re-Authentication For Privilege Escalation Is Not Disabled Globally MUST be verified
         applicability:
           - fedora-linux
@@ -1550,8 +1890,10 @@ controls:
     title: Ensure Sudo Timestamp_Timeout Is Configured
     objective: Ensure Sudo Timestamp_Timeout Is Configured
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: sudo_require_reauthentication
+        state: Active
         text: Sudo Timestamp_Timeout Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1559,12 +1901,15 @@ controls:
     title: Ensure Access To The Su Command Is Restricted
     objective: Ensure Access To The Su Command Is Restricted
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: ensure_pam_wheel_group_empty
+        state: Active
         text: Access To The Su Command Is Restricted MUST be verified
         applicability:
           - fedora-linux
       - id: use_pam_wheel_group_for_su
+        state: Active
         text: Access To The Su Command Is Restricted MUST be verified
         applicability:
           - fedora-linux
@@ -1572,8 +1917,10 @@ controls:
     title: Ensure Latest Version Of Libpwquality Is Installed
     objective: Ensure Latest Version Of Libpwquality Is Installed
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: package_pam_pwquality_installed
+        state: Active
         text: Latest Version Of Libpwquality Is Installed MUST be verified
         applicability:
           - fedora-linux
@@ -1581,12 +1928,15 @@ controls:
     title: Ensure Pam_Faillock Module Is Enabled
     objective: Ensure Pam_Faillock Module Is Enabled
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: account_password_pam_faillock_password_auth
+        state: Active
         text: Pam_Faillock Module Is Enabled MUST be verified
         applicability:
           - fedora-linux
       - id: account_password_pam_faillock_system_auth
+        state: Active
         text: Pam_Faillock Module Is Enabled MUST be verified
         applicability:
           - fedora-linux
@@ -1594,12 +1944,15 @@ controls:
     title: Ensure Pam_Pwquality Module Is Enabled
     objective: Ensure Pam_Pwquality Module Is Enabled
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: accounts_password_pam_pwquality_password_auth
+        state: Active
         text: Pam_Pwquality Module Is Enabled MUST be verified
         applicability:
           - fedora-linux
       - id: accounts_password_pam_pwquality_system_auth
+        state: Active
         text: Pam_Pwquality Module Is Enabled MUST be verified
         applicability:
           - fedora-linux
@@ -1607,8 +1960,10 @@ controls:
     title: CIS Fedora 5 - 3.3.1.1
     objective: CIS Fedora 5 - 3.3.1.1
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: accounts_passwords_pam_faillock_deny
+        state: Active
         text: CIS Fedora 5 - 3.3.1.1 MUST be verified
         applicability:
           - fedora-linux
@@ -1616,8 +1971,10 @@ controls:
     title: CIS Fedora 5 - 3.3.1.2
     objective: CIS Fedora 5 - 3.3.1.2
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: accounts_passwords_pam_faillock_unlock_time
+        state: Active
         text: CIS Fedora 5 - 3.3.1.2 MUST be verified
         applicability:
           - fedora-linux
@@ -1625,8 +1982,10 @@ controls:
     title: CIS Fedora 5 - 3.3.2.1
     objective: CIS Fedora 5 - 3.3.2.1
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: accounts_password_pam_difok
+        state: Active
         text: CIS Fedora 5 - 3.3.2.1 MUST be verified
         applicability:
           - fedora-linux
@@ -1634,8 +1993,10 @@ controls:
     title: CIS Fedora 5 - 3.3.2.2
     objective: CIS Fedora 5 - 3.3.2.2
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: accounts_password_pam_minlen
+        state: Active
         text: CIS Fedora 5 - 3.3.2.2 MUST be verified
         applicability:
           - fedora-linux
@@ -1643,8 +2004,10 @@ controls:
     title: CIS Fedora 5 - 3.3.2.3
     objective: CIS Fedora 5 - 3.3.2.3
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: accounts_password_pam_minclass
+        state: Active
         text: CIS Fedora 5 - 3.3.2.3 MUST be verified
         applicability:
           - fedora-linux
@@ -1652,8 +2015,10 @@ controls:
     title: CIS Fedora 5 - 3.3.2.4
     objective: CIS Fedora 5 - 3.3.2.4
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: accounts_password_pam_maxrepeat
+        state: Active
         text: CIS Fedora 5 - 3.3.2.4 MUST be verified
         applicability:
           - fedora-linux
@@ -1661,8 +2026,10 @@ controls:
     title: CIS Fedora 5 - 3.3.2.6
     objective: CIS Fedora 5 - 3.3.2.6
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: accounts_password_pam_dictcheck
+        state: Active
         text: CIS Fedora 5 - 3.3.2.6 MUST be verified
         applicability:
           - fedora-linux
@@ -1670,8 +2037,10 @@ controls:
     title: CIS Fedora 5 - 3.3.2.7
     objective: CIS Fedora 5 - 3.3.2.7
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: accounts_password_pam_enforce_root
+        state: Active
         text: CIS Fedora 5 - 3.3.2.7 MUST be verified
         applicability:
           - fedora-linux
@@ -1679,12 +2048,15 @@ controls:
     title: CIS Fedora 5 - 3.3.3.1
     objective: CIS Fedora 5 - 3.3.3.1
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: accounts_password_pam_pwhistory_remember_password_auth
+        state: Active
         text: CIS Fedora 5 - 3.3.3.1 MUST be verified
         applicability:
           - fedora-linux
       - id: accounts_password_pam_pwhistory_remember_system_auth
+        state: Active
         text: CIS Fedora 5 - 3.3.3.1 MUST be verified
         applicability:
           - fedora-linux
@@ -1692,8 +2064,10 @@ controls:
     title: CIS Fedora 5 - 3.3.4.1
     objective: CIS Fedora 5 - 3.3.4.1
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: no_empty_passwords
+        state: Active
         text: CIS Fedora 5 - 3.3.4.1 MUST be verified
         applicability:
           - fedora-linux
@@ -1701,12 +2075,15 @@ controls:
     title: CIS Fedora 5 - 3.3.4.3
     objective: CIS Fedora 5 - 3.3.4.3
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: set_password_hashing_algorithm_passwordauth
+        state: Active
         text: CIS Fedora 5 - 3.3.4.3 MUST be verified
         applicability:
           - fedora-linux
       - id: set_password_hashing_algorithm_systemauth
+        state: Active
         text: CIS Fedora 5 - 3.3.4.3 MUST be verified
         applicability:
           - fedora-linux
@@ -1714,12 +2091,15 @@ controls:
     title: Ensure Password Expiration Is Configured
     objective: Ensure Password Expiration Is Configured
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: accounts_maximum_age_login_defs
+        state: Active
         text: Password Expiration Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: accounts_password_set_max_life_existing
+        state: Active
         text: Password Expiration Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1727,12 +2107,15 @@ controls:
     title: Ensure Password Expiration Warning Days Is Configured
     objective: Ensure Password Expiration Warning Days Is Configured
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: accounts_password_set_warn_age_existing
+        state: Active
         text: Password Expiration Warning Days Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: accounts_password_warn_age_login_defs
+        state: Active
         text: Password Expiration Warning Days Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1740,8 +2123,10 @@ controls:
     title: Ensure Strong Password Hashing Algorithm Is Configured
     objective: Ensure Strong Password Hashing Algorithm Is Configured
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: set_password_hashing_algorithm_logindefs
+        state: Active
         text: Strong Password Hashing Algorithm Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1749,12 +2134,15 @@ controls:
     title: Ensure Inactive Password Lock Is Configured
     objective: Ensure Inactive Password Lock Is Configured
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: account_disable_post_pw_expiration
+        state: Active
         text: Inactive Password Lock Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: accounts_set_post_pw_existing
+        state: Active
         text: Inactive Password Lock Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1762,8 +2150,10 @@ controls:
     title: Ensure All Users Last Password Change Date Is In The Past
     objective: Ensure All Users Last Password Change Date Is In The Past
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: accounts_password_last_change_is_in_past
+        state: Active
         text: All Users Last Password Change Date Is In The Past MUST be verified
         applicability:
           - fedora-linux
@@ -1771,8 +2161,10 @@ controls:
     title: Ensure Root Is The Only Uid 0 Account
     objective: Ensure Root Is The Only Uid 0 Account
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: accounts_no_uid_except_zero
+        state: Active
         text: Root Is The Only Uid 0 Account MUST be verified
         applicability:
           - fedora-linux
@@ -1780,8 +2172,10 @@ controls:
     title: Ensure Root Is The Only Gid 0 Account
     objective: Ensure Root Is The Only Gid 0 Account
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: accounts_root_gid_zero
+        state: Active
         text: Root Is The Only Gid 0 Account MUST be verified
         applicability:
           - fedora-linux
@@ -1789,8 +2183,10 @@ controls:
     title: Ensure Root Account Access Is Controlled
     objective: Ensure Root Account Access Is Controlled
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: ensure_root_password_configured
+        state: Active
         text: Root Account Access Is Controlled MUST be verified
         applicability:
           - fedora-linux
@@ -1798,12 +2194,15 @@ controls:
     title: Ensure Root Path Integrity
     objective: Ensure Root Path Integrity
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: accounts_root_path_dirs_no_write
+        state: Active
         text: Root Path Integrity MUST be verified
         applicability:
           - fedora-linux
       - id: root_path_no_dot
+        state: Active
         text: Root Path Integrity MUST be verified
         applicability:
           - fedora-linux
@@ -1811,12 +2210,15 @@ controls:
     title: Ensure System Accounts Do Not Have A Valid Login Shell
     objective: Ensure System Accounts Do Not Have A Valid Login Shell
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: no_password_auth_for_systemaccounts
+        state: Active
         text: System Accounts Do Not Have A Valid Login Shell MUST be verified
         applicability:
           - fedora-linux
       - id: no_shelllogin_for_systemaccounts
+        state: Active
         text: System Accounts Do Not Have A Valid Login Shell MUST be verified
         applicability:
           - fedora-linux
@@ -1824,8 +2226,10 @@ controls:
     title: Ensure Default User Shell Timeout Is Configured
     objective: Ensure Default User Shell Timeout Is Configured
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: accounts_tmout
+        state: Active
         text: Default User Shell Timeout Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1833,16 +2237,20 @@ controls:
     title: Ensure Default User Umask Is Configured
     objective: Ensure Default User Umask Is Configured
     group: access-auth
+    state: Active
     assessment-requirements:
       - id: accounts_umask_etc_bashrc
+        state: Active
         text: Default User Umask Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: accounts_umask_etc_login_defs
+        state: Active
         text: Default User Umask Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: accounts_umask_etc_profile
+        state: Active
         text: Default User Umask Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1850,12 +2258,15 @@ controls:
     title: Ensure Aide Is Installed
     objective: Ensure Aide Is Installed
     group: logging
+    state: Active
     assessment-requirements:
       - id: aide_build_database
+        state: Active
         text: Aide Is Installed MUST be verified
         applicability:
           - fedora-linux
       - id: package_aide_installed
+        state: Active
         text: Aide Is Installed MUST be verified
         applicability:
           - fedora-linux
@@ -1863,8 +2274,10 @@ controls:
     title: Ensure Filesystem Integrity Is Regularly Checked
     objective: Ensure Filesystem Integrity Is Regularly Checked
     group: logging
+    state: Active
     assessment-requirements:
       - id: aide_periodic_cron_checking
+        state: Active
         text: Filesystem Integrity Is Regularly Checked MUST be verified
         applicability:
           - fedora-linux
@@ -1872,8 +2285,10 @@ controls:
     title: Ensure Cryptographic Mechanisms Are Used To Protect The Integrity Of Audit Tools
     objective: Ensure Cryptographic Mechanisms Are Used To Protect The Integrity Of Audit Tools
     group: logging
+    state: Active
     assessment-requirements:
       - id: aide_check_audit_tools
+        state: Active
         text: Cryptographic Mechanisms Are Used To Protect The Integrity Of Audit Tools MUST be verified
         applicability:
           - fedora-linux
@@ -1881,8 +2296,10 @@ controls:
     title: Ensure Journald Service Is Active
     objective: Ensure Journald Service Is Active
     group: logging
+    state: Active
     assessment-requirements:
       - id: service_systemd-journald_enabled
+        state: Active
         text: Journald Service Is Active MUST be verified
         applicability:
           - fedora-linux
@@ -1890,8 +2307,10 @@ controls:
     title: CIS Fedora 6 - 2.2.1.1
     objective: CIS Fedora 6 - 2.2.1.1
     group: logging
+    state: Active
     assessment-requirements:
       - id: package_systemd-journal-remote_installed
+        state: Active
         text: CIS Fedora 6 - 2.2.1.1 MUST be verified
         applicability:
           - fedora-linux
@@ -1899,8 +2318,10 @@ controls:
     title: CIS Fedora 6 - 2.2.1.4
     objective: CIS Fedora 6 - 2.2.1.4
     group: logging
+    state: Active
     assessment-requirements:
       - id: socket_systemd-journal-remote_disabled
+        state: Active
         text: CIS Fedora 6 - 2.2.1.4 MUST be verified
         applicability:
           - fedora-linux
@@ -1908,8 +2329,10 @@ controls:
     title: Ensure Journald Compress Is Configured
     objective: Ensure Journald Compress Is Configured
     group: logging
+    state: Active
     assessment-requirements:
       - id: journald_compress
+        state: Active
         text: Journald Compress Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1917,8 +2340,10 @@ controls:
     title: Ensure Journald Storage Is Configured
     objective: Ensure Journald Storage Is Configured
     group: logging
+    state: Active
     assessment-requirements:
       - id: journald_storage
+        state: Active
         text: Journald Storage Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1926,16 +2351,20 @@ controls:
     title: Ensure Access To All Logfiles Has Been Configured
     objective: Ensure Access To All Logfiles Has Been Configured
     group: logging
+    state: Active
     assessment-requirements:
       - id: rsyslog_files_groupownership
+        state: Active
         text: Access To All Logfiles Has Been Configured MUST be verified
         applicability:
           - fedora-linux
       - id: rsyslog_files_ownership
+        state: Active
         text: Access To All Logfiles Has Been Configured MUST be verified
         applicability:
           - fedora-linux
       - id: rsyslog_files_permissions
+        state: Active
         text: Access To All Logfiles Has Been Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1943,16 +2372,20 @@ controls:
     title: Ensure Access To /Etc/Passwd Is Configured
     objective: Ensure Access To /Etc/Passwd Is Configured
     group: maintenance
+    state: Active
     assessment-requirements:
       - id: file_groupowner_etc_passwd
+        state: Active
         text: Access To /Etc/Passwd Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_owner_etc_passwd
+        state: Active
         text: Access To /Etc/Passwd Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_permissions_etc_passwd
+        state: Active
         text: Access To /Etc/Passwd Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1960,16 +2393,20 @@ controls:
     title: Ensure Access To /Etc/Passwd- Is Configured
     objective: Ensure Access To /Etc/Passwd- Is Configured
     group: maintenance
+    state: Active
     assessment-requirements:
       - id: file_groupowner_backup_etc_passwd
+        state: Active
         text: Access To /Etc/Passwd- Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_owner_backup_etc_passwd
+        state: Active
         text: Access To /Etc/Passwd- Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_permissions_backup_etc_passwd
+        state: Active
         text: Access To /Etc/Passwd- Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1977,16 +2414,20 @@ controls:
     title: Ensure Access To /Etc/Group Is Configured
     objective: Ensure Access To /Etc/Group Is Configured
     group: maintenance
+    state: Active
     assessment-requirements:
       - id: file_groupowner_etc_group
+        state: Active
         text: Access To /Etc/Group Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_owner_etc_group
+        state: Active
         text: Access To /Etc/Group Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_permissions_etc_group
+        state: Active
         text: Access To /Etc/Group Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -1994,16 +2435,20 @@ controls:
     title: Ensure Access To /Etc/Group- Is Configured
     objective: Ensure Access To /Etc/Group- Is Configured
     group: maintenance
+    state: Active
     assessment-requirements:
       - id: file_groupowner_backup_etc_group
+        state: Active
         text: Access To /Etc/Group- Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_owner_backup_etc_group
+        state: Active
         text: Access To /Etc/Group- Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_permissions_backup_etc_group
+        state: Active
         text: Access To /Etc/Group- Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -2011,16 +2456,20 @@ controls:
     title: Ensure Access To /Etc/Shadow Is Configured
     objective: Ensure Access To /Etc/Shadow Is Configured
     group: maintenance
+    state: Active
     assessment-requirements:
       - id: file_groupowner_etc_shadow
+        state: Active
         text: Access To /Etc/Shadow Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_owner_etc_shadow
+        state: Active
         text: Access To /Etc/Shadow Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_permissions_etc_shadow
+        state: Active
         text: Access To /Etc/Shadow Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -2028,16 +2477,20 @@ controls:
     title: Ensure Access To /Etc/Shadow- Is Configured
     objective: Ensure Access To /Etc/Shadow- Is Configured
     group: maintenance
+    state: Active
     assessment-requirements:
       - id: file_groupowner_backup_etc_shadow
+        state: Active
         text: Access To /Etc/Shadow- Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_owner_backup_etc_shadow
+        state: Active
         text: Access To /Etc/Shadow- Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_permissions_backup_etc_shadow
+        state: Active
         text: Access To /Etc/Shadow- Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -2045,16 +2498,20 @@ controls:
     title: Ensure Access To /Etc/Gshadow Is Configured
     objective: Ensure Access To /Etc/Gshadow Is Configured
     group: maintenance
+    state: Active
     assessment-requirements:
       - id: file_groupowner_etc_gshadow
+        state: Active
         text: Access To /Etc/Gshadow Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_owner_etc_gshadow
+        state: Active
         text: Access To /Etc/Gshadow Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_permissions_etc_gshadow
+        state: Active
         text: Access To /Etc/Gshadow Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -2062,16 +2519,20 @@ controls:
     title: Ensure Access To /Etc/Gshadow- Is Configured
     objective: Ensure Access To /Etc/Gshadow- Is Configured
     group: maintenance
+    state: Active
     assessment-requirements:
       - id: file_groupowner_backup_etc_gshadow
+        state: Active
         text: Access To /Etc/Gshadow- Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_owner_backup_etc_gshadow
+        state: Active
         text: Access To /Etc/Gshadow- Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_permissions_backup_etc_gshadow
+        state: Active
         text: Access To /Etc/Gshadow- Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -2079,16 +2540,20 @@ controls:
     title: Ensure Access To /Etc/Shells Is Configured
     objective: Ensure Access To /Etc/Shells Is Configured
     group: maintenance
+    state: Active
     assessment-requirements:
       - id: file_groupowner_etc_shells
+        state: Active
         text: Access To /Etc/Shells Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_owner_etc_shells
+        state: Active
         text: Access To /Etc/Shells Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_permissions_etc_shells
+        state: Active
         text: Access To /Etc/Shells Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -2096,12 +2561,15 @@ controls:
     title: Ensure World Writable Files And Directories Are Secured
     objective: Ensure World Writable Files And Directories Are Secured
     group: maintenance
+    state: Active
     assessment-requirements:
       - id: dir_perms_world_writable_sticky_bits
+        state: Active
         text: World Writable Files And Directories Are Secured MUST be verified
         applicability:
           - fedora-linux
       - id: file_permissions_unauthorized_world_writable
+        state: Active
         text: World Writable Files And Directories Are Secured MUST be verified
         applicability:
           - fedora-linux
@@ -2109,8 +2577,10 @@ controls:
     title: Ensure Accounts In /Etc/Passwd Use Shadowed Passwords
     objective: Ensure Accounts In /Etc/Passwd Use Shadowed Passwords
     group: maintenance
+    state: Active
     assessment-requirements:
       - id: accounts_password_all_shadowed
+        state: Active
         text: Accounts In /Etc/Passwd Use Shadowed Passwords MUST be verified
         applicability:
           - fedora-linux
@@ -2118,8 +2588,10 @@ controls:
     title: Ensure /Etc/Shadow Password Fields Are Not Empty
     objective: Ensure /Etc/Shadow Password Fields Are Not Empty
     group: maintenance
+    state: Active
     assessment-requirements:
       - id: no_empty_passwords_etc_shadow
+        state: Active
         text: /Etc/Shadow Password Fields Are Not Empty MUST be verified
         applicability:
           - fedora-linux
@@ -2127,8 +2599,10 @@ controls:
     title: Ensure All Groups In /Etc/Passwd Exist In /Etc/Group
     objective: Ensure All Groups In /Etc/Passwd Exist In /Etc/Group
     group: maintenance
+    state: Active
     assessment-requirements:
       - id: gid_passwd_group_same
+        state: Active
         text: All Groups In /Etc/Passwd Exist In /Etc/Group MUST be verified
         applicability:
           - fedora-linux
@@ -2136,8 +2610,10 @@ controls:
     title: Ensure No Duplicate Uids Exist
     objective: Ensure No Duplicate Uids Exist
     group: maintenance
+    state: Active
     assessment-requirements:
       - id: account_unique_id
+        state: Active
         text: No Duplicate Uids Exist MUST be verified
         applicability:
           - fedora-linux
@@ -2145,8 +2621,10 @@ controls:
     title: Ensure No Duplicate Gids Exist
     objective: Ensure No Duplicate Gids Exist
     group: maintenance
+    state: Active
     assessment-requirements:
       - id: group_unique_id
+        state: Active
         text: No Duplicate Gids Exist MUST be verified
         applicability:
           - fedora-linux
@@ -2154,8 +2632,10 @@ controls:
     title: Ensure No Duplicate User Names Exist
     objective: Ensure No Duplicate User Names Exist
     group: maintenance
+    state: Active
     assessment-requirements:
       - id: account_unique_name
+        state: Active
         text: No Duplicate User Names Exist MUST be verified
         applicability:
           - fedora-linux
@@ -2163,8 +2643,10 @@ controls:
     title: Ensure No Duplicate Group Names Exist
     objective: Ensure No Duplicate Group Names Exist
     group: maintenance
+    state: Active
     assessment-requirements:
       - id: group_unique_name
+        state: Active
         text: No Duplicate Group Names Exist MUST be verified
         applicability:
           - fedora-linux
@@ -2172,16 +2654,20 @@ controls:
     title: Ensure Local Interactive User Home Directories Are Configured
     objective: Ensure Local Interactive User Home Directories Are Configured
     group: maintenance
+    state: Active
     assessment-requirements:
       - id: accounts_user_interactive_home_directory_exists
+        state: Active
         text: Local Interactive User Home Directories Are Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_ownership_home_directories
+        state: Active
         text: Local Interactive User Home Directories Are Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_permissions_home_directories
+        state: Active
         text: Local Interactive User Home Directories Are Configured MUST be verified
         applicability:
           - fedora-linux
@@ -2189,24 +2675,30 @@ controls:
     title: Ensure Local Interactive User Dot Files Access Is Configured
     objective: Ensure Local Interactive User Dot Files Access Is Configured
     group: maintenance
+    state: Active
     assessment-requirements:
       - id: accounts_user_dot_group_ownership
+        state: Active
         text: Local Interactive User Dot Files Access Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: accounts_user_dot_user_ownership
+        state: Active
         text: Local Interactive User Dot Files Access Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: file_permission_user_init_files
+        state: Active
         text: Local Interactive User Dot Files Access Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: no_forward_files
+        state: Active
         text: Local Interactive User Dot Files Access Is Configured MUST be verified
         applicability:
           - fedora-linux
       - id: no_netrc_files
+        state: Active
         text: Local Interactive User Dot Files Access Is Configured MUST be verified
         applicability:
           - fedora-linux
@@ -2214,8 +2706,10 @@ controls:
     title: Reload Dconf Database
     objective: Reload Dconf Database
     group: operations
+    state: Active
     assessment-requirements:
       - id: dconf_db_up_to_date
+        state: Active
         text: The dconf database MUST be reloaded after configuration changes
         applicability:
           - fedora-linux

--- a/governance/catalogs/cis-fedora-l1-workstation-catalog.yaml
+++ b/governance/catalogs/cis-fedora-l1-workstation-catalog.yaml
@@ -42,8 +42,10 @@ controls:
       title: Ensure Cramfs Kernel Module Is Not Available
       objective: Ensure Cramfs Kernel Module Is Not Available
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: kernel_module_cramfs_disabled
+            state: Active
             text: Cramfs Kernel Module Is Not Available MUST be verified
             applicability:
                 - fedora-linux
@@ -51,8 +53,10 @@ controls:
       title: Ensure Freevxfs Kernel Module Is Not Available
       objective: Ensure Freevxfs Kernel Module Is Not Available
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: kernel_module_freevxfs_disabled
+            state: Active
             text: Freevxfs Kernel Module Is Not Available MUST be verified
             applicability:
                 - fedora-linux
@@ -60,8 +64,10 @@ controls:
       title: Ensure Hfs Kernel Module Is Not Available
       objective: Ensure Hfs Kernel Module Is Not Available
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: kernel_module_hfs_disabled
+            state: Active
             text: Hfs Kernel Module Is Not Available MUST be verified
             applicability:
                 - fedora-linux
@@ -69,8 +75,10 @@ controls:
       title: Ensure Hfsplus Kernel Module Is Not Available
       objective: Ensure Hfsplus Kernel Module Is Not Available
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: kernel_module_hfsplus_disabled
+            state: Active
             text: Hfsplus Kernel Module Is Not Available MUST be verified
             applicability:
                 - fedora-linux
@@ -78,8 +86,10 @@ controls:
       title: Ensure Jffs2 Kernel Module Is Not Available
       objective: Ensure Jffs2 Kernel Module Is Not Available
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: kernel_module_jffs2_disabled
+            state: Active
             text: Jffs2 Kernel Module Is Not Available MUST be verified
             applicability:
                 - fedora-linux
@@ -87,8 +97,10 @@ controls:
       title: CIS Fedora 1 - 1.2.1.1
       objective: CIS Fedora 1 - 1.2.1.1
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: partition_for_tmp
+            state: Active
             text: CIS Fedora 1 - 1.2.1.1 MUST be verified
             applicability:
                 - fedora-linux
@@ -96,8 +108,10 @@ controls:
       title: CIS Fedora 1 - 1.2.1.2
       objective: CIS Fedora 1 - 1.2.1.2
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: mount_option_tmp_nodev
+            state: Active
             text: CIS Fedora 1 - 1.2.1.2 MUST be verified
             applicability:
                 - fedora-linux
@@ -105,8 +119,10 @@ controls:
       title: CIS Fedora 1 - 1.2.1.3
       objective: CIS Fedora 1 - 1.2.1.3
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: mount_option_tmp_nosuid
+            state: Active
             text: CIS Fedora 1 - 1.2.1.3 MUST be verified
             applicability:
                 - fedora-linux
@@ -114,8 +130,10 @@ controls:
       title: CIS Fedora 1 - 1.2.1.4
       objective: CIS Fedora 1 - 1.2.1.4
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: mount_option_tmp_noexec
+            state: Active
             text: CIS Fedora 1 - 1.2.1.4 MUST be verified
             applicability:
                 - fedora-linux
@@ -123,8 +141,10 @@ controls:
       title: CIS Fedora 1 - 1.2.2.1
       objective: CIS Fedora 1 - 1.2.2.1
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: partition_for_dev_shm
+            state: Active
             text: CIS Fedora 1 - 1.2.2.1 MUST be verified
             applicability:
                 - fedora-linux
@@ -132,8 +152,10 @@ controls:
       title: CIS Fedora 1 - 1.2.2.2
       objective: CIS Fedora 1 - 1.2.2.2
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: mount_option_dev_shm_nodev
+            state: Active
             text: CIS Fedora 1 - 1.2.2.2 MUST be verified
             applicability:
                 - fedora-linux
@@ -141,8 +163,10 @@ controls:
       title: CIS Fedora 1 - 1.2.2.3
       objective: CIS Fedora 1 - 1.2.2.3
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: mount_option_dev_shm_nosuid
+            state: Active
             text: CIS Fedora 1 - 1.2.2.3 MUST be verified
             applicability:
                 - fedora-linux
@@ -150,8 +174,10 @@ controls:
       title: CIS Fedora 1 - 1.2.2.4
       objective: CIS Fedora 1 - 1.2.2.4
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: mount_option_dev_shm_noexec
+            state: Active
             text: CIS Fedora 1 - 1.2.2.4 MUST be verified
             applicability:
                 - fedora-linux
@@ -159,8 +185,10 @@ controls:
       title: CIS Fedora 1 - 1.2.3.2
       objective: CIS Fedora 1 - 1.2.3.2
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: mount_option_home_nodev
+            state: Active
             text: CIS Fedora 1 - 1.2.3.2 MUST be verified
             applicability:
                 - fedora-linux
@@ -168,8 +196,10 @@ controls:
       title: CIS Fedora 1 - 1.2.3.3
       objective: CIS Fedora 1 - 1.2.3.3
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: mount_option_home_nosuid
+            state: Active
             text: CIS Fedora 1 - 1.2.3.3 MUST be verified
             applicability:
                 - fedora-linux
@@ -177,8 +207,10 @@ controls:
       title: CIS Fedora 1 - 1.2.4.2
       objective: CIS Fedora 1 - 1.2.4.2
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: mount_option_var_nodev
+            state: Active
             text: CIS Fedora 1 - 1.2.4.2 MUST be verified
             applicability:
                 - fedora-linux
@@ -186,8 +218,10 @@ controls:
       title: CIS Fedora 1 - 1.2.4.3
       objective: CIS Fedora 1 - 1.2.4.3
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: mount_option_var_nosuid
+            state: Active
             text: CIS Fedora 1 - 1.2.4.3 MUST be verified
             applicability:
                 - fedora-linux
@@ -195,8 +229,10 @@ controls:
       title: CIS Fedora 1 - 1.2.5.2
       objective: CIS Fedora 1 - 1.2.5.2
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: mount_option_var_tmp_nodev
+            state: Active
             text: CIS Fedora 1 - 1.2.5.2 MUST be verified
             applicability:
                 - fedora-linux
@@ -204,8 +240,10 @@ controls:
       title: CIS Fedora 1 - 1.2.5.3
       objective: CIS Fedora 1 - 1.2.5.3
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: mount_option_var_tmp_nosuid
+            state: Active
             text: CIS Fedora 1 - 1.2.5.3 MUST be verified
             applicability:
                 - fedora-linux
@@ -213,8 +251,10 @@ controls:
       title: CIS Fedora 1 - 1.2.5.4
       objective: CIS Fedora 1 - 1.2.5.4
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: mount_option_var_tmp_noexec
+            state: Active
             text: CIS Fedora 1 - 1.2.5.4 MUST be verified
             applicability:
                 - fedora-linux
@@ -222,8 +262,10 @@ controls:
       title: CIS Fedora 1 - 1.2.6.2
       objective: CIS Fedora 1 - 1.2.6.2
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: mount_option_var_log_nodev
+            state: Active
             text: CIS Fedora 1 - 1.2.6.2 MUST be verified
             applicability:
                 - fedora-linux
@@ -231,8 +273,10 @@ controls:
       title: CIS Fedora 1 - 1.2.6.3
       objective: CIS Fedora 1 - 1.2.6.3
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: mount_option_var_log_nosuid
+            state: Active
             text: CIS Fedora 1 - 1.2.6.3 MUST be verified
             applicability:
                 - fedora-linux
@@ -240,8 +284,10 @@ controls:
       title: CIS Fedora 1 - 1.2.6.4
       objective: CIS Fedora 1 - 1.2.6.4
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: mount_option_var_log_noexec
+            state: Active
             text: CIS Fedora 1 - 1.2.6.4 MUST be verified
             applicability:
                 - fedora-linux
@@ -249,8 +295,10 @@ controls:
       title: CIS Fedora 1 - 1.2.7.2
       objective: CIS Fedora 1 - 1.2.7.2
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: mount_option_var_log_audit_nodev
+            state: Active
             text: CIS Fedora 1 - 1.2.7.2 MUST be verified
             applicability:
                 - fedora-linux
@@ -258,8 +306,10 @@ controls:
       title: CIS Fedora 1 - 1.2.7.3
       objective: CIS Fedora 1 - 1.2.7.3
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: mount_option_var_log_audit_nosuid
+            state: Active
             text: CIS Fedora 1 - 1.2.7.3 MUST be verified
             applicability:
                 - fedora-linux
@@ -267,8 +317,10 @@ controls:
       title: CIS Fedora 1 - 1.2.7.4
       objective: CIS Fedora 1 - 1.2.7.4
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: mount_option_var_log_audit_noexec
+            state: Active
             text: CIS Fedora 1 - 1.2.7.4 MUST be verified
             applicability:
                 - fedora-linux
@@ -276,8 +328,10 @@ controls:
       title: Ensure Gpgcheck Is Configured
       objective: Ensure Gpgcheck Is Configured
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: ensure_gpgcheck_globally_activated
+            state: Active
             text: Gpgcheck Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -285,8 +339,10 @@ controls:
       title: Ensure Selinux Is Installed
       objective: Ensure Selinux Is Installed
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: package_libselinux_installed
+            state: Active
             text: Selinux Is Installed MUST be verified
             applicability:
                 - fedora-linux
@@ -294,8 +350,10 @@ controls:
       title: Ensure Selinux Is Not Disabled In Bootloader Configuration
       objective: Ensure Selinux Is Not Disabled In Bootloader Configuration
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: grub2_enable_selinux
+            state: Active
             text: Selinux Is Not Disabled In Bootloader Configuration MUST be verified
             applicability:
                 - fedora-linux
@@ -303,8 +361,10 @@ controls:
       title: Ensure Selinux Policy Is Configured
       objective: Ensure Selinux Policy Is Configured
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: selinux_policytype
+            state: Active
             text: Selinux Policy Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -312,8 +372,10 @@ controls:
       title: Ensure The Selinux Mode Is Not Disabled
       objective: Ensure The Selinux Mode Is Not Disabled
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: selinux_not_disabled
+            state: Active
             text: The Selinux Mode Is Not Disabled MUST be verified
             applicability:
                 - fedora-linux
@@ -321,8 +383,10 @@ controls:
       title: Ensure The Mcs Translation Service (Mcstrans) Is Not Installed
       objective: Ensure The Mcs Translation Service (Mcstrans) Is Not Installed
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: package_mcstrans_removed
+            state: Active
             text: The Mcs Translation Service (Mcstrans) Is Not Installed MUST be verified
             applicability:
                 - fedora-linux
@@ -330,8 +394,10 @@ controls:
       title: Ensure Bootloader Password Is Set
       objective: Ensure Bootloader Password Is Set
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: grub2_password
+            state: Active
             text: Bootloader Password Is Set MUST be verified
             applicability:
                 - fedora-linux
@@ -339,8 +405,10 @@ controls:
       title: Ensure Core File Size Is Configured
       objective: Ensure Core File Size Is Configured
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: disable_users_coredumps
+            state: Active
             text: Core File Size Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -348,8 +416,10 @@ controls:
       title: Ensure Systemd-Coredump Storage Is Configured
       objective: Ensure Systemd-Coredump Storage Is Configured
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: coredump_disable_storage
+            state: Active
             text: Systemd-Coredump Storage Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -357,8 +427,10 @@ controls:
       title: Ensure Fs.Protected_Hardlinks Is Configured
       objective: Ensure Fs.Protected_Hardlinks Is Configured
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: sysctl_fs_protected_hardlinks
+            state: Active
             text: Fs.Protected_Hardlinks Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -366,8 +438,10 @@ controls:
       title: Ensure Fs.Protected_Symlinks Is Configured
       objective: Ensure Fs.Protected_Symlinks Is Configured
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: sysctl_fs_protected_symlinks
+            state: Active
             text: Fs.Protected_Symlinks Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -375,8 +449,10 @@ controls:
       title: Ensure Fs.Suid_Dumpable Is Configured
       objective: Ensure Fs.Suid_Dumpable Is Configured
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: sysctl_fs_suid_dumpable
+            state: Active
             text: Fs.Suid_Dumpable Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -384,8 +460,10 @@ controls:
       title: Ensure Kernel.Dmesg_Restrict Is Configured
       objective: Ensure Kernel.Dmesg_Restrict Is Configured
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: sysctl_kernel_dmesg_restrict
+            state: Active
             text: Kernel.Dmesg_Restrict Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -393,8 +471,10 @@ controls:
       title: Ensure Kernel.Kptr_Restrict Is Configured
       objective: Ensure Kernel.Kptr_Restrict Is Configured
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: sysctl_kernel_kptr_restrict
+            state: Active
             text: Kernel.Kptr_Restrict Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -402,8 +482,10 @@ controls:
       title: Ensure Kernel.Yama.Ptrace_Scope Is Configured
       objective: Ensure Kernel.Yama.Ptrace_Scope Is Configured
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: sysctl_kernel_yama_ptrace_scope
+            state: Active
             text: Kernel.Yama.Ptrace_Scope Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -411,8 +493,10 @@ controls:
       title: Ensure Kernel.Randomize_Va_Space Is Configured
       objective: Ensure Kernel.Randomize_Va_Space Is Configured
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: sysctl_kernel_randomize_va_space
+            state: Active
             text: Kernel.Randomize_Va_Space Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -420,8 +504,10 @@ controls:
       title: Ensure Systemd-Coredump Processsizemax Is Configured
       objective: Ensure Systemd-Coredump Processsizemax Is Configured
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: coredump_disable_backtraces
+            state: Active
             text: Systemd-Coredump Processsizemax Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -429,8 +515,10 @@ controls:
       title: Ensure System Wide Crypto Policy Disables Sha1 Hash And Signature Support
       objective: Ensure System Wide Crypto Policy Disables Sha1 Hash And Signature Support
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: cis_fedora_1-6.2-ar
+            state: Active
             text: System Wide Crypto Policy Disables Sha1 Hash And Signature Support MUST be verified
             applicability:
                 - fedora-linux
@@ -438,8 +526,10 @@ controls:
       title: Ensure System Wide Crypto Policy Macs Are Configured
       objective: Ensure System Wide Crypto Policy Macs Are Configured
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: cis_fedora_1-6.3-ar
+            state: Active
             text: System Wide Crypto Policy Macs Are Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -447,8 +537,10 @@ controls:
       title: Ensure System Wide Crypto Policy Disables Cbc For Ssh
       objective: Ensure System Wide Crypto Policy Disables Cbc For Ssh
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: cis_fedora_1-6.4-ar
+            state: Active
             text: System Wide Crypto Policy Disables Cbc For Ssh MUST be verified
             applicability:
                 - fedora-linux
@@ -456,8 +548,10 @@ controls:
       title: Ensure /Etc/Motd Is Configured
       objective: Ensure /Etc/Motd Is Configured
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: banner_etc_motd_cis
+            state: Active
             text: /Etc/Motd Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -465,8 +559,10 @@ controls:
       title: Ensure /Etc/Issue Is Configured
       objective: Ensure /Etc/Issue Is Configured
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: banner_etc_issue_cis
+            state: Active
             text: /Etc/Issue Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -474,8 +570,10 @@ controls:
       title: Ensure /Etc/Issue.Net Is Configured
       objective: Ensure /Etc/Issue.Net Is Configured
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: banner_etc_issue_net_cis
+            state: Active
             text: /Etc/Issue.Net Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -483,16 +581,20 @@ controls:
       title: Ensure Access To /Etc/Motd Is Configured
       objective: Ensure Access To /Etc/Motd Is Configured
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: file_groupowner_etc_motd
+            state: Active
             text: Access To /Etc/Motd Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_owner_etc_motd
+            state: Active
             text: Access To /Etc/Motd Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_permissions_etc_motd
+            state: Active
             text: Access To /Etc/Motd Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -500,16 +602,20 @@ controls:
       title: Ensure Access To /Etc/Issue Is Configured
       objective: Ensure Access To /Etc/Issue Is Configured
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: file_groupowner_etc_issue
+            state: Active
             text: Access To /Etc/Issue Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_owner_etc_issue
+            state: Active
             text: Access To /Etc/Issue Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_permissions_etc_issue
+            state: Active
             text: Access To /Etc/Issue Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -517,16 +623,20 @@ controls:
       title: Ensure Access To /Etc/Issue.Net Is Configured
       objective: Ensure Access To /Etc/Issue.Net Is Configured
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: file_groupowner_etc_issue_net
+            state: Active
             text: Access To /Etc/Issue.Net Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_owner_etc_issue_net
+            state: Active
             text: Access To /Etc/Issue.Net Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_permissions_etc_issue_net
+            state: Active
             text: Access To /Etc/Issue.Net Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -534,12 +644,15 @@ controls:
       title: Ensure Gdm Login Banner Is Configured
       objective: Ensure Gdm Login Banner Is Configured
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: dconf_gnome_banner_enabled
+            state: Active
             text: Gdm Login Banner Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: dconf_gnome_login_banner_text
+            state: Active
             text: Gdm Login Banner Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -547,8 +660,10 @@ controls:
       title: Ensure Gdm Disable-User-List Is Configured
       objective: Ensure Gdm Disable-User-List Is Configured
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: dconf_gnome_disable_user_list
+            state: Active
             text: Gdm Disable-User-List Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -556,20 +671,25 @@ controls:
       title: Ensure Gdm Screen Lock Is Configured
       objective: Ensure Gdm Screen Lock Is Configured
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: dconf_gnome_screensaver_idle_delay
+            state: Active
             text: Gdm Screen Lock Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: dconf_gnome_screensaver_lock_delay
+            state: Active
             text: Gdm Screen Lock Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: dconf_gnome_screensaver_user_locks
+            state: Active
             text: Gdm Screen Lock Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: dconf_gnome_session_idle_user_locks
+            state: Active
             text: Gdm Screen Lock Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -577,8 +697,10 @@ controls:
       title: Ensure Gdm Autorun-Never Is Configured
       objective: Ensure Gdm Autorun-Never Is Configured
       group: initial-setup
+      state: Active
       assessment-requirements:
           - id: dconf_gnome_disable_autorun
+            state: Active
             text: Gdm Autorun-Never Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -586,8 +708,10 @@ controls:
       title: Ensure Rpcbind Services Are Not In Use
       objective: Ensure Rpcbind Services Are Not In Use
       group: services
+      state: Active
       assessment-requirements:
           - id: service_rpcbind_disabled
+            state: Active
             text: Rpcbind Services Are Not In Use MUST be verified
             applicability:
                 - fedora-linux
@@ -595,8 +719,10 @@ controls:
       title: Ensure Rsync Services Are Not In Use
       objective: Ensure Rsync Services Are Not In Use
       group: services
+      state: Active
       assessment-requirements:
           - id: package_rsync_removed
+            state: Active
             text: Rsync Services Are Not In Use MUST be verified
             applicability:
                 - fedora-linux
@@ -604,8 +730,10 @@ controls:
       title: Ensure Samba File Server Services Are Not In Use
       objective: Ensure Samba File Server Services Are Not In Use
       group: services
+      state: Active
       assessment-requirements:
           - id: package_samba_removed
+            state: Active
             text: Samba File Server Services Are Not In Use MUST be verified
             applicability:
                 - fedora-linux
@@ -613,8 +741,10 @@ controls:
       title: Ensure Snmp Services Are Not In Use
       objective: Ensure Snmp Services Are Not In Use
       group: services
+      state: Active
       assessment-requirements:
           - id: package_net-snmp_removed
+            state: Active
             text: Snmp Services Are Not In Use MUST be verified
             applicability:
                 - fedora-linux
@@ -622,8 +752,10 @@ controls:
       title: Ensure Telnet Server Services Are Not In Use
       objective: Ensure Telnet Server Services Are Not In Use
       group: services
+      state: Active
       assessment-requirements:
           - id: package_telnet-server_removed
+            state: Active
             text: Telnet Server Services Are Not In Use MUST be verified
             applicability:
                 - fedora-linux
@@ -631,8 +763,10 @@ controls:
       title: Ensure Tftp Server Services Are Not In Use
       objective: Ensure Tftp Server Services Are Not In Use
       group: services
+      state: Active
       assessment-requirements:
           - id: package_tftp-server_removed
+            state: Active
             text: Tftp Server Services Are Not In Use MUST be verified
             applicability:
                 - fedora-linux
@@ -640,8 +774,10 @@ controls:
       title: Ensure Web Proxy Server Services Are Not In Use
       objective: Ensure Web Proxy Server Services Are Not In Use
       group: services
+      state: Active
       assessment-requirements:
           - id: package_squid_removed
+            state: Active
             text: Web Proxy Server Services Are Not In Use MUST be verified
             applicability:
                 - fedora-linux
@@ -649,12 +785,15 @@ controls:
       title: Ensure Web Server Services Are Not In Use
       objective: Ensure Web Server Services Are Not In Use
       group: services
+      state: Active
       assessment-requirements:
           - id: package_httpd_removed
+            state: Active
             text: Web Server Services Are Not In Use MUST be verified
             applicability:
                 - fedora-linux
           - id: package_nginx_removed
+            state: Active
             text: Web Server Services Are Not In Use MUST be verified
             applicability:
                 - fedora-linux
@@ -662,12 +801,15 @@ controls:
       title: Ensure Mail Transfer Agents Are Configured For Local-Only Mode
       objective: Ensure Mail Transfer Agents Are Configured For Local-Only Mode
       group: services
+      state: Active
       assessment-requirements:
           - id: has_nonlocal_mta
+            state: Active
             text: Mail Transfer Agents Are Configured For Local-Only Mode MUST be verified
             applicability:
                 - fedora-linux
           - id: postfix_network_listening_disabled
+            state: Active
             text: Mail Transfer Agents Are Configured For Local-Only Mode MUST be verified
             applicability:
                 - fedora-linux
@@ -675,8 +817,10 @@ controls:
       title: Ensure Dhcp Server Services Are Not In Use
       objective: Ensure Dhcp Server Services Are Not In Use
       group: services
+      state: Active
       assessment-requirements:
           - id: package_kea_removed
+            state: Active
             text: Dhcp Server Services Are Not In Use MUST be verified
             applicability:
                 - fedora-linux
@@ -684,8 +828,10 @@ controls:
       title: Ensure Dns Server Services Are Not In Use
       objective: Ensure Dns Server Services Are Not In Use
       group: services
+      state: Active
       assessment-requirements:
           - id: package_bind_removed
+            state: Active
             text: Dns Server Services Are Not In Use MUST be verified
             applicability:
                 - fedora-linux
@@ -693,8 +839,10 @@ controls:
       title: Ensure Dnsmasq Services Are Not In Use
       objective: Ensure Dnsmasq Services Are Not In Use
       group: services
+      state: Active
       assessment-requirements:
           - id: package_dnsmasq_removed
+            state: Active
             text: Dnsmasq Services Are Not In Use MUST be verified
             applicability:
                 - fedora-linux
@@ -702,8 +850,10 @@ controls:
       title: Ensure Ftp Server Services Are Not In Use
       objective: Ensure Ftp Server Services Are Not In Use
       group: services
+      state: Active
       assessment-requirements:
           - id: package_vsftpd_removed
+            state: Active
             text: Ftp Server Services Are Not In Use MUST be verified
             applicability:
                 - fedora-linux
@@ -711,12 +861,15 @@ controls:
       title: Ensure Message Access Server Services Are Not In Use
       objective: Ensure Message Access Server Services Are Not In Use
       group: services
+      state: Active
       assessment-requirements:
           - id: package_cyrus-imapd_removed
+            state: Active
             text: Message Access Server Services Are Not In Use MUST be verified
             applicability:
                 - fedora-linux
           - id: package_dovecot_removed
+            state: Active
             text: Message Access Server Services Are Not In Use MUST be verified
             applicability:
                 - fedora-linux
@@ -724,8 +877,10 @@ controls:
       title: Ensure Network File System Services Are Not In Use
       objective: Ensure Network File System Services Are Not In Use
       group: services
+      state: Active
       assessment-requirements:
           - id: service_nfs_disabled
+            state: Active
             text: Network File System Services Are Not In Use MUST be verified
             applicability:
                 - fedora-linux
@@ -733,8 +888,10 @@ controls:
       title: Ensure Ftp Client Is Not Installed
       objective: Ensure Ftp Client Is Not Installed
       group: services
+      state: Active
       assessment-requirements:
           - id: package_ftp_removed
+            state: Active
             text: Ftp Client Is Not Installed MUST be verified
             applicability:
                 - fedora-linux
@@ -742,8 +899,10 @@ controls:
       title: Ensure Telnet Client Is Not Installed
       objective: Ensure Telnet Client Is Not Installed
       group: services
+      state: Active
       assessment-requirements:
           - id: package_telnet_removed
+            state: Active
             text: Telnet Client Is Not Installed MUST be verified
             applicability:
                 - fedora-linux
@@ -751,8 +910,10 @@ controls:
       title: Ensure Tftp Client Is Not Installed
       objective: Ensure Tftp Client Is Not Installed
       group: services
+      state: Active
       assessment-requirements:
           - id: package_tftp_removed
+            state: Active
             text: Tftp Client Is Not Installed MUST be verified
             applicability:
                 - fedora-linux
@@ -760,8 +921,10 @@ controls:
       title: Ensure Chrony Is Configured
       objective: Ensure Chrony Is Configured
       group: services
+      state: Active
       assessment-requirements:
           - id: chronyd_specify_remote_server
+            state: Active
             text: Chrony Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -769,8 +932,10 @@ controls:
       title: Ensure Chrony Is Not Run As The Root User
       objective: Ensure Chrony Is Not Run As The Root User
       group: services
+      state: Active
       assessment-requirements:
           - id: chronyd_run_as_chrony_user
+            state: Active
             text: Chrony Is Not Run As The Root User MUST be verified
             applicability:
                 - fedora-linux
@@ -778,12 +943,15 @@ controls:
       title: Ensure Cron Daemon Is Enabled And Active
       objective: Ensure Cron Daemon Is Enabled And Active
       group: services
+      state: Active
       assessment-requirements:
           - id: package_cron_installed
+            state: Active
             text: Cron Daemon Is Enabled And Active MUST be verified
             applicability:
                 - fedora-linux
           - id: service_crond_enabled
+            state: Active
             text: Cron Daemon Is Enabled And Active MUST be verified
             applicability:
                 - fedora-linux
@@ -791,16 +959,20 @@ controls:
       title: Ensure Access To /Etc/Crontab Is Configured
       objective: Ensure Access To /Etc/Crontab Is Configured
       group: services
+      state: Active
       assessment-requirements:
           - id: file_groupowner_crontab
+            state: Active
             text: Access To /Etc/Crontab Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_owner_crontab
+            state: Active
             text: Access To /Etc/Crontab Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_permissions_crontab
+            state: Active
             text: Access To /Etc/Crontab Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -808,16 +980,20 @@ controls:
       title: Ensure Access To /Etc/Cron.Hourly Is Configured
       objective: Ensure Access To /Etc/Cron.Hourly Is Configured
       group: services
+      state: Active
       assessment-requirements:
           - id: file_groupowner_cron_hourly
+            state: Active
             text: Access To /Etc/Cron.Hourly Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_owner_cron_hourly
+            state: Active
             text: Access To /Etc/Cron.Hourly Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_permissions_cron_hourly
+            state: Active
             text: Access To /Etc/Cron.Hourly Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -825,16 +1001,20 @@ controls:
       title: Ensure Access To /Etc/Cron.Daily Is Configured
       objective: Ensure Access To /Etc/Cron.Daily Is Configured
       group: services
+      state: Active
       assessment-requirements:
           - id: file_groupowner_cron_daily
+            state: Active
             text: Access To /Etc/Cron.Daily Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_owner_cron_daily
+            state: Active
             text: Access To /Etc/Cron.Daily Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_permissions_cron_daily
+            state: Active
             text: Access To /Etc/Cron.Daily Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -842,16 +1022,20 @@ controls:
       title: Ensure Access To /Etc/Cron.Weekly Is Configured
       objective: Ensure Access To /Etc/Cron.Weekly Is Configured
       group: services
+      state: Active
       assessment-requirements:
           - id: file_groupowner_cron_weekly
+            state: Active
             text: Access To /Etc/Cron.Weekly Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_owner_cron_weekly
+            state: Active
             text: Access To /Etc/Cron.Weekly Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_permissions_cron_weekly
+            state: Active
             text: Access To /Etc/Cron.Weekly Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -859,16 +1043,20 @@ controls:
       title: Ensure Access To /Etc/Cron.Monthly Is Configured
       objective: Ensure Access To /Etc/Cron.Monthly Is Configured
       group: services
+      state: Active
       assessment-requirements:
           - id: file_groupowner_cron_monthly
+            state: Active
             text: Access To /Etc/Cron.Monthly Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_owner_cron_monthly
+            state: Active
             text: Access To /Etc/Cron.Monthly Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_permissions_cron_monthly
+            state: Active
             text: Access To /Etc/Cron.Monthly Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -876,16 +1064,20 @@ controls:
       title: Ensure Access To /Etc/Cron.D Is Configured
       objective: Ensure Access To /Etc/Cron.D Is Configured
       group: services
+      state: Active
       assessment-requirements:
           - id: file_groupowner_cron_d
+            state: Active
             text: Access To /Etc/Cron.D Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_owner_cron_d
+            state: Active
             text: Access To /Etc/Cron.D Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_permissions_cron_d
+            state: Active
             text: Access To /Etc/Cron.D Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -893,24 +1085,30 @@ controls:
       title: Ensure Access To Crontab Is Configured
       objective: Ensure Access To Crontab Is Configured
       group: services
+      state: Active
       assessment-requirements:
           - id: file_cron_allow_exists
+            state: Active
             text: Access To Crontab Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_cron_deny_not_exist
+            state: Active
             text: Access To Crontab Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_groupowner_cron_allow
+            state: Active
             text: Access To Crontab Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_owner_cron_allow
+            state: Active
             text: Access To Crontab Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_permissions_cron_allow
+            state: Active
             text: Access To Crontab Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -918,20 +1116,25 @@ controls:
       title: Ensure Access To At Is Configured
       objective: Ensure Access To At Is Configured
       group: services
+      state: Active
       assessment-requirements:
           - id: file_at_deny_not_exist
+            state: Active
             text: Access To At Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_groupowner_at_allow
+            state: Active
             text: Access To At Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_owner_at_allow
+            state: Active
             text: Access To At Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_permissions_at_allow
+            state: Active
             text: Access To At Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -939,8 +1142,10 @@ controls:
       title: Ensure Atm Kernel Module Is Not Available
       objective: Ensure Atm Kernel Module Is Not Available
       group: network
+      state: Active
       assessment-requirements:
           - id: kernel_module_atm_disabled
+            state: Active
             text: Atm Kernel Module Is Not Available MUST be verified
             applicability:
                 - fedora-linux
@@ -948,8 +1153,10 @@ controls:
       title: Ensure Can Kernel Module Is Not Available
       objective: Ensure Can Kernel Module Is Not Available
       group: network
+      state: Active
       assessment-requirements:
           - id: kernel_module_can_disabled
+            state: Active
             text: Can Kernel Module Is Not Available MUST be verified
             applicability:
                 - fedora-linux
@@ -957,8 +1164,10 @@ controls:
       title: Ensure Dccp Kernel Module Is Not Available
       objective: Ensure Dccp Kernel Module Is Not Available
       group: network
+      state: Active
       assessment-requirements:
           - id: kernel_module_dccp_disabled
+            state: Active
             text: Dccp Kernel Module Is Not Available MUST be verified
             applicability:
                 - fedora-linux
@@ -966,8 +1175,10 @@ controls:
       title: Ensure Tipc Kernel Module Is Not Available
       objective: Ensure Tipc Kernel Module Is Not Available
       group: network
+      state: Active
       assessment-requirements:
           - id: kernel_module_tipc_disabled
+            state: Active
             text: Tipc Kernel Module Is Not Available MUST be verified
             applicability:
                 - fedora-linux
@@ -975,8 +1186,10 @@ controls:
       title: Ensure Rds Kernel Module Is Not Available
       objective: Ensure Rds Kernel Module Is Not Available
       group: network
+      state: Active
       assessment-requirements:
           - id: kernel_module_rds_disabled
+            state: Active
             text: Rds Kernel Module Is Not Available MUST be verified
             applicability:
                 - fedora-linux
@@ -984,8 +1197,10 @@ controls:
       title: Ensure Net.Ipv4.Ip_Forward Is Configured
       objective: Ensure Net.Ipv4.Ip_Forward Is Configured
       group: network
+      state: Active
       assessment-requirements:
           - id: sysctl_net_ipv4_ip_forward
+            state: Active
             text: Net.Ipv4.Ip_Forward Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -993,8 +1208,10 @@ controls:
       title: Ensure Net.Ipv4.Conf.All.Secure_Redirects Is Configured
       objective: Ensure Net.Ipv4.Conf.All.Secure_Redirects Is Configured
       group: network
+      state: Active
       assessment-requirements:
           - id: sysctl_net_ipv4_conf_all_secure_redirects
+            state: Active
             text: Net.Ipv4.Conf.All.Secure_Redirects Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1002,8 +1219,10 @@ controls:
       title: Ensure Net.Ipv4.Conf.Default.Secure_Redirects Is Configured
       objective: Ensure Net.Ipv4.Conf.Default.Secure_Redirects Is Configured
       group: network
+      state: Active
       assessment-requirements:
           - id: sysctl_net_ipv4_conf_default_secure_redirects
+            state: Active
             text: Net.Ipv4.Conf.Default.Secure_Redirects Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1011,8 +1230,10 @@ controls:
       title: Ensure Net.Ipv4.Conf.All.Rp_Filter Is Configured
       objective: Ensure Net.Ipv4.Conf.All.Rp_Filter Is Configured
       group: network
+      state: Active
       assessment-requirements:
           - id: sysctl_net_ipv4_conf_all_rp_filter
+            state: Active
             text: Net.Ipv4.Conf.All.Rp_Filter Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1020,8 +1241,10 @@ controls:
       title: Ensure Net.Ipv4.Conf.Default.Rp_Filter Is Configured
       objective: Ensure Net.Ipv4.Conf.Default.Rp_Filter Is Configured
       group: network
+      state: Active
       assessment-requirements:
           - id: sysctl_net_ipv4_conf_default_rp_filter
+            state: Active
             text: Net.Ipv4.Conf.Default.Rp_Filter Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1029,8 +1252,10 @@ controls:
       title: Ensure Net.Ipv4.Conf.All.Accept_Source_Route Is Configured
       objective: Ensure Net.Ipv4.Conf.All.Accept_Source_Route Is Configured
       group: network
+      state: Active
       assessment-requirements:
           - id: sysctl_net_ipv4_conf_all_accept_source_route
+            state: Active
             text: Net.Ipv4.Conf.All.Accept_Source_Route Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1038,8 +1263,10 @@ controls:
       title: Ensure Net.Ipv4.Conf.Default.Accept_Source_Route Is Configured
       objective: Ensure Net.Ipv4.Conf.Default.Accept_Source_Route Is Configured
       group: network
+      state: Active
       assessment-requirements:
           - id: sysctl_net_ipv4_conf_default_accept_source_route
+            state: Active
             text: Net.Ipv4.Conf.Default.Accept_Source_Route Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1047,8 +1274,10 @@ controls:
       title: Ensure Net.Ipv4.Conf.All.Log_Martians Is Configured
       objective: Ensure Net.Ipv4.Conf.All.Log_Martians Is Configured
       group: network
+      state: Active
       assessment-requirements:
           - id: sysctl_net_ipv4_conf_all_log_martians
+            state: Active
             text: Net.Ipv4.Conf.All.Log_Martians Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1056,8 +1285,10 @@ controls:
       title: Ensure Net.Ipv4.Conf.Default.Log_Martians Is Configured
       objective: Ensure Net.Ipv4.Conf.Default.Log_Martians Is Configured
       group: network
+      state: Active
       assessment-requirements:
           - id: sysctl_net_ipv4_conf_default_log_martians
+            state: Active
             text: Net.Ipv4.Conf.Default.Log_Martians Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1065,8 +1296,10 @@ controls:
       title: Ensure Net.Ipv4.Tcp_Syncookies Is Configured
       objective: Ensure Net.Ipv4.Tcp_Syncookies Is Configured
       group: network
+      state: Active
       assessment-requirements:
           - id: sysctl_net_ipv4_tcp_syncookies
+            state: Active
             text: Net.Ipv4.Tcp_Syncookies Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1074,8 +1307,10 @@ controls:
       title: Ensure Net.Ipv4.Conf.All.Send_Redirects Is Configured
       objective: Ensure Net.Ipv4.Conf.All.Send_Redirects Is Configured
       group: network
+      state: Active
       assessment-requirements:
           - id: sysctl_net_ipv4_conf_all_send_redirects
+            state: Active
             text: Net.Ipv4.Conf.All.Send_Redirects Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1083,8 +1318,10 @@ controls:
       title: Ensure Net.Ipv4.Conf.Default.Send_Redirects Is Configured
       objective: Ensure Net.Ipv4.Conf.Default.Send_Redirects Is Configured
       group: network
+      state: Active
       assessment-requirements:
           - id: sysctl_net_ipv4_conf_default_send_redirects
+            state: Active
             text: Net.Ipv4.Conf.Default.Send_Redirects Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1092,8 +1329,10 @@ controls:
       title: Ensure Net.Ipv4.Icmp_Ignore_Bogus_Error_Responses Is Configured
       objective: Ensure Net.Ipv4.Icmp_Ignore_Bogus_Error_Responses Is Configured
       group: network
+      state: Active
       assessment-requirements:
           - id: sysctl_net_ipv4_icmp_ignore_bogus_error_responses
+            state: Active
             text: Net.Ipv4.Icmp_Ignore_Bogus_Error_Responses Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1101,8 +1340,10 @@ controls:
       title: Ensure Net.Ipv4.Icmp_Echo_Ignore_Broadcasts Is Configured
       objective: Ensure Net.Ipv4.Icmp_Echo_Ignore_Broadcasts Is Configured
       group: network
+      state: Active
       assessment-requirements:
           - id: sysctl_net_ipv4_icmp_echo_ignore_broadcasts
+            state: Active
             text: Net.Ipv4.Icmp_Echo_Ignore_Broadcasts Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1110,8 +1351,10 @@ controls:
       title: Ensure Net.Ipv4.Conf.All.Accept_Redirects Is Configured
       objective: Ensure Net.Ipv4.Conf.All.Accept_Redirects Is Configured
       group: network
+      state: Active
       assessment-requirements:
           - id: sysctl_net_ipv4_conf_all_accept_redirects
+            state: Active
             text: Net.Ipv4.Conf.All.Accept_Redirects Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1119,8 +1362,10 @@ controls:
       title: Ensure Net.Ipv4.Conf.Default.Accept_Redirects Is Configured
       objective: Ensure Net.Ipv4.Conf.Default.Accept_Redirects Is Configured
       group: network
+      state: Active
       assessment-requirements:
           - id: sysctl_net_ipv4_conf_default_accept_redirects
+            state: Active
             text: Net.Ipv4.Conf.Default.Accept_Redirects Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1128,8 +1373,10 @@ controls:
       title: Ensure Net.Ipv6.Conf.All.Forwarding Is Configured
       objective: Ensure Net.Ipv6.Conf.All.Forwarding Is Configured
       group: network
+      state: Active
       assessment-requirements:
           - id: sysctl_net_ipv6_conf_all_forwarding
+            state: Active
             text: Net.Ipv6.Conf.All.Forwarding Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1137,8 +1384,10 @@ controls:
       title: Ensure Net.Ipv6.Conf.All.Accept_Redirects Is Configured
       objective: Ensure Net.Ipv6.Conf.All.Accept_Redirects Is Configured
       group: network
+      state: Active
       assessment-requirements:
           - id: sysctl_net_ipv6_conf_all_accept_redirects
+            state: Active
             text: Net.Ipv6.Conf.All.Accept_Redirects Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1146,8 +1395,10 @@ controls:
       title: Ensure Net.Ipv6.Conf.Default.Accept_Redirects Is Configured
       objective: Ensure Net.Ipv6.Conf.Default.Accept_Redirects Is Configured
       group: network
+      state: Active
       assessment-requirements:
           - id: sysctl_net_ipv6_conf_default_accept_redirects
+            state: Active
             text: Net.Ipv6.Conf.Default.Accept_Redirects Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1155,8 +1406,10 @@ controls:
       title: Ensure Net.Ipv6.Conf.All.Accept_Source_Route Is Configured
       objective: Ensure Net.Ipv6.Conf.All.Accept_Source_Route Is Configured
       group: network
+      state: Active
       assessment-requirements:
           - id: sysctl_net_ipv6_conf_all_accept_source_route
+            state: Active
             text: Net.Ipv6.Conf.All.Accept_Source_Route Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1164,8 +1417,10 @@ controls:
       title: Ensure Net.Ipv6.Conf.Default.Accept_Source_Route Is Configured
       objective: Ensure Net.Ipv6.Conf.Default.Accept_Source_Route Is Configured
       group: network
+      state: Active
       assessment-requirements:
           - id: sysctl_net_ipv6_conf_default_accept_source_route
+            state: Active
             text: Net.Ipv6.Conf.Default.Accept_Source_Route Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1173,8 +1428,10 @@ controls:
       title: Ensure Net.Ipv6.Conf.All.Accept_Ra Is Configured
       objective: Ensure Net.Ipv6.Conf.All.Accept_Ra Is Configured
       group: network
+      state: Active
       assessment-requirements:
           - id: sysctl_net_ipv6_conf_all_accept_ra
+            state: Active
             text: Net.Ipv6.Conf.All.Accept_Ra Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1182,8 +1439,10 @@ controls:
       title: Ensure Net.Ipv6.Conf.Default.Accept_Ra Is Configured
       objective: Ensure Net.Ipv6.Conf.Default.Accept_Ra Is Configured
       group: network
+      state: Active
       assessment-requirements:
           - id: sysctl_net_ipv6_conf_default_accept_ra
+            state: Active
             text: Net.Ipv6.Conf.Default.Accept_Ra Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1191,8 +1450,10 @@ controls:
       title: Ensure Nftables Is Installed
       objective: Ensure Nftables Is Installed
       group: firewall
+      state: Active
       assessment-requirements:
           - id: package_nftables_installed
+            state: Active
             text: Nftables Is Installed MUST be verified
             applicability:
                 - fedora-linux
@@ -1200,16 +1461,20 @@ controls:
       title: Ensure A Single Firewall Configuration Utility Is In Use
       objective: Ensure A Single Firewall Configuration Utility Is In Use
       group: firewall
+      state: Active
       assessment-requirements:
           - id: package_firewalld_installed
+            state: Active
             text: A Single Firewall Configuration Utility Is In Use MUST be verified
             applicability:
                 - fedora-linux
           - id: service_firewalld_enabled
+            state: Active
             text: A Single Firewall Configuration Utility Is In Use MUST be verified
             applicability:
                 - fedora-linux
           - id: service_nftables_disabled
+            state: Active
             text: A Single Firewall Configuration Utility Is In Use MUST be verified
             applicability:
                 - fedora-linux
@@ -1217,12 +1482,15 @@ controls:
       title: Ensure Firewalld Loopback Traffic Is Configured
       objective: Ensure Firewalld Loopback Traffic Is Configured
       group: firewall
+      state: Active
       assessment-requirements:
           - id: firewalld_loopback_traffic_restricted
+            state: Active
             text: Firewalld Loopback Traffic Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: firewalld_loopback_traffic_trusted
+            state: Active
             text: Firewalld Loopback Traffic Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1230,16 +1498,20 @@ controls:
       title: Ensure Access To /Etc/Ssh/Sshd_Config Is Configured
       objective: Ensure Access To /Etc/Ssh/Sshd_Config Is Configured
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: file_groupowner_sshd_config
+            state: Active
             text: Access To /Etc/Ssh/Sshd_Config Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_owner_sshd_config
+            state: Active
             text: Access To /Etc/Ssh/Sshd_Config Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_permissions_sshd_config
+            state: Active
             text: Access To /Etc/Ssh/Sshd_Config Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1247,8 +1519,10 @@ controls:
       title: Ensure Sshd Gssapiauthentication Is Disabled
       objective: Ensure Sshd Gssapiauthentication Is Disabled
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: sshd_disable_gssapi_auth
+            state: Active
             text: Sshd Gssapiauthentication Is Disabled MUST be verified
             applicability:
                 - fedora-linux
@@ -1256,8 +1530,10 @@ controls:
       title: Ensure Sshd Hostbasedauthentication Is Disabled
       objective: Ensure Sshd Hostbasedauthentication Is Disabled
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: disable_host_auth
+            state: Active
             text: Sshd Hostbasedauthentication Is Disabled MUST be verified
             applicability:
                 - fedora-linux
@@ -1265,8 +1541,10 @@ controls:
       title: Ensure Sshd Ignorerhosts Is Enabled
       objective: Ensure Sshd Ignorerhosts Is Enabled
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: sshd_disable_rhosts
+            state: Active
             text: Sshd Ignorerhosts Is Enabled MUST be verified
             applicability:
                 - fedora-linux
@@ -1274,8 +1552,10 @@ controls:
       title: Ensure Sshd Logingracetime Is Configured
       objective: Ensure Sshd Logingracetime Is Configured
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: sshd_set_login_grace_time
+            state: Active
             text: Sshd Logingracetime Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1283,8 +1563,10 @@ controls:
       title: Ensure Sshd Loglevel Is Configured
       objective: Ensure Sshd Loglevel Is Configured
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: sshd_set_loglevel_verbose
+            state: Active
             text: Sshd Loglevel Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1292,8 +1574,10 @@ controls:
       title: Ensure Sshd Maxauthtries Is Configured
       objective: Ensure Sshd Maxauthtries Is Configured
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: sshd_set_max_auth_tries
+            state: Active
             text: Sshd Maxauthtries Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1301,8 +1585,10 @@ controls:
       title: Ensure Sshd Maxstartups Is Configured
       objective: Ensure Sshd Maxstartups Is Configured
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: sshd_set_maxstartups
+            state: Active
             text: Sshd Maxstartups Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1310,8 +1596,10 @@ controls:
       title: Ensure Sshd Maxsessions Is Configured
       objective: Ensure Sshd Maxsessions Is Configured
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: sshd_set_max_sessions
+            state: Active
             text: Sshd Maxsessions Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1319,8 +1607,10 @@ controls:
       title: Ensure Sshd Permitemptypasswords Is Disabled
       objective: Ensure Sshd Permitemptypasswords Is Disabled
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: sshd_disable_empty_passwords
+            state: Active
             text: Sshd Permitemptypasswords Is Disabled MUST be verified
             applicability:
                 - fedora-linux
@@ -1328,16 +1618,20 @@ controls:
       title: Ensure Access To Ssh Private Host Key Files Is Configured
       objective: Ensure Access To Ssh Private Host Key Files Is Configured
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: file_groupownership_sshd_private_key
+            state: Active
             text: Access To Ssh Private Host Key Files Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_ownership_sshd_private_key
+            state: Active
             text: Access To Ssh Private Host Key Files Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_permissions_sshd_private_key
+            state: Active
             text: Access To Ssh Private Host Key Files Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1345,8 +1639,10 @@ controls:
       title: Ensure Sshd Permitrootlogin Is Disabled
       objective: Ensure Sshd Permitrootlogin Is Disabled
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: sshd_disable_root_login
+            state: Active
             text: Sshd Permitrootlogin Is Disabled MUST be verified
             applicability:
                 - fedora-linux
@@ -1354,8 +1650,10 @@ controls:
       title: Ensure Sshd Permituserenvironment Is Disabled
       objective: Ensure Sshd Permituserenvironment Is Disabled
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: sshd_do_not_permit_user_env
+            state: Active
             text: Sshd Permituserenvironment Is Disabled MUST be verified
             applicability:
                 - fedora-linux
@@ -1363,8 +1661,10 @@ controls:
       title: Ensure Sshd Usepam Is Enabled
       objective: Ensure Sshd Usepam Is Enabled
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: sshd_enable_pam
+            state: Active
             text: Sshd Usepam Is Enabled MUST be verified
             applicability:
                 - fedora-linux
@@ -1372,16 +1672,20 @@ controls:
       title: Ensure Access To Ssh Public Host Key Files Is Configured
       objective: Ensure Access To Ssh Public Host Key Files Is Configured
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: file_groupownership_sshd_pub_key
+            state: Active
             text: Access To Ssh Public Host Key Files Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_ownership_sshd_pub_key
+            state: Active
             text: Access To Ssh Public Host Key Files Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_permissions_sshd_pub_key
+            state: Active
             text: Access To Ssh Public Host Key Files Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1389,8 +1693,10 @@ controls:
       title: Ensure Sshd Ciphers Are Configured
       objective: Ensure Sshd Ciphers Are Configured
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: cis_fedora_5-1.4-ar
+            state: Active
             text: Sshd Ciphers Are Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1398,8 +1704,10 @@ controls:
       title: Ensure Sshd Kexalgorithms Is Configured
       objective: Ensure Sshd Kexalgorithms Is Configured
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: cis_fedora_5-1.5-ar
+            state: Active
             text: Sshd Kexalgorithms Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1407,8 +1715,10 @@ controls:
       title: Ensure Sshd Macs Are Configured
       objective: Ensure Sshd Macs Are Configured
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: cis_fedora_5-1.6-ar
+            state: Active
             text: Sshd Macs Are Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1416,8 +1726,10 @@ controls:
       title: Ensure Sshd Access Is Configured
       objective: Ensure Sshd Access Is Configured
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: sshd_limit_user_access
+            state: Active
             text: Sshd Access Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1425,8 +1737,10 @@ controls:
       title: Ensure Sshd Banner Is Configured
       objective: Ensure Sshd Banner Is Configured
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: sshd_enable_warning_banner_net
+            state: Active
             text: Sshd Banner Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1434,12 +1748,15 @@ controls:
       title: Ensure Sshd Clientaliveinterval And Clientalivecountmax Are Configured
       objective: Ensure Sshd Clientaliveinterval And Clientalivecountmax Are Configured
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: sshd_set_idle_timeout
+            state: Active
             text: Sshd Clientaliveinterval And Clientalivecountmax Are Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: sshd_set_keepalive
+            state: Active
             text: Sshd Clientaliveinterval And Clientalivecountmax Are Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1447,8 +1764,10 @@ controls:
       title: Ensure Sudo Is Installed
       objective: Ensure Sudo Is Installed
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: package_sudo_installed
+            state: Active
             text: Sudo Is Installed MUST be verified
             applicability:
                 - fedora-linux
@@ -1456,8 +1775,10 @@ controls:
       title: Ensure Sudo Commands Use Pty
       objective: Ensure Sudo Commands Use Pty
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: sudo_add_use_pty
+            state: Active
             text: Sudo Commands Use Pty MUST be verified
             applicability:
                 - fedora-linux
@@ -1465,8 +1786,10 @@ controls:
       title: Ensure Sudo Log File Exists
       objective: Ensure Sudo Log File Exists
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: sudo_custom_logfile
+            state: Active
             text: Sudo Log File Exists MUST be verified
             applicability:
                 - fedora-linux
@@ -1474,8 +1797,10 @@ controls:
       title: Ensure Re-Authentication For Privilege Escalation Is Not Disabled Globally
       objective: Ensure Re-Authentication For Privilege Escalation Is Not Disabled Globally
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: sudo_remove_no_authenticate
+            state: Active
             text: Re-Authentication For Privilege Escalation Is Not Disabled Globally MUST be verified
             applicability:
                 - fedora-linux
@@ -1483,8 +1808,10 @@ controls:
       title: Ensure Sudo Timestamp_Timeout Is Configured
       objective: Ensure Sudo Timestamp_Timeout Is Configured
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: sudo_require_reauthentication
+            state: Active
             text: Sudo Timestamp_Timeout Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1492,12 +1819,15 @@ controls:
       title: Ensure Access To The Su Command Is Restricted
       objective: Ensure Access To The Su Command Is Restricted
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: ensure_pam_wheel_group_empty
+            state: Active
             text: Access To The Su Command Is Restricted MUST be verified
             applicability:
                 - fedora-linux
           - id: use_pam_wheel_group_for_su
+            state: Active
             text: Access To The Su Command Is Restricted MUST be verified
             applicability:
                 - fedora-linux
@@ -1505,8 +1835,10 @@ controls:
       title: Ensure Latest Version Of Libpwquality Is Installed
       objective: Ensure Latest Version Of Libpwquality Is Installed
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: package_pam_pwquality_installed
+            state: Active
             text: Latest Version Of Libpwquality Is Installed MUST be verified
             applicability:
                 - fedora-linux
@@ -1514,12 +1846,15 @@ controls:
       title: Ensure Pam_Faillock Module Is Enabled
       objective: Ensure Pam_Faillock Module Is Enabled
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: account_password_pam_faillock_password_auth
+            state: Active
             text: Pam_Faillock Module Is Enabled MUST be verified
             applicability:
                 - fedora-linux
           - id: account_password_pam_faillock_system_auth
+            state: Active
             text: Pam_Faillock Module Is Enabled MUST be verified
             applicability:
                 - fedora-linux
@@ -1527,12 +1862,15 @@ controls:
       title: Ensure Pam_Pwquality Module Is Enabled
       objective: Ensure Pam_Pwquality Module Is Enabled
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: accounts_password_pam_pwquality_password_auth
+            state: Active
             text: Pam_Pwquality Module Is Enabled MUST be verified
             applicability:
                 - fedora-linux
           - id: accounts_password_pam_pwquality_system_auth
+            state: Active
             text: Pam_Pwquality Module Is Enabled MUST be verified
             applicability:
                 - fedora-linux
@@ -1540,8 +1878,10 @@ controls:
       title: CIS Fedora 5 - 3.3.1.1
       objective: CIS Fedora 5 - 3.3.1.1
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: accounts_passwords_pam_faillock_deny
+            state: Active
             text: CIS Fedora 5 - 3.3.1.1 MUST be verified
             applicability:
                 - fedora-linux
@@ -1549,8 +1889,10 @@ controls:
       title: CIS Fedora 5 - 3.3.1.2
       objective: CIS Fedora 5 - 3.3.1.2
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: accounts_passwords_pam_faillock_unlock_time
+            state: Active
             text: CIS Fedora 5 - 3.3.1.2 MUST be verified
             applicability:
                 - fedora-linux
@@ -1558,8 +1900,10 @@ controls:
       title: CIS Fedora 5 - 3.3.2.1
       objective: CIS Fedora 5 - 3.3.2.1
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: accounts_password_pam_difok
+            state: Active
             text: CIS Fedora 5 - 3.3.2.1 MUST be verified
             applicability:
                 - fedora-linux
@@ -1567,8 +1911,10 @@ controls:
       title: CIS Fedora 5 - 3.3.2.2
       objective: CIS Fedora 5 - 3.3.2.2
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: accounts_password_pam_minlen
+            state: Active
             text: CIS Fedora 5 - 3.3.2.2 MUST be verified
             applicability:
                 - fedora-linux
@@ -1576,8 +1922,10 @@ controls:
       title: CIS Fedora 5 - 3.3.2.3
       objective: CIS Fedora 5 - 3.3.2.3
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: accounts_password_pam_minclass
+            state: Active
             text: CIS Fedora 5 - 3.3.2.3 MUST be verified
             applicability:
                 - fedora-linux
@@ -1585,8 +1933,10 @@ controls:
       title: CIS Fedora 5 - 3.3.2.4
       objective: CIS Fedora 5 - 3.3.2.4
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: accounts_password_pam_maxrepeat
+            state: Active
             text: CIS Fedora 5 - 3.3.2.4 MUST be verified
             applicability:
                 - fedora-linux
@@ -1594,8 +1944,10 @@ controls:
       title: CIS Fedora 5 - 3.3.2.6
       objective: CIS Fedora 5 - 3.3.2.6
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: accounts_password_pam_dictcheck
+            state: Active
             text: CIS Fedora 5 - 3.3.2.6 MUST be verified
             applicability:
                 - fedora-linux
@@ -1603,8 +1955,10 @@ controls:
       title: CIS Fedora 5 - 3.3.2.7
       objective: CIS Fedora 5 - 3.3.2.7
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: accounts_password_pam_enforce_root
+            state: Active
             text: CIS Fedora 5 - 3.3.2.7 MUST be verified
             applicability:
                 - fedora-linux
@@ -1612,12 +1966,15 @@ controls:
       title: CIS Fedora 5 - 3.3.3.1
       objective: CIS Fedora 5 - 3.3.3.1
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: accounts_password_pam_pwhistory_remember_password_auth
+            state: Active
             text: CIS Fedora 5 - 3.3.3.1 MUST be verified
             applicability:
                 - fedora-linux
           - id: accounts_password_pam_pwhistory_remember_system_auth
+            state: Active
             text: CIS Fedora 5 - 3.3.3.1 MUST be verified
             applicability:
                 - fedora-linux
@@ -1625,8 +1982,10 @@ controls:
       title: CIS Fedora 5 - 3.3.4.1
       objective: CIS Fedora 5 - 3.3.4.1
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: no_empty_passwords
+            state: Active
             text: CIS Fedora 5 - 3.3.4.1 MUST be verified
             applicability:
                 - fedora-linux
@@ -1634,12 +1993,15 @@ controls:
       title: CIS Fedora 5 - 3.3.4.3
       objective: CIS Fedora 5 - 3.3.4.3
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: set_password_hashing_algorithm_passwordauth
+            state: Active
             text: CIS Fedora 5 - 3.3.4.3 MUST be verified
             applicability:
                 - fedora-linux
           - id: set_password_hashing_algorithm_systemauth
+            state: Active
             text: CIS Fedora 5 - 3.3.4.3 MUST be verified
             applicability:
                 - fedora-linux
@@ -1647,12 +2009,15 @@ controls:
       title: Ensure Password Expiration Is Configured
       objective: Ensure Password Expiration Is Configured
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: accounts_maximum_age_login_defs
+            state: Active
             text: Password Expiration Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: accounts_password_set_max_life_existing
+            state: Active
             text: Password Expiration Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1660,12 +2025,15 @@ controls:
       title: Ensure Password Expiration Warning Days Is Configured
       objective: Ensure Password Expiration Warning Days Is Configured
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: accounts_password_set_warn_age_existing
+            state: Active
             text: Password Expiration Warning Days Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: accounts_password_warn_age_login_defs
+            state: Active
             text: Password Expiration Warning Days Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1673,8 +2041,10 @@ controls:
       title: Ensure Strong Password Hashing Algorithm Is Configured
       objective: Ensure Strong Password Hashing Algorithm Is Configured
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: set_password_hashing_algorithm_logindefs
+            state: Active
             text: Strong Password Hashing Algorithm Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1682,12 +2052,15 @@ controls:
       title: Ensure Inactive Password Lock Is Configured
       objective: Ensure Inactive Password Lock Is Configured
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: account_disable_post_pw_expiration
+            state: Active
             text: Inactive Password Lock Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: accounts_set_post_pw_existing
+            state: Active
             text: Inactive Password Lock Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1695,8 +2068,10 @@ controls:
       title: Ensure All Users Last Password Change Date Is In The Past
       objective: Ensure All Users Last Password Change Date Is In The Past
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: accounts_password_last_change_is_in_past
+            state: Active
             text: All Users Last Password Change Date Is In The Past MUST be verified
             applicability:
                 - fedora-linux
@@ -1704,8 +2079,10 @@ controls:
       title: Ensure Root Is The Only Uid 0 Account
       objective: Ensure Root Is The Only Uid 0 Account
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: accounts_no_uid_except_zero
+            state: Active
             text: Root Is The Only Uid 0 Account MUST be verified
             applicability:
                 - fedora-linux
@@ -1713,8 +2090,10 @@ controls:
       title: Ensure Root Is The Only Gid 0 Account
       objective: Ensure Root Is The Only Gid 0 Account
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: accounts_root_gid_zero
+            state: Active
             text: Root Is The Only Gid 0 Account MUST be verified
             applicability:
                 - fedora-linux
@@ -1722,8 +2101,10 @@ controls:
       title: Ensure Root Account Access Is Controlled
       objective: Ensure Root Account Access Is Controlled
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: ensure_root_password_configured
+            state: Active
             text: Root Account Access Is Controlled MUST be verified
             applicability:
                 - fedora-linux
@@ -1731,12 +2112,15 @@ controls:
       title: Ensure Root Path Integrity
       objective: Ensure Root Path Integrity
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: accounts_root_path_dirs_no_write
+            state: Active
             text: Root Path Integrity MUST be verified
             applicability:
                 - fedora-linux
           - id: root_path_no_dot
+            state: Active
             text: Root Path Integrity MUST be verified
             applicability:
                 - fedora-linux
@@ -1744,12 +2128,15 @@ controls:
       title: Ensure System Accounts Do Not Have A Valid Login Shell
       objective: Ensure System Accounts Do Not Have A Valid Login Shell
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: no_password_auth_for_systemaccounts
+            state: Active
             text: System Accounts Do Not Have A Valid Login Shell MUST be verified
             applicability:
                 - fedora-linux
           - id: no_shelllogin_for_systemaccounts
+            state: Active
             text: System Accounts Do Not Have A Valid Login Shell MUST be verified
             applicability:
                 - fedora-linux
@@ -1757,8 +2144,10 @@ controls:
       title: Ensure Default User Shell Timeout Is Configured
       objective: Ensure Default User Shell Timeout Is Configured
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: accounts_tmout
+            state: Active
             text: Default User Shell Timeout Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1766,16 +2155,20 @@ controls:
       title: Ensure Default User Umask Is Configured
       objective: Ensure Default User Umask Is Configured
       group: access-auth
+      state: Active
       assessment-requirements:
           - id: accounts_umask_etc_bashrc
+            state: Active
             text: Default User Umask Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: accounts_umask_etc_login_defs
+            state: Active
             text: Default User Umask Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: accounts_umask_etc_profile
+            state: Active
             text: Default User Umask Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1783,12 +2176,15 @@ controls:
       title: Ensure Aide Is Installed
       objective: Ensure Aide Is Installed
       group: logging
+      state: Active
       assessment-requirements:
           - id: aide_build_database
+            state: Active
             text: Aide Is Installed MUST be verified
             applicability:
                 - fedora-linux
           - id: package_aide_installed
+            state: Active
             text: Aide Is Installed MUST be verified
             applicability:
                 - fedora-linux
@@ -1796,8 +2192,10 @@ controls:
       title: Ensure Filesystem Integrity Is Regularly Checked
       objective: Ensure Filesystem Integrity Is Regularly Checked
       group: logging
+      state: Active
       assessment-requirements:
           - id: aide_periodic_cron_checking
+            state: Active
             text: Filesystem Integrity Is Regularly Checked MUST be verified
             applicability:
                 - fedora-linux
@@ -1805,8 +2203,10 @@ controls:
       title: Ensure Cryptographic Mechanisms Are Used To Protect The Integrity Of Audit Tools
       objective: Ensure Cryptographic Mechanisms Are Used To Protect The Integrity Of Audit Tools
       group: logging
+      state: Active
       assessment-requirements:
           - id: aide_check_audit_tools
+            state: Active
             text: Cryptographic Mechanisms Are Used To Protect The Integrity Of Audit Tools MUST be verified
             applicability:
                 - fedora-linux
@@ -1814,8 +2214,10 @@ controls:
       title: Ensure Journald Service Is Active
       objective: Ensure Journald Service Is Active
       group: logging
+      state: Active
       assessment-requirements:
           - id: service_systemd-journald_enabled
+            state: Active
             text: Journald Service Is Active MUST be verified
             applicability:
                 - fedora-linux
@@ -1823,8 +2225,10 @@ controls:
       title: CIS Fedora 6 - 2.2.1.1
       objective: CIS Fedora 6 - 2.2.1.1
       group: logging
+      state: Active
       assessment-requirements:
           - id: package_systemd-journal-remote_installed
+            state: Active
             text: CIS Fedora 6 - 2.2.1.1 MUST be verified
             applicability:
                 - fedora-linux
@@ -1832,8 +2236,10 @@ controls:
       title: CIS Fedora 6 - 2.2.1.4
       objective: CIS Fedora 6 - 2.2.1.4
       group: logging
+      state: Active
       assessment-requirements:
           - id: socket_systemd-journal-remote_disabled
+            state: Active
             text: CIS Fedora 6 - 2.2.1.4 MUST be verified
             applicability:
                 - fedora-linux
@@ -1841,8 +2247,10 @@ controls:
       title: Ensure Journald Compress Is Configured
       objective: Ensure Journald Compress Is Configured
       group: logging
+      state: Active
       assessment-requirements:
           - id: journald_compress
+            state: Active
             text: Journald Compress Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1850,8 +2258,10 @@ controls:
       title: Ensure Journald Storage Is Configured
       objective: Ensure Journald Storage Is Configured
       group: logging
+      state: Active
       assessment-requirements:
           - id: journald_storage
+            state: Active
             text: Journald Storage Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1859,16 +2269,20 @@ controls:
       title: Ensure Access To All Logfiles Has Been Configured
       objective: Ensure Access To All Logfiles Has Been Configured
       group: logging
+      state: Active
       assessment-requirements:
           - id: rsyslog_files_groupownership
+            state: Active
             text: Access To All Logfiles Has Been Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: rsyslog_files_ownership
+            state: Active
             text: Access To All Logfiles Has Been Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: rsyslog_files_permissions
+            state: Active
             text: Access To All Logfiles Has Been Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1876,16 +2290,20 @@ controls:
       title: Ensure Access To /Etc/Passwd Is Configured
       objective: Ensure Access To /Etc/Passwd Is Configured
       group: maintenance
+      state: Active
       assessment-requirements:
           - id: file_groupowner_etc_passwd
+            state: Active
             text: Access To /Etc/Passwd Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_owner_etc_passwd
+            state: Active
             text: Access To /Etc/Passwd Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_permissions_etc_passwd
+            state: Active
             text: Access To /Etc/Passwd Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1893,12 +2311,15 @@ controls:
       title: Ensure World Writable Files And Directories Are Secured
       objective: Ensure World Writable Files And Directories Are Secured
       group: maintenance
+      state: Active
       assessment-requirements:
           - id: dir_perms_world_writable_sticky_bits
+            state: Active
             text: World Writable Files And Directories Are Secured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_permissions_unauthorized_world_writable
+            state: Active
             text: World Writable Files And Directories Are Secured MUST be verified
             applicability:
                 - fedora-linux
@@ -1906,16 +2327,20 @@ controls:
       title: Ensure Access To /Etc/Passwd- Is Configured
       objective: Ensure Access To /Etc/Passwd- Is Configured
       group: maintenance
+      state: Active
       assessment-requirements:
           - id: file_groupowner_backup_etc_passwd
+            state: Active
             text: Access To /Etc/Passwd- Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_owner_backup_etc_passwd
+            state: Active
             text: Access To /Etc/Passwd- Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_permissions_backup_etc_passwd
+            state: Active
             text: Access To /Etc/Passwd- Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1923,16 +2348,20 @@ controls:
       title: Ensure Access To /Etc/Group Is Configured
       objective: Ensure Access To /Etc/Group Is Configured
       group: maintenance
+      state: Active
       assessment-requirements:
           - id: file_groupowner_etc_group
+            state: Active
             text: Access To /Etc/Group Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_owner_etc_group
+            state: Active
             text: Access To /Etc/Group Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_permissions_etc_group
+            state: Active
             text: Access To /Etc/Group Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1940,16 +2369,20 @@ controls:
       title: Ensure Access To /Etc/Group- Is Configured
       objective: Ensure Access To /Etc/Group- Is Configured
       group: maintenance
+      state: Active
       assessment-requirements:
           - id: file_groupowner_backup_etc_group
+            state: Active
             text: Access To /Etc/Group- Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_owner_backup_etc_group
+            state: Active
             text: Access To /Etc/Group- Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_permissions_backup_etc_group
+            state: Active
             text: Access To /Etc/Group- Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1957,16 +2390,20 @@ controls:
       title: Ensure Access To /Etc/Shadow Is Configured
       objective: Ensure Access To /Etc/Shadow Is Configured
       group: maintenance
+      state: Active
       assessment-requirements:
           - id: file_groupowner_etc_shadow
+            state: Active
             text: Access To /Etc/Shadow Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_owner_etc_shadow
+            state: Active
             text: Access To /Etc/Shadow Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_permissions_etc_shadow
+            state: Active
             text: Access To /Etc/Shadow Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1974,16 +2411,20 @@ controls:
       title: Ensure Access To /Etc/Shadow- Is Configured
       objective: Ensure Access To /Etc/Shadow- Is Configured
       group: maintenance
+      state: Active
       assessment-requirements:
           - id: file_groupowner_backup_etc_shadow
+            state: Active
             text: Access To /Etc/Shadow- Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_owner_backup_etc_shadow
+            state: Active
             text: Access To /Etc/Shadow- Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_permissions_backup_etc_shadow
+            state: Active
             text: Access To /Etc/Shadow- Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -1991,16 +2432,20 @@ controls:
       title: Ensure Access To /Etc/Gshadow Is Configured
       objective: Ensure Access To /Etc/Gshadow Is Configured
       group: maintenance
+      state: Active
       assessment-requirements:
           - id: file_groupowner_etc_gshadow
+            state: Active
             text: Access To /Etc/Gshadow Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_owner_etc_gshadow
+            state: Active
             text: Access To /Etc/Gshadow Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_permissions_etc_gshadow
+            state: Active
             text: Access To /Etc/Gshadow Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -2008,16 +2453,20 @@ controls:
       title: Ensure Access To /Etc/Gshadow- Is Configured
       objective: Ensure Access To /Etc/Gshadow- Is Configured
       group: maintenance
+      state: Active
       assessment-requirements:
           - id: file_groupowner_backup_etc_gshadow
+            state: Active
             text: Access To /Etc/Gshadow- Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_owner_backup_etc_gshadow
+            state: Active
             text: Access To /Etc/Gshadow- Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_permissions_backup_etc_gshadow
+            state: Active
             text: Access To /Etc/Gshadow- Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -2025,16 +2474,20 @@ controls:
       title: Ensure Access To /Etc/Shells Is Configured
       objective: Ensure Access To /Etc/Shells Is Configured
       group: maintenance
+      state: Active
       assessment-requirements:
           - id: file_groupowner_etc_shells
+            state: Active
             text: Access To /Etc/Shells Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_owner_etc_shells
+            state: Active
             text: Access To /Etc/Shells Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_permissions_etc_shells
+            state: Active
             text: Access To /Etc/Shells Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -2042,8 +2495,10 @@ controls:
       title: Ensure Accounts In /Etc/Passwd Use Shadowed Passwords
       objective: Ensure Accounts In /Etc/Passwd Use Shadowed Passwords
       group: maintenance
+      state: Active
       assessment-requirements:
           - id: accounts_password_all_shadowed
+            state: Active
             text: Accounts In /Etc/Passwd Use Shadowed Passwords MUST be verified
             applicability:
                 - fedora-linux
@@ -2051,8 +2506,10 @@ controls:
       title: Ensure /Etc/Shadow Password Fields Are Not Empty
       objective: Ensure /Etc/Shadow Password Fields Are Not Empty
       group: maintenance
+      state: Active
       assessment-requirements:
           - id: no_empty_passwords_etc_shadow
+            state: Active
             text: /Etc/Shadow Password Fields Are Not Empty MUST be verified
             applicability:
                 - fedora-linux
@@ -2060,8 +2517,10 @@ controls:
       title: Ensure All Groups In /Etc/Passwd Exist In /Etc/Group
       objective: Ensure All Groups In /Etc/Passwd Exist In /Etc/Group
       group: maintenance
+      state: Active
       assessment-requirements:
           - id: gid_passwd_group_same
+            state: Active
             text: All Groups In /Etc/Passwd Exist In /Etc/Group MUST be verified
             applicability:
                 - fedora-linux
@@ -2069,8 +2528,10 @@ controls:
       title: Ensure No Duplicate Uids Exist
       objective: Ensure No Duplicate Uids Exist
       group: maintenance
+      state: Active
       assessment-requirements:
           - id: account_unique_id
+            state: Active
             text: No Duplicate Uids Exist MUST be verified
             applicability:
                 - fedora-linux
@@ -2078,8 +2539,10 @@ controls:
       title: Ensure No Duplicate Gids Exist
       objective: Ensure No Duplicate Gids Exist
       group: maintenance
+      state: Active
       assessment-requirements:
           - id: group_unique_id
+            state: Active
             text: No Duplicate Gids Exist MUST be verified
             applicability:
                 - fedora-linux
@@ -2087,8 +2550,10 @@ controls:
       title: Ensure No Duplicate User Names Exist
       objective: Ensure No Duplicate User Names Exist
       group: maintenance
+      state: Active
       assessment-requirements:
           - id: account_unique_name
+            state: Active
             text: No Duplicate User Names Exist MUST be verified
             applicability:
                 - fedora-linux
@@ -2096,8 +2561,10 @@ controls:
       title: Ensure No Duplicate Group Names Exist
       objective: Ensure No Duplicate Group Names Exist
       group: maintenance
+      state: Active
       assessment-requirements:
           - id: group_unique_name
+            state: Active
             text: No Duplicate Group Names Exist MUST be verified
             applicability:
                 - fedora-linux
@@ -2105,16 +2572,20 @@ controls:
       title: Ensure Local Interactive User Home Directories Are Configured
       objective: Ensure Local Interactive User Home Directories Are Configured
       group: maintenance
+      state: Active
       assessment-requirements:
           - id: accounts_user_interactive_home_directory_exists
+            state: Active
             text: Local Interactive User Home Directories Are Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_ownership_home_directories
+            state: Active
             text: Local Interactive User Home Directories Are Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_permissions_home_directories
+            state: Active
             text: Local Interactive User Home Directories Are Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -2122,24 +2593,30 @@ controls:
       title: Ensure Local Interactive User Dot Files Access Is Configured
       objective: Ensure Local Interactive User Dot Files Access Is Configured
       group: maintenance
+      state: Active
       assessment-requirements:
           - id: accounts_user_dot_group_ownership
+            state: Active
             text: Local Interactive User Dot Files Access Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: accounts_user_dot_user_ownership
+            state: Active
             text: Local Interactive User Dot Files Access Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: file_permission_user_init_files
+            state: Active
             text: Local Interactive User Dot Files Access Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: no_forward_files
+            state: Active
             text: Local Interactive User Dot Files Access Is Configured MUST be verified
             applicability:
                 - fedora-linux
           - id: no_netrc_files
+            state: Active
             text: Local Interactive User Dot Files Access Is Configured MUST be verified
             applicability:
                 - fedora-linux
@@ -2147,8 +2624,10 @@ controls:
       title: Reload Dconf Database
       objective: Reload Dconf Database
       group: operations
+      state: Active
       assessment-requirements:
           - id: dconf_db_up_to_date
+            state: Active
             text: The dconf database MUST be reloaded after configuration changes
             applicability:
                 - fedora-linux

--- a/governance/policies/ampel-branch-protection-policy.yaml
+++ b/governance/policies/ampel-branch-protection-policy.yaml
@@ -2,6 +2,7 @@ title: AMPEL Branch Protection Policy
 metadata:
     id: ampel-branch-protection-policy
     type: Policy
+    gemara-version: "1.2.0"
     description: Automated evaluation policy for branch protection controls using AMPEL
     author:
         id: complytime
@@ -12,7 +13,7 @@ metadata:
           title: Branch Protection Controls
           version: 1.0.0
           description: Control catalog for branch protection rules
-          url: ../catalogs/ampel-branch-protection-catalog.yaml
+          url: file://../catalogs/ampel-branch-protection-catalog.yaml
 contacts:
     responsible:
         - name: Repository Administrator
@@ -31,7 +32,7 @@ imports:
 adherence:
     evaluation-methods:
         - id: ampel-automated-evaluation
-          type: Gate
+          type: Behavioral
           mode: Automated
           description: AMPEL automated branch protection evaluation
           executor:
@@ -44,33 +45,33 @@ adherence:
           frequency: on-demand
           evaluation-methods:
               - id: ampel-automated-evaluation
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: minimum-approvals
           requirement-id: minimum-approvals
           frequency: on-demand
           evaluation-methods:
               - id: ampel-automated-evaluation
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: block-force-push
           requirement-id: block-force-push
           frequency: on-demand
           evaluation-methods:
               - id: ampel-automated-evaluation
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: prevent-admin-bypass
           requirement-id: prevent-admin-bypass
           frequency: on-demand
           evaluation-methods:
               - id: ampel-automated-evaluation
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: require-code-owner-review
           requirement-id: require-code-owner-review
           frequency: on-demand
           evaluation-methods:
               - id: ampel-automated-evaluation
-                type: Gate
+                type: Behavioral
                 mode: Automated

--- a/governance/policies/cis-fedora-l1-server-policy.yaml
+++ b/governance/policies/cis-fedora-l1-server-policy.yaml
@@ -13,12 +13,12 @@ metadata:
       title: CIS Fedora Linux - Level 1 Server
       version: 1.0.0
       description: Control catalog for CIS Fedora Linux Level 1 Server Benchmark
-      url: ../catalogs/cis-fedora-l1-server-catalog.yaml
+      url: file://../catalogs/cis-fedora-l1-server-catalog.yaml
     - id: cis-fedora-l1-guidance
       title: CIS Fedora Linux - Level 1 Guidance
       version: 1.0.0
       description: Guidance catalog for CIS Fedora Linux Level 1 Benchmark
-      url: ../guidance/cis-fedora-l1-guidance.yaml
+      url: file://../guidance/cis-fedora-l1-guidance.yaml
 contacts:
   responsible:
     - name: System Administrator
@@ -38,7 +38,7 @@ imports:
 adherence:
   evaluation-methods:
     - id: openscap-automated
-      type: Gate
+      type: Behavioral
       mode: Automated
       description: OpenSCAP automated compliance evaluation
       executor:
@@ -51,1979 +51,1979 @@ adherence:
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: account_password_pam_faillock_password_auth
       requirement-id: account_password_pam_faillock_password_auth
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: account_password_pam_faillock_system_auth
       requirement-id: account_password_pam_faillock_system_auth
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: account_unique_id
       requirement-id: account_unique_id
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: account_unique_name
       requirement-id: account_unique_name
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: accounts_maximum_age_login_defs
       requirement-id: accounts_maximum_age_login_defs
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: accounts_no_uid_except_zero
       requirement-id: accounts_no_uid_except_zero
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: accounts_password_all_shadowed
       requirement-id: accounts_password_all_shadowed
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: accounts_password_last_change_is_in_past
       requirement-id: accounts_password_last_change_is_in_past
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: accounts_password_pam_dictcheck
       requirement-id: accounts_password_pam_dictcheck
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: accounts_password_pam_difok
       requirement-id: accounts_password_pam_difok
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: accounts_password_pam_enforce_root
       requirement-id: accounts_password_pam_enforce_root
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: accounts_password_pam_maxrepeat
       requirement-id: accounts_password_pam_maxrepeat
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: accounts_password_pam_minclass
       requirement-id: accounts_password_pam_minclass
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: accounts_password_pam_minlen
       requirement-id: accounts_password_pam_minlen
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: accounts_password_pam_pwhistory_remember_password_auth
       requirement-id: accounts_password_pam_pwhistory_remember_password_auth
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: accounts_password_pam_pwhistory_remember_system_auth
       requirement-id: accounts_password_pam_pwhistory_remember_system_auth
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: accounts_password_pam_pwquality_password_auth
       requirement-id: accounts_password_pam_pwquality_password_auth
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: accounts_password_pam_pwquality_system_auth
       requirement-id: accounts_password_pam_pwquality_system_auth
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: accounts_password_set_max_life_existing
       requirement-id: accounts_password_set_max_life_existing
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: accounts_password_set_warn_age_existing
       requirement-id: accounts_password_set_warn_age_existing
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: accounts_password_warn_age_login_defs
       requirement-id: accounts_password_warn_age_login_defs
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: accounts_passwords_pam_faillock_deny
       requirement-id: accounts_passwords_pam_faillock_deny
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: accounts_passwords_pam_faillock_unlock_time
       requirement-id: accounts_passwords_pam_faillock_unlock_time
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: accounts_root_gid_zero
       requirement-id: accounts_root_gid_zero
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: accounts_root_path_dirs_no_write
       requirement-id: accounts_root_path_dirs_no_write
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: accounts_set_post_pw_existing
       requirement-id: accounts_set_post_pw_existing
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: accounts_tmout
       requirement-id: accounts_tmout
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: accounts_umask_etc_bashrc
       requirement-id: accounts_umask_etc_bashrc
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: accounts_umask_etc_login_defs
       requirement-id: accounts_umask_etc_login_defs
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: accounts_umask_etc_profile
       requirement-id: accounts_umask_etc_profile
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: accounts_user_dot_group_ownership
       requirement-id: accounts_user_dot_group_ownership
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: accounts_user_dot_user_ownership
       requirement-id: accounts_user_dot_user_ownership
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: accounts_user_interactive_home_directory_exists
       requirement-id: accounts_user_interactive_home_directory_exists
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: aide_build_database
       requirement-id: aide_build_database
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: aide_check_audit_tools
       requirement-id: aide_check_audit_tools
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: aide_periodic_cron_checking
       requirement-id: aide_periodic_cron_checking
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: banner_etc_issue_cis
       requirement-id: banner_etc_issue_cis
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: banner_etc_issue_net_cis
       requirement-id: banner_etc_issue_net_cis
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: banner_etc_motd_cis
       requirement-id: banner_etc_motd_cis
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: chronyd_run_as_chrony_user
       requirement-id: chronyd_run_as_chrony_user
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: chronyd_specify_remote_server
       requirement-id: chronyd_specify_remote_server
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: coredump_disable_backtraces
       requirement-id: coredump_disable_backtraces
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: coredump_disable_storage
       requirement-id: coredump_disable_storage
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: dconf_db_up_to_date
       requirement-id: dconf_db_up_to_date
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: dconf_gnome_banner_enabled
       requirement-id: dconf_gnome_banner_enabled
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - frequency: on-demand
       id: dconf_gnome_disable_automount
       requirement-id: dconf_gnome_disable_automount
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - frequency: on-demand
       id: dconf_gnome_disable_automount_open
       requirement-id: dconf_gnome_disable_automount_open
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: dconf_gnome_disable_autorun
       requirement-id: dconf_gnome_disable_autorun
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: dconf_gnome_disable_user_list
       requirement-id: dconf_gnome_disable_user_list
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: dconf_gnome_login_banner_text
       requirement-id: dconf_gnome_login_banner_text
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: dconf_gnome_screensaver_idle_delay
       requirement-id: dconf_gnome_screensaver_idle_delay
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: dconf_gnome_screensaver_lock_delay
       requirement-id: dconf_gnome_screensaver_lock_delay
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: dconf_gnome_screensaver_user_locks
       requirement-id: dconf_gnome_screensaver_user_locks
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: dconf_gnome_session_idle_user_locks
       requirement-id: dconf_gnome_session_idle_user_locks
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: dir_perms_world_writable_sticky_bits
       requirement-id: dir_perms_world_writable_sticky_bits
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: disable_host_auth
       requirement-id: disable_host_auth
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: disable_users_coredumps
       requirement-id: disable_users_coredumps
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: ensure_gpgcheck_globally_activated
       requirement-id: ensure_gpgcheck_globally_activated
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: ensure_pam_wheel_group_empty
       requirement-id: ensure_pam_wheel_group_empty
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: ensure_root_password_configured
       requirement-id: ensure_root_password_configured
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_at_deny_not_exist
       requirement-id: file_at_deny_not_exist
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_cron_allow_exists
       requirement-id: file_cron_allow_exists
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_cron_deny_not_exist
       requirement-id: file_cron_deny_not_exist
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_groupowner_at_allow
       requirement-id: file_groupowner_at_allow
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_groupowner_backup_etc_group
       requirement-id: file_groupowner_backup_etc_group
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_groupowner_backup_etc_gshadow
       requirement-id: file_groupowner_backup_etc_gshadow
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_groupowner_backup_etc_passwd
       requirement-id: file_groupowner_backup_etc_passwd
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_groupowner_backup_etc_shadow
       requirement-id: file_groupowner_backup_etc_shadow
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_groupowner_cron_allow
       requirement-id: file_groupowner_cron_allow
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_groupowner_cron_d
       requirement-id: file_groupowner_cron_d
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_groupowner_cron_daily
       requirement-id: file_groupowner_cron_daily
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_groupowner_cron_hourly
       requirement-id: file_groupowner_cron_hourly
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_groupowner_cron_monthly
       requirement-id: file_groupowner_cron_monthly
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_groupowner_cron_weekly
       requirement-id: file_groupowner_cron_weekly
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_groupowner_crontab
       requirement-id: file_groupowner_crontab
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_groupowner_etc_group
       requirement-id: file_groupowner_etc_group
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_groupowner_etc_gshadow
       requirement-id: file_groupowner_etc_gshadow
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_groupowner_etc_issue
       requirement-id: file_groupowner_etc_issue
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_groupowner_etc_issue_net
       requirement-id: file_groupowner_etc_issue_net
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_groupowner_etc_motd
       requirement-id: file_groupowner_etc_motd
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_groupowner_etc_passwd
       requirement-id: file_groupowner_etc_passwd
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_groupowner_etc_shadow
       requirement-id: file_groupowner_etc_shadow
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_groupowner_etc_shells
       requirement-id: file_groupowner_etc_shells
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_groupowner_sshd_config
       requirement-id: file_groupowner_sshd_config
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_groupownership_sshd_private_key
       requirement-id: file_groupownership_sshd_private_key
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_groupownership_sshd_pub_key
       requirement-id: file_groupownership_sshd_pub_key
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_owner_at_allow
       requirement-id: file_owner_at_allow
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_owner_backup_etc_group
       requirement-id: file_owner_backup_etc_group
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_owner_backup_etc_gshadow
       requirement-id: file_owner_backup_etc_gshadow
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_owner_backup_etc_passwd
       requirement-id: file_owner_backup_etc_passwd
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_owner_backup_etc_shadow
       requirement-id: file_owner_backup_etc_shadow
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_owner_cron_allow
       requirement-id: file_owner_cron_allow
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_owner_cron_d
       requirement-id: file_owner_cron_d
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_owner_cron_daily
       requirement-id: file_owner_cron_daily
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_owner_cron_hourly
       requirement-id: file_owner_cron_hourly
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_owner_cron_monthly
       requirement-id: file_owner_cron_monthly
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_owner_cron_weekly
       requirement-id: file_owner_cron_weekly
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_owner_crontab
       requirement-id: file_owner_crontab
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_owner_etc_group
       requirement-id: file_owner_etc_group
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_owner_etc_gshadow
       requirement-id: file_owner_etc_gshadow
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_owner_etc_issue
       requirement-id: file_owner_etc_issue
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_owner_etc_issue_net
       requirement-id: file_owner_etc_issue_net
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_owner_etc_motd
       requirement-id: file_owner_etc_motd
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_owner_etc_passwd
       requirement-id: file_owner_etc_passwd
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_owner_etc_shadow
       requirement-id: file_owner_etc_shadow
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_owner_etc_shells
       requirement-id: file_owner_etc_shells
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_owner_sshd_config
       requirement-id: file_owner_sshd_config
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_ownership_home_directories
       requirement-id: file_ownership_home_directories
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_ownership_sshd_private_key
       requirement-id: file_ownership_sshd_private_key
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_ownership_sshd_pub_key
       requirement-id: file_ownership_sshd_pub_key
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_permission_user_init_files
       requirement-id: file_permission_user_init_files
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_permissions_at_allow
       requirement-id: file_permissions_at_allow
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_permissions_backup_etc_group
       requirement-id: file_permissions_backup_etc_group
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_permissions_backup_etc_gshadow
       requirement-id: file_permissions_backup_etc_gshadow
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_permissions_backup_etc_passwd
       requirement-id: file_permissions_backup_etc_passwd
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_permissions_backup_etc_shadow
       requirement-id: file_permissions_backup_etc_shadow
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_permissions_cron_allow
       requirement-id: file_permissions_cron_allow
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_permissions_cron_d
       requirement-id: file_permissions_cron_d
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_permissions_cron_daily
       requirement-id: file_permissions_cron_daily
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_permissions_cron_hourly
       requirement-id: file_permissions_cron_hourly
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_permissions_cron_monthly
       requirement-id: file_permissions_cron_monthly
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_permissions_cron_weekly
       requirement-id: file_permissions_cron_weekly
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_permissions_crontab
       requirement-id: file_permissions_crontab
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_permissions_etc_group
       requirement-id: file_permissions_etc_group
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_permissions_etc_gshadow
       requirement-id: file_permissions_etc_gshadow
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_permissions_etc_issue
       requirement-id: file_permissions_etc_issue
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_permissions_etc_issue_net
       requirement-id: file_permissions_etc_issue_net
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_permissions_etc_motd
       requirement-id: file_permissions_etc_motd
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_permissions_etc_passwd
       requirement-id: file_permissions_etc_passwd
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_permissions_etc_shadow
       requirement-id: file_permissions_etc_shadow
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_permissions_etc_shells
       requirement-id: file_permissions_etc_shells
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_permissions_home_directories
       requirement-id: file_permissions_home_directories
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_permissions_sshd_config
       requirement-id: file_permissions_sshd_config
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_permissions_sshd_private_key
       requirement-id: file_permissions_sshd_private_key
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_permissions_sshd_pub_key
       requirement-id: file_permissions_sshd_pub_key
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: file_permissions_unauthorized_world_writable
       requirement-id: file_permissions_unauthorized_world_writable
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: firewalld_loopback_traffic_restricted
       requirement-id: firewalld_loopback_traffic_restricted
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: firewalld_loopback_traffic_trusted
       requirement-id: firewalld_loopback_traffic_trusted
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: gid_passwd_group_same
       requirement-id: gid_passwd_group_same
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: group_unique_id
       requirement-id: group_unique_id
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: group_unique_name
       requirement-id: group_unique_name
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: grub2_enable_selinux
       requirement-id: grub2_enable_selinux
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: grub2_password
       requirement-id: grub2_password
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: has_nonlocal_mta
       requirement-id: has_nonlocal_mta
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: journald_compress
       requirement-id: journald_compress
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: journald_storage
       requirement-id: journald_storage
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: kernel_module_atm_disabled
       requirement-id: kernel_module_atm_disabled
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: kernel_module_can_disabled
       requirement-id: kernel_module_can_disabled
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: kernel_module_cramfs_disabled
       requirement-id: kernel_module_cramfs_disabled
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: kernel_module_dccp_disabled
       requirement-id: kernel_module_dccp_disabled
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - frequency: on-demand
       id: kernel_module_firewire-core_disabled
       requirement-id: kernel_module_firewire-core_disabled
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: kernel_module_freevxfs_disabled
       requirement-id: kernel_module_freevxfs_disabled
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: kernel_module_hfs_disabled
       requirement-id: kernel_module_hfs_disabled
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: kernel_module_hfsplus_disabled
       requirement-id: kernel_module_hfsplus_disabled
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: kernel_module_jffs2_disabled
       requirement-id: kernel_module_jffs2_disabled
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: kernel_module_rds_disabled
       requirement-id: kernel_module_rds_disabled
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: kernel_module_tipc_disabled
       requirement-id: kernel_module_tipc_disabled
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - frequency: on-demand
       id: kernel_module_usb-storage_disabled
       requirement-id: kernel_module_usb-storage_disabled
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: mount_option_dev_shm_nodev
       requirement-id: mount_option_dev_shm_nodev
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: mount_option_dev_shm_noexec
       requirement-id: mount_option_dev_shm_noexec
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: mount_option_dev_shm_nosuid
       requirement-id: mount_option_dev_shm_nosuid
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: mount_option_home_nodev
       requirement-id: mount_option_home_nodev
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: mount_option_home_nosuid
       requirement-id: mount_option_home_nosuid
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: mount_option_tmp_nodev
       requirement-id: mount_option_tmp_nodev
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: mount_option_tmp_noexec
       requirement-id: mount_option_tmp_noexec
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: mount_option_tmp_nosuid
       requirement-id: mount_option_tmp_nosuid
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: mount_option_var_log_audit_nodev
       requirement-id: mount_option_var_log_audit_nodev
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: mount_option_var_log_audit_noexec
       requirement-id: mount_option_var_log_audit_noexec
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: mount_option_var_log_audit_nosuid
       requirement-id: mount_option_var_log_audit_nosuid
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: mount_option_var_log_nodev
       requirement-id: mount_option_var_log_nodev
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: mount_option_var_log_noexec
       requirement-id: mount_option_var_log_noexec
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: mount_option_var_log_nosuid
       requirement-id: mount_option_var_log_nosuid
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: mount_option_var_nodev
       requirement-id: mount_option_var_nodev
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: mount_option_var_nosuid
       requirement-id: mount_option_var_nosuid
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: mount_option_var_tmp_nodev
       requirement-id: mount_option_var_tmp_nodev
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: mount_option_var_tmp_noexec
       requirement-id: mount_option_var_tmp_noexec
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: mount_option_var_tmp_nosuid
       requirement-id: mount_option_var_tmp_nosuid
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: no_empty_passwords
       requirement-id: no_empty_passwords
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: no_empty_passwords_etc_shadow
       requirement-id: no_empty_passwords_etc_shadow
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: no_forward_files
       requirement-id: no_forward_files
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: no_netrc_files
       requirement-id: no_netrc_files
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: no_password_auth_for_systemaccounts
       requirement-id: no_password_auth_for_systemaccounts
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: no_shelllogin_for_systemaccounts
       requirement-id: no_shelllogin_for_systemaccounts
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: package_aide_installed
       requirement-id: package_aide_installed
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: package_bind_removed
       requirement-id: package_bind_removed
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: package_cron_installed
       requirement-id: package_cron_installed
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: package_cyrus-imapd_removed
       requirement-id: package_cyrus-imapd_removed
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: package_dnsmasq_removed
       requirement-id: package_dnsmasq_removed
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: package_dovecot_removed
       requirement-id: package_dovecot_removed
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: package_firewalld_installed
       requirement-id: package_firewalld_installed
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: package_ftp_removed
       requirement-id: package_ftp_removed
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: package_httpd_removed
       requirement-id: package_httpd_removed
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: package_kea_removed
       requirement-id: package_kea_removed
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: package_libselinux_installed
       requirement-id: package_libselinux_installed
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: package_mcstrans_removed
       requirement-id: package_mcstrans_removed
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: package_net-snmp_removed
       requirement-id: package_net-snmp_removed
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: package_nftables_installed
       requirement-id: package_nftables_installed
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: package_nginx_removed
       requirement-id: package_nginx_removed
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: package_pam_pwquality_installed
       requirement-id: package_pam_pwquality_installed
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: package_rsync_removed
       requirement-id: package_rsync_removed
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: package_samba_removed
       requirement-id: package_samba_removed
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - frequency: on-demand
       id: package_setroubleshoot_removed
       requirement-id: package_setroubleshoot_removed
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: package_squid_removed
       requirement-id: package_squid_removed
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: package_sudo_installed
       requirement-id: package_sudo_installed
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: package_systemd-journal-remote_installed
       requirement-id: package_systemd-journal-remote_installed
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: package_telnet-server_removed
       requirement-id: package_telnet-server_removed
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: package_telnet_removed
       requirement-id: package_telnet_removed
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: package_tftp-server_removed
       requirement-id: package_tftp-server_removed
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: package_tftp_removed
       requirement-id: package_tftp_removed
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: package_vsftpd_removed
       requirement-id: package_vsftpd_removed
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: partition_for_dev_shm
       requirement-id: partition_for_dev_shm
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: partition_for_tmp
       requirement-id: partition_for_tmp
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: postfix_network_listening_disabled
       requirement-id: postfix_network_listening_disabled
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: root_path_no_dot
       requirement-id: root_path_no_dot
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: rsyslog_files_groupownership
       requirement-id: rsyslog_files_groupownership
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: rsyslog_files_ownership
       requirement-id: rsyslog_files_ownership
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: rsyslog_files_permissions
       requirement-id: rsyslog_files_permissions
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: selinux_not_disabled
       requirement-id: selinux_not_disabled
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: selinux_policytype
       requirement-id: selinux_policytype
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - frequency: on-demand
       id: service_autofs_disabled
       requirement-id: service_autofs_disabled
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - frequency: on-demand
       id: service_avahi-daemon_disabled
       requirement-id: service_avahi-daemon_disabled
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - frequency: on-demand
       id: service_bluetooth_disabled
       requirement-id: service_bluetooth_disabled
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: service_crond_enabled
       requirement-id: service_crond_enabled
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - frequency: on-demand
       id: service_cups_disabled
       requirement-id: service_cups_disabled
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: service_firewalld_enabled
       requirement-id: service_firewalld_enabled
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: service_nfs_disabled
       requirement-id: service_nfs_disabled
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: service_nftables_disabled
       requirement-id: service_nftables_disabled
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: service_rpcbind_disabled
       requirement-id: service_rpcbind_disabled
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: service_systemd-journald_enabled
       requirement-id: service_systemd-journald_enabled
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: set_password_hashing_algorithm_logindefs
       requirement-id: set_password_hashing_algorithm_logindefs
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: set_password_hashing_algorithm_passwordauth
       requirement-id: set_password_hashing_algorithm_passwordauth
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: set_password_hashing_algorithm_systemauth
       requirement-id: set_password_hashing_algorithm_systemauth
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: socket_systemd-journal-remote_disabled
       requirement-id: socket_systemd-journal-remote_disabled
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sshd_disable_empty_passwords
       requirement-id: sshd_disable_empty_passwords
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sshd_disable_rhosts
       requirement-id: sshd_disable_rhosts
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sshd_disable_root_login
       requirement-id: sshd_disable_root_login
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sshd_do_not_permit_user_env
       requirement-id: sshd_do_not_permit_user_env
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sshd_enable_pam
       requirement-id: sshd_enable_pam
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sshd_enable_warning_banner_net
       requirement-id: sshd_enable_warning_banner_net
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sshd_limit_user_access
       requirement-id: sshd_limit_user_access
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sshd_set_idle_timeout
       requirement-id: sshd_set_idle_timeout
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sshd_set_keepalive
       requirement-id: sshd_set_keepalive
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sshd_set_login_grace_time
       requirement-id: sshd_set_login_grace_time
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sshd_set_loglevel_verbose
       requirement-id: sshd_set_loglevel_verbose
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sshd_set_max_auth_tries
       requirement-id: sshd_set_max_auth_tries
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sshd_set_max_sessions
       requirement-id: sshd_set_max_sessions
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sshd_set_maxstartups
       requirement-id: sshd_set_maxstartups
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sudo_add_use_pty
       requirement-id: sudo_add_use_pty
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sudo_custom_logfile
       requirement-id: sudo_custom_logfile
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sudo_remove_no_authenticate
       requirement-id: sudo_remove_no_authenticate
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sudo_require_reauthentication
       requirement-id: sudo_require_reauthentication
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sysctl_fs_protected_hardlinks
       requirement-id: sysctl_fs_protected_hardlinks
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sysctl_fs_protected_symlinks
       requirement-id: sysctl_fs_protected_symlinks
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sysctl_fs_suid_dumpable
       requirement-id: sysctl_fs_suid_dumpable
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sysctl_kernel_dmesg_restrict
       requirement-id: sysctl_kernel_dmesg_restrict
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sysctl_kernel_kptr_restrict
       requirement-id: sysctl_kernel_kptr_restrict
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sysctl_kernel_randomize_va_space
       requirement-id: sysctl_kernel_randomize_va_space
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sysctl_kernel_yama_ptrace_scope
       requirement-id: sysctl_kernel_yama_ptrace_scope
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sysctl_net_ipv4_conf_all_accept_redirects
       requirement-id: sysctl_net_ipv4_conf_all_accept_redirects
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sysctl_net_ipv4_conf_all_accept_source_route
       requirement-id: sysctl_net_ipv4_conf_all_accept_source_route
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sysctl_net_ipv4_conf_all_log_martians
       requirement-id: sysctl_net_ipv4_conf_all_log_martians
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sysctl_net_ipv4_conf_all_rp_filter
       requirement-id: sysctl_net_ipv4_conf_all_rp_filter
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sysctl_net_ipv4_conf_all_secure_redirects
       requirement-id: sysctl_net_ipv4_conf_all_secure_redirects
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sysctl_net_ipv4_conf_all_send_redirects
       requirement-id: sysctl_net_ipv4_conf_all_send_redirects
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sysctl_net_ipv4_conf_default_accept_redirects
       requirement-id: sysctl_net_ipv4_conf_default_accept_redirects
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sysctl_net_ipv4_conf_default_accept_source_route
       requirement-id: sysctl_net_ipv4_conf_default_accept_source_route
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sysctl_net_ipv4_conf_default_log_martians
       requirement-id: sysctl_net_ipv4_conf_default_log_martians
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sysctl_net_ipv4_conf_default_rp_filter
       requirement-id: sysctl_net_ipv4_conf_default_rp_filter
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sysctl_net_ipv4_conf_default_secure_redirects
       requirement-id: sysctl_net_ipv4_conf_default_secure_redirects
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sysctl_net_ipv4_conf_default_send_redirects
       requirement-id: sysctl_net_ipv4_conf_default_send_redirects
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sysctl_net_ipv4_icmp_echo_ignore_broadcasts
       requirement-id: sysctl_net_ipv4_icmp_echo_ignore_broadcasts
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sysctl_net_ipv4_icmp_ignore_bogus_error_responses
       requirement-id: sysctl_net_ipv4_icmp_ignore_bogus_error_responses
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sysctl_net_ipv4_tcp_syncookies
       requirement-id: sysctl_net_ipv4_tcp_syncookies
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sysctl_net_ipv6_conf_all_accept_ra
       requirement-id: sysctl_net_ipv6_conf_all_accept_ra
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sysctl_net_ipv6_conf_all_accept_redirects
       requirement-id: sysctl_net_ipv6_conf_all_accept_redirects
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sysctl_net_ipv6_conf_all_accept_source_route
       requirement-id: sysctl_net_ipv6_conf_all_accept_source_route
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sysctl_net_ipv6_conf_all_forwarding
       requirement-id: sysctl_net_ipv6_conf_all_forwarding
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sysctl_net_ipv6_conf_default_accept_ra
       requirement-id: sysctl_net_ipv6_conf_default_accept_ra
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sysctl_net_ipv6_conf_default_accept_redirects
       requirement-id: sysctl_net_ipv6_conf_default_accept_redirects
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: sysctl_net_ipv6_conf_default_accept_source_route
       requirement-id: sysctl_net_ipv6_conf_default_accept_source_route
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - id: use_pam_wheel_group_for_su
       requirement-id: use_pam_wheel_group_for_su
       frequency: on-demand
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
     - frequency: on-demand
       id: wireless_disable_interfaces
       requirement-id: wireless_disable_interfaces
       evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated

--- a/governance/policies/cis-fedora-l1-workstation-policy.yaml
+++ b/governance/policies/cis-fedora-l1-workstation-policy.yaml
@@ -13,12 +13,12 @@ metadata:
           title: CIS Fedora Linux - Level 1 Workstation
           version: 1.0.0
           description: Control catalog for CIS Fedora Linux Level 1 Workstation Benchmark
-          url: ../catalogs/cis-fedora-l1-workstation-catalog.yaml
+          url: file://../catalogs/cis-fedora-l1-workstation-catalog.yaml
         - id: cis-fedora-l1-guidance
           title: CIS Fedora Linux - Level 1 Guidance
           version: 1.0.0
           description: Guidance catalog for CIS Fedora Linux Level 1 Benchmark
-          url: ../guidance/cis-fedora-l1-guidance.yaml
+          url: file://../guidance/cis-fedora-l1-guidance.yaml
 contacts:
     responsible:
         - name: System Administrator
@@ -38,7 +38,7 @@ imports:
 adherence:
     evaluation-methods:
         - id: openscap-automated
-          type: Gate
+          type: Behavioral
           mode: Automated
           description: OpenSCAP automated compliance evaluation
           executor:
@@ -51,1923 +51,1923 @@ adherence:
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: account_password_pam_faillock_password_auth
           requirement-id: account_password_pam_faillock_password_auth
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: account_password_pam_faillock_system_auth
           requirement-id: account_password_pam_faillock_system_auth
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: account_unique_id
           requirement-id: account_unique_id
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: account_unique_name
           requirement-id: account_unique_name
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: accounts_maximum_age_login_defs
           requirement-id: accounts_maximum_age_login_defs
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: accounts_no_uid_except_zero
           requirement-id: accounts_no_uid_except_zero
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: accounts_password_all_shadowed
           requirement-id: accounts_password_all_shadowed
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: accounts_password_last_change_is_in_past
           requirement-id: accounts_password_last_change_is_in_past
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: accounts_password_pam_dictcheck
           requirement-id: accounts_password_pam_dictcheck
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: accounts_password_pam_difok
           requirement-id: accounts_password_pam_difok
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: accounts_password_pam_enforce_root
           requirement-id: accounts_password_pam_enforce_root
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: accounts_password_pam_maxrepeat
           requirement-id: accounts_password_pam_maxrepeat
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: accounts_password_pam_minclass
           requirement-id: accounts_password_pam_minclass
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: accounts_password_pam_minlen
           requirement-id: accounts_password_pam_minlen
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: accounts_password_pam_pwhistory_remember_password_auth
           requirement-id: accounts_password_pam_pwhistory_remember_password_auth
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: accounts_password_pam_pwhistory_remember_system_auth
           requirement-id: accounts_password_pam_pwhistory_remember_system_auth
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: accounts_password_pam_pwquality_password_auth
           requirement-id: accounts_password_pam_pwquality_password_auth
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: accounts_password_pam_pwquality_system_auth
           requirement-id: accounts_password_pam_pwquality_system_auth
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: accounts_password_set_max_life_existing
           requirement-id: accounts_password_set_max_life_existing
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: accounts_password_set_warn_age_existing
           requirement-id: accounts_password_set_warn_age_existing
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: accounts_password_warn_age_login_defs
           requirement-id: accounts_password_warn_age_login_defs
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: accounts_passwords_pam_faillock_deny
           requirement-id: accounts_passwords_pam_faillock_deny
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: accounts_passwords_pam_faillock_unlock_time
           requirement-id: accounts_passwords_pam_faillock_unlock_time
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: accounts_root_gid_zero
           requirement-id: accounts_root_gid_zero
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: accounts_root_path_dirs_no_write
           requirement-id: accounts_root_path_dirs_no_write
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: accounts_set_post_pw_existing
           requirement-id: accounts_set_post_pw_existing
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: accounts_tmout
           requirement-id: accounts_tmout
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: accounts_umask_etc_bashrc
           requirement-id: accounts_umask_etc_bashrc
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: accounts_umask_etc_login_defs
           requirement-id: accounts_umask_etc_login_defs
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: accounts_umask_etc_profile
           requirement-id: accounts_umask_etc_profile
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: accounts_user_dot_group_ownership
           requirement-id: accounts_user_dot_group_ownership
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: accounts_user_dot_user_ownership
           requirement-id: accounts_user_dot_user_ownership
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: accounts_user_interactive_home_directory_exists
           requirement-id: accounts_user_interactive_home_directory_exists
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: aide_build_database
           requirement-id: aide_build_database
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: aide_check_audit_tools
           requirement-id: aide_check_audit_tools
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: aide_periodic_cron_checking
           requirement-id: aide_periodic_cron_checking
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: banner_etc_issue_cis
           requirement-id: banner_etc_issue_cis
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: banner_etc_issue_net_cis
           requirement-id: banner_etc_issue_net_cis
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: banner_etc_motd_cis
           requirement-id: banner_etc_motd_cis
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: chronyd_run_as_chrony_user
           requirement-id: chronyd_run_as_chrony_user
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: chronyd_specify_remote_server
           requirement-id: chronyd_specify_remote_server
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: coredump_disable_backtraces
           requirement-id: coredump_disable_backtraces
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: coredump_disable_storage
           requirement-id: coredump_disable_storage
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: dconf_db_up_to_date
           requirement-id: dconf_db_up_to_date
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: dconf_gnome_banner_enabled
           requirement-id: dconf_gnome_banner_enabled
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: dconf_gnome_disable_autorun
           requirement-id: dconf_gnome_disable_autorun
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: dconf_gnome_disable_user_list
           requirement-id: dconf_gnome_disable_user_list
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: dconf_gnome_login_banner_text
           requirement-id: dconf_gnome_login_banner_text
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: dconf_gnome_screensaver_idle_delay
           requirement-id: dconf_gnome_screensaver_idle_delay
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: dconf_gnome_screensaver_lock_delay
           requirement-id: dconf_gnome_screensaver_lock_delay
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: dconf_gnome_screensaver_user_locks
           requirement-id: dconf_gnome_screensaver_user_locks
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: dconf_gnome_session_idle_user_locks
           requirement-id: dconf_gnome_session_idle_user_locks
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: dir_perms_world_writable_sticky_bits
           requirement-id: dir_perms_world_writable_sticky_bits
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: disable_host_auth
           requirement-id: disable_host_auth
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: disable_users_coredumps
           requirement-id: disable_users_coredumps
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: ensure_gpgcheck_globally_activated
           requirement-id: ensure_gpgcheck_globally_activated
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: ensure_pam_wheel_group_empty
           requirement-id: ensure_pam_wheel_group_empty
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: ensure_root_password_configured
           requirement-id: ensure_root_password_configured
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_at_deny_not_exist
           requirement-id: file_at_deny_not_exist
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_cron_allow_exists
           requirement-id: file_cron_allow_exists
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_cron_deny_not_exist
           requirement-id: file_cron_deny_not_exist
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_groupowner_at_allow
           requirement-id: file_groupowner_at_allow
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_groupowner_backup_etc_group
           requirement-id: file_groupowner_backup_etc_group
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_groupowner_backup_etc_gshadow
           requirement-id: file_groupowner_backup_etc_gshadow
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_groupowner_backup_etc_passwd
           requirement-id: file_groupowner_backup_etc_passwd
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_groupowner_backup_etc_shadow
           requirement-id: file_groupowner_backup_etc_shadow
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_groupowner_cron_allow
           requirement-id: file_groupowner_cron_allow
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_groupowner_cron_d
           requirement-id: file_groupowner_cron_d
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_groupowner_cron_daily
           requirement-id: file_groupowner_cron_daily
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_groupowner_cron_hourly
           requirement-id: file_groupowner_cron_hourly
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_groupowner_cron_monthly
           requirement-id: file_groupowner_cron_monthly
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_groupowner_cron_weekly
           requirement-id: file_groupowner_cron_weekly
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_groupowner_crontab
           requirement-id: file_groupowner_crontab
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_groupowner_etc_group
           requirement-id: file_groupowner_etc_group
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_groupowner_etc_gshadow
           requirement-id: file_groupowner_etc_gshadow
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_groupowner_etc_issue
           requirement-id: file_groupowner_etc_issue
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_groupowner_etc_issue_net
           requirement-id: file_groupowner_etc_issue_net
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_groupowner_etc_motd
           requirement-id: file_groupowner_etc_motd
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_groupowner_etc_passwd
           requirement-id: file_groupowner_etc_passwd
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_groupowner_etc_shadow
           requirement-id: file_groupowner_etc_shadow
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_groupowner_etc_shells
           requirement-id: file_groupowner_etc_shells
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_groupowner_sshd_config
           requirement-id: file_groupowner_sshd_config
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_groupownership_sshd_private_key
           requirement-id: file_groupownership_sshd_private_key
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_groupownership_sshd_pub_key
           requirement-id: file_groupownership_sshd_pub_key
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_owner_at_allow
           requirement-id: file_owner_at_allow
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_owner_backup_etc_group
           requirement-id: file_owner_backup_etc_group
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_owner_backup_etc_gshadow
           requirement-id: file_owner_backup_etc_gshadow
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_owner_backup_etc_passwd
           requirement-id: file_owner_backup_etc_passwd
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_owner_backup_etc_shadow
           requirement-id: file_owner_backup_etc_shadow
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_owner_cron_allow
           requirement-id: file_owner_cron_allow
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_owner_cron_d
           requirement-id: file_owner_cron_d
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_owner_cron_daily
           requirement-id: file_owner_cron_daily
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_owner_cron_hourly
           requirement-id: file_owner_cron_hourly
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_owner_cron_monthly
           requirement-id: file_owner_cron_monthly
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_owner_cron_weekly
           requirement-id: file_owner_cron_weekly
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_owner_crontab
           requirement-id: file_owner_crontab
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_owner_etc_group
           requirement-id: file_owner_etc_group
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_owner_etc_gshadow
           requirement-id: file_owner_etc_gshadow
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_owner_etc_issue
           requirement-id: file_owner_etc_issue
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_owner_etc_issue_net
           requirement-id: file_owner_etc_issue_net
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_owner_etc_motd
           requirement-id: file_owner_etc_motd
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_owner_etc_passwd
           requirement-id: file_owner_etc_passwd
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_owner_etc_shadow
           requirement-id: file_owner_etc_shadow
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_owner_etc_shells
           requirement-id: file_owner_etc_shells
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_owner_sshd_config
           requirement-id: file_owner_sshd_config
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_ownership_home_directories
           requirement-id: file_ownership_home_directories
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_ownership_sshd_private_key
           requirement-id: file_ownership_sshd_private_key
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_ownership_sshd_pub_key
           requirement-id: file_ownership_sshd_pub_key
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_permission_user_init_files
           requirement-id: file_permission_user_init_files
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_permissions_at_allow
           requirement-id: file_permissions_at_allow
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_permissions_backup_etc_group
           requirement-id: file_permissions_backup_etc_group
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_permissions_backup_etc_gshadow
           requirement-id: file_permissions_backup_etc_gshadow
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_permissions_backup_etc_passwd
           requirement-id: file_permissions_backup_etc_passwd
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_permissions_backup_etc_shadow
           requirement-id: file_permissions_backup_etc_shadow
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_permissions_cron_allow
           requirement-id: file_permissions_cron_allow
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_permissions_cron_d
           requirement-id: file_permissions_cron_d
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_permissions_cron_daily
           requirement-id: file_permissions_cron_daily
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_permissions_cron_hourly
           requirement-id: file_permissions_cron_hourly
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_permissions_cron_monthly
           requirement-id: file_permissions_cron_monthly
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_permissions_cron_weekly
           requirement-id: file_permissions_cron_weekly
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_permissions_crontab
           requirement-id: file_permissions_crontab
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_permissions_etc_group
           requirement-id: file_permissions_etc_group
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_permissions_etc_gshadow
           requirement-id: file_permissions_etc_gshadow
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_permissions_etc_issue
           requirement-id: file_permissions_etc_issue
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_permissions_etc_issue_net
           requirement-id: file_permissions_etc_issue_net
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_permissions_etc_motd
           requirement-id: file_permissions_etc_motd
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_permissions_etc_passwd
           requirement-id: file_permissions_etc_passwd
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_permissions_etc_shadow
           requirement-id: file_permissions_etc_shadow
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_permissions_etc_shells
           requirement-id: file_permissions_etc_shells
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_permissions_home_directories
           requirement-id: file_permissions_home_directories
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_permissions_sshd_config
           requirement-id: file_permissions_sshd_config
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_permissions_sshd_private_key
           requirement-id: file_permissions_sshd_private_key
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_permissions_sshd_pub_key
           requirement-id: file_permissions_sshd_pub_key
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: file_permissions_unauthorized_world_writable
           requirement-id: file_permissions_unauthorized_world_writable
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: firewalld_loopback_traffic_restricted
           requirement-id: firewalld_loopback_traffic_restricted
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: firewalld_loopback_traffic_trusted
           requirement-id: firewalld_loopback_traffic_trusted
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: gid_passwd_group_same
           requirement-id: gid_passwd_group_same
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: group_unique_id
           requirement-id: group_unique_id
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: group_unique_name
           requirement-id: group_unique_name
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: grub2_enable_selinux
           requirement-id: grub2_enable_selinux
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: grub2_password
           requirement-id: grub2_password
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: has_nonlocal_mta
           requirement-id: has_nonlocal_mta
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: journald_compress
           requirement-id: journald_compress
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: journald_storage
           requirement-id: journald_storage
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: kernel_module_atm_disabled
           requirement-id: kernel_module_atm_disabled
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: kernel_module_can_disabled
           requirement-id: kernel_module_can_disabled
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: kernel_module_cramfs_disabled
           requirement-id: kernel_module_cramfs_disabled
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: kernel_module_dccp_disabled
           requirement-id: kernel_module_dccp_disabled
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: kernel_module_freevxfs_disabled
           requirement-id: kernel_module_freevxfs_disabled
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: kernel_module_hfs_disabled
           requirement-id: kernel_module_hfs_disabled
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: kernel_module_hfsplus_disabled
           requirement-id: kernel_module_hfsplus_disabled
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: kernel_module_jffs2_disabled
           requirement-id: kernel_module_jffs2_disabled
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: kernel_module_rds_disabled
           requirement-id: kernel_module_rds_disabled
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: kernel_module_tipc_disabled
           requirement-id: kernel_module_tipc_disabled
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: mount_option_dev_shm_nodev
           requirement-id: mount_option_dev_shm_nodev
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: mount_option_dev_shm_noexec
           requirement-id: mount_option_dev_shm_noexec
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: mount_option_dev_shm_nosuid
           requirement-id: mount_option_dev_shm_nosuid
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: mount_option_home_nodev
           requirement-id: mount_option_home_nodev
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: mount_option_home_nosuid
           requirement-id: mount_option_home_nosuid
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: mount_option_tmp_nodev
           requirement-id: mount_option_tmp_nodev
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: mount_option_tmp_noexec
           requirement-id: mount_option_tmp_noexec
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: mount_option_tmp_nosuid
           requirement-id: mount_option_tmp_nosuid
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: mount_option_var_log_audit_nodev
           requirement-id: mount_option_var_log_audit_nodev
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: mount_option_var_log_audit_noexec
           requirement-id: mount_option_var_log_audit_noexec
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: mount_option_var_log_audit_nosuid
           requirement-id: mount_option_var_log_audit_nosuid
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: mount_option_var_log_nodev
           requirement-id: mount_option_var_log_nodev
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: mount_option_var_log_noexec
           requirement-id: mount_option_var_log_noexec
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: mount_option_var_log_nosuid
           requirement-id: mount_option_var_log_nosuid
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: mount_option_var_nodev
           requirement-id: mount_option_var_nodev
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: mount_option_var_nosuid
           requirement-id: mount_option_var_nosuid
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: mount_option_var_tmp_nodev
           requirement-id: mount_option_var_tmp_nodev
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: mount_option_var_tmp_noexec
           requirement-id: mount_option_var_tmp_noexec
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: mount_option_var_tmp_nosuid
           requirement-id: mount_option_var_tmp_nosuid
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: no_empty_passwords
           requirement-id: no_empty_passwords
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: no_empty_passwords_etc_shadow
           requirement-id: no_empty_passwords_etc_shadow
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: no_forward_files
           requirement-id: no_forward_files
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: no_netrc_files
           requirement-id: no_netrc_files
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: no_password_auth_for_systemaccounts
           requirement-id: no_password_auth_for_systemaccounts
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: no_shelllogin_for_systemaccounts
           requirement-id: no_shelllogin_for_systemaccounts
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: package_aide_installed
           requirement-id: package_aide_installed
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: package_bind_removed
           requirement-id: package_bind_removed
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: package_cron_installed
           requirement-id: package_cron_installed
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: package_cyrus-imapd_removed
           requirement-id: package_cyrus-imapd_removed
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: package_dnsmasq_removed
           requirement-id: package_dnsmasq_removed
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: package_dovecot_removed
           requirement-id: package_dovecot_removed
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: package_firewalld_installed
           requirement-id: package_firewalld_installed
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: package_ftp_removed
           requirement-id: package_ftp_removed
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: package_httpd_removed
           requirement-id: package_httpd_removed
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: package_kea_removed
           requirement-id: package_kea_removed
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: package_libselinux_installed
           requirement-id: package_libselinux_installed
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: package_mcstrans_removed
           requirement-id: package_mcstrans_removed
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: package_net-snmp_removed
           requirement-id: package_net-snmp_removed
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: package_nftables_installed
           requirement-id: package_nftables_installed
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: package_nginx_removed
           requirement-id: package_nginx_removed
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: package_pam_pwquality_installed
           requirement-id: package_pam_pwquality_installed
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: package_rsync_removed
           requirement-id: package_rsync_removed
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: package_samba_removed
           requirement-id: package_samba_removed
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: package_squid_removed
           requirement-id: package_squid_removed
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: package_sudo_installed
           requirement-id: package_sudo_installed
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: package_systemd-journal-remote_installed
           requirement-id: package_systemd-journal-remote_installed
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: package_telnet-server_removed
           requirement-id: package_telnet-server_removed
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: package_telnet_removed
           requirement-id: package_telnet_removed
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: package_tftp-server_removed
           requirement-id: package_tftp-server_removed
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: package_tftp_removed
           requirement-id: package_tftp_removed
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: package_vsftpd_removed
           requirement-id: package_vsftpd_removed
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: partition_for_dev_shm
           requirement-id: partition_for_dev_shm
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: partition_for_tmp
           requirement-id: partition_for_tmp
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: postfix_network_listening_disabled
           requirement-id: postfix_network_listening_disabled
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: root_path_no_dot
           requirement-id: root_path_no_dot
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: rsyslog_files_groupownership
           requirement-id: rsyslog_files_groupownership
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: rsyslog_files_ownership
           requirement-id: rsyslog_files_ownership
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: rsyslog_files_permissions
           requirement-id: rsyslog_files_permissions
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: selinux_not_disabled
           requirement-id: selinux_not_disabled
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: selinux_policytype
           requirement-id: selinux_policytype
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: service_crond_enabled
           requirement-id: service_crond_enabled
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: service_firewalld_enabled
           requirement-id: service_firewalld_enabled
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: service_nfs_disabled
           requirement-id: service_nfs_disabled
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: service_nftables_disabled
           requirement-id: service_nftables_disabled
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: service_rpcbind_disabled
           requirement-id: service_rpcbind_disabled
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: service_systemd-journald_enabled
           requirement-id: service_systemd-journald_enabled
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: set_password_hashing_algorithm_logindefs
           requirement-id: set_password_hashing_algorithm_logindefs
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: set_password_hashing_algorithm_passwordauth
           requirement-id: set_password_hashing_algorithm_passwordauth
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: set_password_hashing_algorithm_systemauth
           requirement-id: set_password_hashing_algorithm_systemauth
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: socket_systemd-journal-remote_disabled
           requirement-id: socket_systemd-journal-remote_disabled
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sshd_disable_empty_passwords
           requirement-id: sshd_disable_empty_passwords
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sshd_disable_gssapi_auth
           requirement-id: sshd_disable_gssapi_auth
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sshd_disable_rhosts
           requirement-id: sshd_disable_rhosts
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sshd_disable_root_login
           requirement-id: sshd_disable_root_login
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sshd_do_not_permit_user_env
           requirement-id: sshd_do_not_permit_user_env
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sshd_enable_pam
           requirement-id: sshd_enable_pam
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sshd_enable_warning_banner_net
           requirement-id: sshd_enable_warning_banner_net
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sshd_limit_user_access
           requirement-id: sshd_limit_user_access
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sshd_set_idle_timeout
           requirement-id: sshd_set_idle_timeout
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sshd_set_keepalive
           requirement-id: sshd_set_keepalive
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sshd_set_login_grace_time
           requirement-id: sshd_set_login_grace_time
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sshd_set_loglevel_verbose
           requirement-id: sshd_set_loglevel_verbose
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sshd_set_max_auth_tries
           requirement-id: sshd_set_max_auth_tries
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sshd_set_max_sessions
           requirement-id: sshd_set_max_sessions
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sshd_set_maxstartups
           requirement-id: sshd_set_maxstartups
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sudo_add_use_pty
           requirement-id: sudo_add_use_pty
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sudo_custom_logfile
           requirement-id: sudo_custom_logfile
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sudo_remove_no_authenticate
           requirement-id: sudo_remove_no_authenticate
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sudo_require_reauthentication
           requirement-id: sudo_require_reauthentication
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sysctl_fs_protected_hardlinks
           requirement-id: sysctl_fs_protected_hardlinks
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sysctl_fs_protected_symlinks
           requirement-id: sysctl_fs_protected_symlinks
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sysctl_fs_suid_dumpable
           requirement-id: sysctl_fs_suid_dumpable
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sysctl_kernel_dmesg_restrict
           requirement-id: sysctl_kernel_dmesg_restrict
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sysctl_kernel_kptr_restrict
           requirement-id: sysctl_kernel_kptr_restrict
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sysctl_kernel_randomize_va_space
           requirement-id: sysctl_kernel_randomize_va_space
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sysctl_kernel_yama_ptrace_scope
           requirement-id: sysctl_kernel_yama_ptrace_scope
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sysctl_net_ipv4_conf_all_accept_redirects
           requirement-id: sysctl_net_ipv4_conf_all_accept_redirects
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sysctl_net_ipv4_conf_all_accept_source_route
           requirement-id: sysctl_net_ipv4_conf_all_accept_source_route
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sysctl_net_ipv4_conf_all_log_martians
           requirement-id: sysctl_net_ipv4_conf_all_log_martians
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sysctl_net_ipv4_conf_all_rp_filter
           requirement-id: sysctl_net_ipv4_conf_all_rp_filter
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sysctl_net_ipv4_conf_all_secure_redirects
           requirement-id: sysctl_net_ipv4_conf_all_secure_redirects
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sysctl_net_ipv4_conf_all_send_redirects
           requirement-id: sysctl_net_ipv4_conf_all_send_redirects
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sysctl_net_ipv4_conf_default_accept_redirects
           requirement-id: sysctl_net_ipv4_conf_default_accept_redirects
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sysctl_net_ipv4_conf_default_accept_source_route
           requirement-id: sysctl_net_ipv4_conf_default_accept_source_route
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sysctl_net_ipv4_conf_default_log_martians
           requirement-id: sysctl_net_ipv4_conf_default_log_martians
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sysctl_net_ipv4_conf_default_rp_filter
           requirement-id: sysctl_net_ipv4_conf_default_rp_filter
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sysctl_net_ipv4_conf_default_secure_redirects
           requirement-id: sysctl_net_ipv4_conf_default_secure_redirects
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sysctl_net_ipv4_conf_default_send_redirects
           requirement-id: sysctl_net_ipv4_conf_default_send_redirects
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sysctl_net_ipv4_icmp_echo_ignore_broadcasts
           requirement-id: sysctl_net_ipv4_icmp_echo_ignore_broadcasts
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sysctl_net_ipv4_icmp_ignore_bogus_error_responses
           requirement-id: sysctl_net_ipv4_icmp_ignore_bogus_error_responses
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sysctl_net_ipv4_ip_forward
           requirement-id: sysctl_net_ipv4_ip_forward
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sysctl_net_ipv4_tcp_syncookies
           requirement-id: sysctl_net_ipv4_tcp_syncookies
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sysctl_net_ipv6_conf_all_accept_ra
           requirement-id: sysctl_net_ipv6_conf_all_accept_ra
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sysctl_net_ipv6_conf_all_accept_redirects
           requirement-id: sysctl_net_ipv6_conf_all_accept_redirects
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sysctl_net_ipv6_conf_all_accept_source_route
           requirement-id: sysctl_net_ipv6_conf_all_accept_source_route
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sysctl_net_ipv6_conf_all_forwarding
           requirement-id: sysctl_net_ipv6_conf_all_forwarding
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sysctl_net_ipv6_conf_default_accept_ra
           requirement-id: sysctl_net_ipv6_conf_default_accept_ra
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sysctl_net_ipv6_conf_default_accept_redirects
           requirement-id: sysctl_net_ipv6_conf_default_accept_redirects
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: sysctl_net_ipv6_conf_default_accept_source_route
           requirement-id: sysctl_net_ipv6_conf_default_accept_source_route
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated
         - id: use_pam_wheel_group_for_su
           requirement-id: use_pam_wheel_group_for_su
           frequency: on-demand
           evaluation-methods:
               - id: openscap-automated
-                type: Gate
+                type: Behavioral
                 mode: Automated


### PR DESCRIPTION
## Summary

- **Catalogs**: rename `families`→`groups`, `family`→`group` (ampel), add `state: Active` to all controls and assessment-requirements across all three catalogs, add `gemara-version` and `applicability-groups` metadata (ampel), fix `applicability` values to match group IDs (ampel)
- **Policies**: change `evaluation-methods` type from `Gate` to `Behavioral` (`Gate` is an `#EnforcementMethodType`, not `#EvaluationMethodType`), add `gemara-version` metadata (ampel), prefix `mapping-references` URLs with `file://` to satisfy the CUE URL regex constraint
- **Workflow**: update `gemaraproj/gemara-registry-cli` → `gemaraproj/gemara-publish-action@v0.1.1` — the repo was renamed and GitHub Actions does not reliably follow renames for `uses:` resolution. The publish currently succeeds via redirect but already fails on `complytime-labs/complytime-policies-internal`. Fixing proactively to avoid unpredictable breakage.

All governance YAML files now pass local validation:

```bash
cue vet -c -d '#ControlCatalog' 'github.com/gemaraproj/gemara@v1.2.0' governance/catalogs/*.yaml
cue vet -c -d '#Policy' 'github.com/gemaraproj/gemara@v1.2.0' governance/policies/*.yaml
cue vet -c -d '#GuidanceCatalog' 'github.com/gemaraproj/gemara@v1.2.0' governance/guidance/*.yaml
```

Closes #31

## Test plan

- [ ] CUE validation CI workflow passes on this PR
- [ ] Verify no behavioral changes to policy consumption by `complyctl`
- [ ] Publish workflow resolves `gemara-publish-action` correctly after merge