### PR TITLE
fix: replace deprecated @latest with :latest in policy URLs

### DIFF
--- a/.complytime/complytime.yaml
+++ b/.complytime/complytime.yaml
@@ -10,16 +10,16 @@
 # List tags:
 #   curl -sS https://quay.io/v2/complytime/policies-ampel-branch-protection/tags/list
 #
-# Policy `url`: optional scheme; @suffix = tag or sha256:…
+# Policy `url`: optional scheme; :tag or @sha256:… suffix
 #   (complyctl tag/digest resolution, complytime/complyctl main+).
 
 policies:
   - id: ampel-branch-protection
-    url: quay.io/complytime/policies-ampel-branch-protection@latest
+    url: quay.io/complytime/policies-ampel-branch-protection:latest
   - id: cis-fedora-l1-workstation
-    url: quay.io/complytime/policies-cis-fedora-l1-workstation@latest
+    url: quay.io/complytime/policies-cis-fedora-l1-workstation:latest
   - id: cis-fedora-l1-server
-    url: quay.io/complytime/policies-cis-fedora-l1-server@latest
+    url: quay.io/complytime/policies-cis-fedora-l1-server:latest
 
 targets:
   - id: default

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -84,10 +84,8 @@ This returns the `sha256:…` digest, which you can use for immutable references
 oras pull quay.io/complytime/policies-cis-fedora-l1-workstation@sha256:<digest> -o ./output
 ```
 
-> **Note:** ORAS, cosign, and curl use standard OCI reference syntax
-> (`:tag` and `@sha256:digest`). `complyctl` uses its own `@tag` convention
-> in `complytime.yaml` — see the [Using with complyctl](#using-with-complyctl)
-> section below.
+> **Note:** All tools — ORAS, cosign, curl, and `complyctl` — use standard
+> OCI reference syntax (`:tag` and `@sha256:digest`).
 
 ## Verifying the Cosign signature
 
@@ -144,7 +142,7 @@ published bundle in `complytime.yaml`:
 ```yaml
 # complytime.yaml
 policies:
-  - url: quay.io/complytime/policies-ampel-branch-protection@latest
+  - url: quay.io/complytime/policies-ampel-branch-protection:latest
     id: ampel-bp
 ```
 


### PR DESCRIPTION
## Summary

Replace the deprecated `@version`/`@latest` notation with standard OCI `:tag` syntax in policy URLs. `complyctl` now emits a deprecation warning for the `@` form, and the project's own config should not trip its own deprecation warning.

## Changes

### `.complytime/complytime.yaml`
- Updated inline comment to reflect the new `:tag` / `@sha256:…` reference format
- Replaced `@latest` with `:latest` in all three policy URLs:
  - `policies-ampel-branch-protection`
  - `policies-cis-fedora-l1-workstation`
  - `policies-cis-fedora-l1-server`

### `docs/usage.md`
- Updated the example `complytime.yaml` snippet to use `:latest` instead of `@latest`
- Removed stale note that described `complyctl` as using a non-standard `@tag` convention; all tools now use standard OCI reference syntax

## Not Changed

- `docs/adr/0001-one-quay-repo-per-bundle.md` — left as historical record of the original design decision.

## Testing

- `make test` — all 16 tests pass
- Verified no remaining `@latest` references outside the ADR

Closes #50