### PR TITLE
Add NIST SP 800-53 Rev 5 artifacts for Fedora

### DIFF
--- a/bundles/nist-800-53-rev5-fedora.yaml
+++ b/bundles/nist-800-53-rev5-fedora.yaml
@@ -1,0 +1,4 @@
+layers:
+- governance/guidance/nist-800-53-rev5-guidance.yaml
+- governance/catalogs/nist-800-53-rev5-fedora-catalog.yaml
+- governance/policies/nist-800-53-rev5-fedora-policy.yaml

--- a/governance/catalogs/nist-800-53-rev5-fedora-catalog.yaml
+++ b/governance/catalogs/nist-800-53-rev5-fedora-catalog.yaml
@@ -1,0 +1,16560 @@
+metadata:
+  id: nist-800-53-rev5-fedora
+  type: ControlCatalog
+  gemara-version: 1.2.0
+  description: NIST Special Publication 800-53 Revision 5 controls for FEDORA, generated from ComplianceAsCode
+  author:
+    id: complianceascode
+    name: ComplianceAsCode Project
+    type: Software
+    uri: https://github.com/ComplianceAsCode/content
+  version: Revision 5
+  date: '2026-08-21T12:23:27Z'
+  applicability-groups:
+  - id: fedora-low
+    title: FEDORA Low Baseline
+    description: NIST 800-53 Low impact baseline for FEDORA
+  - id: fedora-moderate
+    title: FEDORA Moderate Baseline
+    description: NIST 800-53 Moderate impact baseline for FEDORA (inherits Low)
+  - id: fedora-high
+    title: FEDORA High Baseline
+    description: NIST 800-53 High impact baseline for FEDORA (inherits Moderate)
+title: NIST Special Publication 800-53 Revision 5 for Fedora
+groups:
+- id: ac
+  title: Access Control
+  description: 'NIST 800-53 AC family: Access Control'
+- id: at
+  title: Awareness and Training
+  description: 'NIST 800-53 AT family: Awareness and Training'
+- id: au
+  title: Audit and Accountability
+  description: 'NIST 800-53 AU family: Audit and Accountability'
+- id: ca
+  title: Assessment, Authorization, and Monitoring
+  description: 'NIST 800-53 CA family: Assessment, Authorization, and Monitoring'
+- id: cm
+  title: Configuration Management
+  description: 'NIST 800-53 CM family: Configuration Management'
+- id: cp
+  title: Contingency Planning
+  description: 'NIST 800-53 CP family: Contingency Planning'
+- id: ia
+  title: Identification and Authentication
+  description: 'NIST 800-53 IA family: Identification and Authentication'
+- id: ir
+  title: Incident Response
+  description: 'NIST 800-53 IR family: Incident Response'
+- id: ma
+  title: Maintenance
+  description: 'NIST 800-53 MA family: Maintenance'
+- id: mp
+  title: Media Protection
+  description: 'NIST 800-53 MP family: Media Protection'
+- id: pe
+  title: Physical and Environmental Protection
+  description: 'NIST 800-53 PE family: Physical and Environmental Protection'
+- id: pl
+  title: Planning
+  description: 'NIST 800-53 PL family: Planning'
+- id: pm
+  title: Program Management
+  description: 'NIST 800-53 PM family: Program Management'
+- id: ps
+  title: Personnel Security
+  description: 'NIST 800-53 PS family: Personnel Security'
+- id: pt
+  title: PII Processing and Transparency
+  description: 'NIST 800-53 PT family: PII Processing and Transparency'
+- id: ra
+  title: Risk Assessment
+  description: 'NIST 800-53 RA family: Risk Assessment'
+- id: sa
+  title: System and Services Acquisition
+  description: 'NIST 800-53 SA family: System and Services Acquisition'
+- id: sc
+  title: System and Communications Protection
+  description: 'NIST 800-53 SC family: System and Communications Protection'
+- id: si
+  title: System and Information Integrity
+  description: 'NIST 800-53 SI family: System and Information Integrity'
+- id: sr
+  title: Supply Chain Risk Management
+  description: 'NIST 800-53 SR family: Supply Chain Risk Management'
+controls:
+- id: ac-1
+  title: Policy and Procedures
+  objective: 'Develop, document, and disseminate to {{ insert: param, ac-1_prm_1 }}: Designate an {{ insert: param, ac-01_odp.04
+    }} to manage the development, documentation, and dissemination of the access control policy and procedures; and Review
+    and update the current access control:'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-2.1
+  title: Automated System Account Management
+  objective: 'Support the management of system accounts using {{ insert: param, ac-02.01_odp }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-2.2
+  title: Automated Temporary and Emergency Account Management
+  objective: 'Automatically {{ insert: param, ac-02.02_odp.01 }} temporary and emergency accounts after {{ insert: param,
+    ac-02.02_odp.02 }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-2.3
+  title: Disable Accounts
+  objective: 'Disable accounts within {{ insert: param, ac-02.03_odp.01 }} when the accounts:'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-2.4
+  title: Automated Audit Actions
+  objective: Automatically audit account creation, modification, enabling, disabling, and removal actions.
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-2.5
+  title: Inactivity Logout
+  objective: 'Require that users log out when {{ insert: param, ac-02.05_odp }}.'
+  group: ac
+  assessment-requirements:
+  - id: accounts_tmout
+    state: Active
+    text: Rule 'accounts_tmout' MUST be verified
+    applicability: &id001
+    - fedora-moderate
+  - id: no_invalid_shell_accounts_unlocked
+    state: Active
+    text: Rule 'no_invalid_shell_accounts_unlocked' MUST be verified
+    applicability: *id001
+  - id: no_password_auth_for_systemaccounts
+    state: Active
+    text: Rule 'no_password_auth_for_systemaccounts' MUST be verified
+    applicability: *id001
+  - id: no_shelllogin_for_systemaccounts
+    state: Active
+    text: Rule 'no_shelllogin_for_systemaccounts' MUST be verified
+    applicability: *id001
+  - id: inactivity_timeout_value
+    state: Active
+    text: Variable 'inactivity_timeout_value' is set to '15_minutes'
+    applicability: *id001
+  - id: var_accounts_tmout
+    state: Active
+    text: Variable 'var_accounts_tmout' is set to '15_min'
+    applicability: *id001
+  state: Active
+- id: ac-2.6
+  title: Dynamic Privilege Management
+  objective: 'Implement {{ insert: param, ac-02.06_odp }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-2.7
+  title: Privileged User Accounts
+  objective: 'Establish and administer privileged user accounts in accordance with {{ insert: param, ac-02.07_odp }}; Monitor
+    privileged role or attribute assignments; Monitor changes to roles or attributes; and Revoke access when privileged role
+    or attribute assignments are no longer appropriate.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-2.8
+  title: Dynamic Account Management
+  objective: 'Create, activate, manage, and deactivate {{ insert: param, ac-02.08_odp }} dynamically.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-2.9
+  title: Restrictions on Use of Shared and Group Accounts
+  objective: 'Only permit the use of shared and group accounts that meet {{ insert: param, ac-02.09_odp }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-2.10
+  title: Shared and Group Account Credential Change
+  objective: Shared and Group Account Credential Change
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-2.11
+  title: Usage Conditions
+  objective: 'Enforce {{ insert: param, ac-02.11_odp.01 }} for {{ insert: param, ac-02.11_odp.02 }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: ac-2.12
+  title: Account Monitoring for Atypical Usage
+  objective: 'Monitor system accounts for {{ insert: param, ac-02.12_odp.01 }} ; and Report atypical usage of system accounts
+    to {{ insert: param, ac-02.12_odp.02 }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: ac-2.13
+  title: Disable Accounts for High-risk Individuals
+  objective: 'Disable accounts of individuals within {{ insert: param, ac-02.13_odp.01 }} of discovery of {{ insert: param,
+    ac-02.13_odp.02 }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-2
+  title: Account Management
+  objective: 'Define and document the types of accounts allowed and specifically prohibited for use within the system; Assign
+    account managers; Require {{ insert: param, ac-02_odp.01 }} for group and role membership; Specify: Require approvals
+    by {{ insert: param, ac-02_odp.03 }} for requests to create accounts; Create, enable, modify, disable, and remove accounts
+    in accordance with {{ insert: param, ac-02_odp.04 }}; Monitor the use of accounts; Notify account managers and {{ insert:
+    param, ac-02_odp.05 }} within: Authorize access to the system based on: Review accounts for compliance with account management
+    requirements {{ insert: param, ac-02_odp.10 }}; Establish and implement a process for changing shared or group account
+    authenticators (if deployed) when individuals are removed from the group; and Align account management processes with
+    personnel termination and transfer processes.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-3.1
+  title: Restricted Access to Privileged Functions
+  objective: Restricted Access to Privileged Functions
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-3.2
+  title: Dual Authorization
+  objective: 'Enforce dual authorization for {{ insert: param, ac-03.02_odp }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-3.3
+  title: Mandatory Access Control
+  objective: 'Enforce {{ insert: param, ac-3.3_prm_1 }} over the set of covered subjects and objects specified in the policy,
+    and where the policy:'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-3.4
+  title: Discretionary Access Control
+  objective: 'Enforce {{ insert: param, ac-3.4_prm_1 }} over the set of covered subjects and objects specified in the policy,
+    and where the policy specifies that a subject that has been granted access to information can do one or more of the following:'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-3.5
+  title: Security-relevant Information
+  objective: 'Prevent access to {{ insert: param, ac-03.05_odp }} except during secure, non-operable system states.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-3.6
+  title: Protection of User and System Information
+  objective: Protection of User and System Information
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-3.7
+  title: Role-based Access Control
+  objective: 'Enforce a role-based access control policy over defined subjects and objects and control access based upon {{
+    insert: param, ac-3.7_prm_1 }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-3.8
+  title: Revocation of Access Authorizations
+  objective: 'Enforce the revocation of access authorizations resulting from changes to the security attributes of subjects
+    and objects based on {{ insert: param, ac-03.08_odp }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-3.9
+  title: Controlled Release
+  objective: 'Release information outside of the system only if:'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-3.10
+  title: Audited Override of Access Control Mechanisms
+  objective: 'Employ an audited override of automated access control mechanisms under {{ insert: param, ac-03.10_odp.01 }}
+    by {{ insert: param, ac-03.10_odp.02 }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-3.11
+  title: Restrict Access to Specific Information Types
+  objective: 'Restrict access to data repositories containing {{ insert: param, ac-03.11_odp }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-3.12
+  title: Assert and Enforce Application Access
+  objective: 'Require applications to assert, as part of the installation process, the access needed to the following system
+    applications and functions: {{ insert: param, ac-03.12_odp }}; Provide an enforcement mechanism to prevent unauthorized
+    access; and Approve access changes after initial installation of the application.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-3.13
+  title: Attribute-based Access Control
+  objective: 'Enforce attribute-based access control policy over defined subjects and objects and control access based upon
+    {{ insert: param, ac-03.13_odp }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-3.14
+  title: Individual Access
+  objective: 'Provide {{ insert: param, ac-03.14_odp.01 }} to enable individuals to have access to the following elements
+    of their personally identifiable information: {{ insert: param, ac-03.14_odp.02 }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-3.15
+  title: Discretionary and Mandatory Access Control
+  objective: 'Enforce {{ insert: param, ac-3.15_prm_1 }} over the set of covered subjects and objects specified in the policy;
+    and Enforce {{ insert: param, ac-3.15_prm_2 }} over the set of covered subjects and objects specified in the policy.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-3
+  title: Access Enforcement
+  objective: Enforce approved authorizations for logical access to information and system resources in accordance with 
+    applicable access control policies.
+  group: ac
+  assessment-requirements:
+  - id: accounts_umask_etc_bashrc
+    state: Active
+    text: Rule 'accounts_umask_etc_bashrc' MUST be verified
+    applicability: &id002
+    - fedora-low
+  - id: accounts_umask_etc_login_defs
+    state: Active
+    text: Rule 'accounts_umask_etc_login_defs' MUST be verified
+    applicability: *id002
+  - id: accounts_umask_etc_profile
+    state: Active
+    text: Rule 'accounts_umask_etc_profile' MUST be verified
+    applicability: *id002
+  - id: accounts_umask_root
+    state: Active
+    text: Rule 'accounts_umask_root' MUST be verified
+    applicability: *id002
+  - id: audit_rules_immutable
+    state: Active
+    text: Rule 'audit_rules_immutable' MUST be verified
+    applicability: *id002
+  - id: dir_perms_world_writable_sticky_bits
+    state: Active
+    text: Rule 'dir_perms_world_writable_sticky_bits' MUST be verified
+    applicability: *id002
+  - id: directory_groupowner_sshd_config_d
+    state: Active
+    text: Rule 'directory_groupowner_sshd_config_d' MUST be verified
+    applicability: *id002
+  - id: directory_owner_sshd_config_d
+    state: Active
+    text: Rule 'directory_owner_sshd_config_d' MUST be verified
+    applicability: *id002
+  - id: directory_permissions_sshd_config_d
+    state: Active
+    text: Rule 'directory_permissions_sshd_config_d' MUST be verified
+    applicability: *id002
+  - id: ensure_pam_wheel_group_empty
+    state: Active
+    text: Rule 'ensure_pam_wheel_group_empty' MUST be verified
+    applicability: *id002
+  - id: file_at_allow_exists
+    state: Active
+    text: Rule 'file_at_allow_exists' MUST be verified
+    applicability: *id002
+  - id: file_at_deny_not_exist
+    state: Active
+    text: Rule 'file_at_deny_not_exist' MUST be verified
+    applicability: *id002
+  - id: file_cron_allow_exists
+    state: Active
+    text: Rule 'file_cron_allow_exists' MUST be verified
+    applicability: *id002
+  - id: file_cron_deny_not_exist
+    state: Active
+    text: Rule 'file_cron_deny_not_exist' MUST be verified
+    applicability: *id002
+  - id: file_groupowner_at_allow
+    state: Active
+    text: Rule 'file_groupowner_at_allow' MUST be verified
+    applicability: *id002
+  - id: file_groupowner_backup_etc_group
+    state: Active
+    text: Rule 'file_groupowner_backup_etc_group' MUST be verified
+    applicability: *id002
+  - id: file_groupowner_backup_etc_gshadow
+    state: Active
+    text: Rule 'file_groupowner_backup_etc_gshadow' MUST be verified
+    applicability: *id002
+  - id: file_groupowner_backup_etc_passwd
+    state: Active
+    text: Rule 'file_groupowner_backup_etc_passwd' MUST be verified
+    applicability: *id002
+  - id: file_groupowner_backup_etc_shadow
+    state: Active
+    text: Rule 'file_groupowner_backup_etc_shadow' MUST be verified
+    applicability: *id002
+  - id: file_groupowner_cron_allow
+    state: Active
+    text: Rule 'file_groupowner_cron_allow' MUST be verified
+    applicability: *id002
+  - id: file_groupowner_cron_d
+    state: Active
+    text: Rule 'file_groupowner_cron_d' MUST be verified
+    applicability: *id002
+  - id: file_groupowner_cron_daily
+    state: Active
+    text: Rule 'file_groupowner_cron_daily' MUST be verified
+    applicability: *id002
+  - id: file_groupowner_cron_hourly
+    state: Active
+    text: Rule 'file_groupowner_cron_hourly' MUST be verified
+    applicability: *id002
+  - id: file_groupowner_cron_monthly
+    state: Active
+    text: Rule 'file_groupowner_cron_monthly' MUST be verified
+    applicability: *id002
+  - id: file_groupowner_cron_weekly
+    state: Active
+    text: Rule 'file_groupowner_cron_weekly' MUST be verified
+    applicability: *id002
+  - id: file_groupowner_cron_yearly
+    state: Active
+    text: Rule 'file_groupowner_cron_yearly' MUST be verified
+    applicability: *id002
+  - id: file_groupowner_crontab
+    state: Active
+    text: Rule 'file_groupowner_crontab' MUST be verified
+    applicability: *id002
+  - id: file_groupowner_etc_group
+    state: Active
+    text: Rule 'file_groupowner_etc_group' MUST be verified
+    applicability: *id002
+  - id: file_groupowner_etc_gshadow
+    state: Active
+    text: Rule 'file_groupowner_etc_gshadow' MUST be verified
+    applicability: *id002
+  - id: file_groupowner_etc_issue
+    state: Active
+    text: Rule 'file_groupowner_etc_issue' MUST be verified
+    applicability: *id002
+  - id: file_groupowner_etc_issue_net
+    state: Active
+    text: Rule 'file_groupowner_etc_issue_net' MUST be verified
+    applicability: *id002
+  - id: file_groupowner_etc_motd
+    state: Active
+    text: Rule 'file_groupowner_etc_motd' MUST be verified
+    applicability: *id002
+  - id: file_groupowner_etc_passwd
+    state: Active
+    text: Rule 'file_groupowner_etc_passwd' MUST be verified
+    applicability: *id002
+  - id: file_groupowner_etc_security_opasswd
+    state: Active
+    text: Rule 'file_groupowner_etc_security_opasswd' MUST be verified
+    applicability: *id002
+  - id: file_groupowner_etc_security_opasswd_old
+    state: Active
+    text: Rule 'file_groupowner_etc_security_opasswd_old' MUST be verified
+    applicability: *id002
+  - id: file_groupowner_etc_shadow
+    state: Active
+    text: Rule 'file_groupowner_etc_shadow' MUST be verified
+    applicability: *id002
+  - id: file_groupowner_etc_shells
+    state: Active
+    text: Rule 'file_groupowner_etc_shells' MUST be verified
+    applicability: *id002
+  - id: file_groupowner_sshd_config
+    state: Active
+    text: Rule 'file_groupowner_sshd_config' MUST be verified
+    applicability: *id002
+  - id: file_groupowner_sshd_drop_in_config
+    state: Active
+    text: Rule 'file_groupowner_sshd_drop_in_config' MUST be verified
+    applicability: *id002
+  - id: file_groupownership_sshd_private_key
+    state: Active
+    text: Rule 'file_groupownership_sshd_private_key' MUST be verified
+    applicability: *id002
+  - id: file_groupownership_sshd_pub_key
+    state: Active
+    text: Rule 'file_groupownership_sshd_pub_key' MUST be verified
+    applicability: *id002
+  - id: file_owner_at_allow
+    state: Active
+    text: Rule 'file_owner_at_allow' MUST be verified
+    applicability: *id002
+  - id: file_owner_backup_etc_group
+    state: Active
+    text: Rule 'file_owner_backup_etc_group' MUST be verified
+    applicability: *id002
+  - id: file_owner_backup_etc_gshadow
+    state: Active
+    text: Rule 'file_owner_backup_etc_gshadow' MUST be verified
+    applicability: *id002
+  - id: file_owner_backup_etc_passwd
+    state: Active
+    text: Rule 'file_owner_backup_etc_passwd' MUST be verified
+    applicability: *id002
+  - id: file_owner_backup_etc_shadow
+    state: Active
+    text: Rule 'file_owner_backup_etc_shadow' MUST be verified
+    applicability: *id002
+  - id: file_owner_cron_allow
+    state: Active
+    text: Rule 'file_owner_cron_allow' MUST be verified
+    applicability: *id002
+  - id: file_owner_cron_d
+    state: Active
+    text: Rule 'file_owner_cron_d' MUST be verified
+    applicability: *id002
+  - id: file_owner_cron_daily
+    state: Active
+    text: Rule 'file_owner_cron_daily' MUST be verified
+    applicability: *id002
+  - id: file_owner_cron_hourly
+    state: Active
+    text: Rule 'file_owner_cron_hourly' MUST be verified
+    applicability: *id002
+  - id: file_owner_cron_monthly
+    state: Active
+    text: Rule 'file_owner_cron_monthly' MUST be verified
+    applicability: *id002
+  - id: file_owner_cron_weekly
+    state: Active
+    text: Rule 'file_owner_cron_weekly' MUST be verified
+    applicability: *id002
+  - id: file_owner_cron_yearly
+    state: Active
+    text: Rule 'file_owner_cron_yearly' MUST be verified
+    applicability: *id002
+  - id: file_owner_crontab
+    state: Active
+    text: Rule 'file_owner_crontab' MUST be verified
+    applicability: *id002
+  - id: file_owner_etc_group
+    state: Active
+    text: Rule 'file_owner_etc_group' MUST be verified
+    applicability: *id002
+  - id: file_owner_etc_gshadow
+    state: Active
+    text: Rule 'file_owner_etc_gshadow' MUST be verified
+    applicability: *id002
+  - id: file_owner_etc_issue
+    state: Active
+    text: Rule 'file_owner_etc_issue' MUST be verified
+    applicability: *id002
+  - id: file_owner_etc_issue_net
+    state: Active
+    text: Rule 'file_owner_etc_issue_net' MUST be verified
+    applicability: *id002
+  - id: file_owner_etc_motd
+    state: Active
+    text: Rule 'file_owner_etc_motd' MUST be verified
+    applicability: *id002
+  - id: file_owner_etc_passwd
+    state: Active
+    text: Rule 'file_owner_etc_passwd' MUST be verified
+    applicability: *id002
+  - id: file_owner_etc_security_opasswd
+    state: Active
+    text: Rule 'file_owner_etc_security_opasswd' MUST be verified
+    applicability: *id002
+  - id: file_owner_etc_security_opasswd_old
+    state: Active
+    text: Rule 'file_owner_etc_security_opasswd_old' MUST be verified
+    applicability: *id002
+  - id: file_owner_etc_shadow
+    state: Active
+    text: Rule 'file_owner_etc_shadow' MUST be verified
+    applicability: *id002
+  - id: file_owner_etc_shells
+    state: Active
+    text: Rule 'file_owner_etc_shells' MUST be verified
+    applicability: *id002
+  - id: file_owner_sshd_config
+    state: Active
+    text: Rule 'file_owner_sshd_config' MUST be verified
+    applicability: *id002
+  - id: file_owner_sshd_drop_in_config
+    state: Active
+    text: Rule 'file_owner_sshd_drop_in_config' MUST be verified
+    applicability: *id002
+  - id: file_ownership_sshd_private_key
+    state: Active
+    text: Rule 'file_ownership_sshd_private_key' MUST be verified
+    applicability: *id002
+  - id: file_ownership_sshd_pub_key
+    state: Active
+    text: Rule 'file_ownership_sshd_pub_key' MUST be verified
+    applicability: *id002
+  - id: file_permissions_at_allow
+    state: Active
+    text: Rule 'file_permissions_at_allow' MUST be verified
+    applicability: *id002
+  - id: file_permissions_backup_etc_group
+    state: Active
+    text: Rule 'file_permissions_backup_etc_group' MUST be verified
+    applicability: *id002
+  - id: file_permissions_backup_etc_gshadow
+    state: Active
+    text: Rule 'file_permissions_backup_etc_gshadow' MUST be verified
+    applicability: *id002
+  - id: file_permissions_backup_etc_passwd
+    state: Active
+    text: Rule 'file_permissions_backup_etc_passwd' MUST be verified
+    applicability: *id002
+  - id: file_permissions_backup_etc_shadow
+    state: Active
+    text: Rule 'file_permissions_backup_etc_shadow' MUST be verified
+    applicability: *id002
+  - id: file_permissions_cron_allow
+    state: Active
+    text: Rule 'file_permissions_cron_allow' MUST be verified
+    applicability: *id002
+  - id: file_permissions_cron_d
+    state: Active
+    text: Rule 'file_permissions_cron_d' MUST be verified
+    applicability: *id002
+  - id: file_permissions_cron_daily
+    state: Active
+    text: Rule 'file_permissions_cron_daily' MUST be verified
+    applicability: *id002
+  - id: file_permissions_cron_hourly
+    state: Active
+    text: Rule 'file_permissions_cron_hourly' MUST be verified
+    applicability: *id002
+  - id: file_permissions_cron_monthly
+    state: Active
+    text: Rule 'file_permissions_cron_monthly' MUST be verified
+    applicability: *id002
+  - id: file_permissions_cron_weekly
+    state: Active
+    text: Rule 'file_permissions_cron_weekly' MUST be verified
+    applicability: *id002
+  - id: file_permissions_cron_yearly
+    state: Active
+    text: Rule 'file_permissions_cron_yearly' MUST be verified
+    applicability: *id002
+  - id: file_permissions_crontab
+    state: Active
+    text: Rule 'file_permissions_crontab' MUST be verified
+    applicability: *id002
+  - id: file_permissions_etc_group
+    state: Active
+    text: Rule 'file_permissions_etc_group' MUST be verified
+    applicability: *id002
+  - id: file_permissions_etc_gshadow
+    state: Active
+    text: Rule 'file_permissions_etc_gshadow' MUST be verified
+    applicability: *id002
+  - id: file_permissions_etc_issue
+    state: Active
+    text: Rule 'file_permissions_etc_issue' MUST be verified
+    applicability: *id002
+  - id: file_permissions_etc_issue_net
+    state: Active
+    text: Rule 'file_permissions_etc_issue_net' MUST be verified
+    applicability: *id002
+  - id: file_permissions_etc_motd
+    state: Active
+    text: Rule 'file_permissions_etc_motd' MUST be verified
+    applicability: *id002
+  - id: file_permissions_etc_passwd
+    state: Active
+    text: Rule 'file_permissions_etc_passwd' MUST be verified
+    applicability: *id002
+  - id: file_permissions_etc_security_opasswd
+    state: Active
+    text: Rule 'file_permissions_etc_security_opasswd' MUST be verified
+    applicability: *id002
+  - id: file_permissions_etc_security_opasswd_old
+    state: Active
+    text: Rule 'file_permissions_etc_security_opasswd_old' MUST be verified
+    applicability: *id002
+  - id: file_permissions_etc_shadow
+    state: Active
+    text: Rule 'file_permissions_etc_shadow' MUST be verified
+    applicability: *id002
+  - id: file_permissions_etc_shells
+    state: Active
+    text: Rule 'file_permissions_etc_shells' MUST be verified
+    applicability: *id002
+  - id: file_permissions_sshd_config
+    state: Active
+    text: Rule 'file_permissions_sshd_config' MUST be verified
+    applicability: *id002
+  - id: file_permissions_sshd_drop_in_config
+    state: Active
+    text: Rule 'file_permissions_sshd_drop_in_config' MUST be verified
+    applicability: *id002
+  - id: file_permissions_sshd_private_key
+    state: Active
+    text: Rule 'file_permissions_sshd_private_key' MUST be verified
+    applicability: *id002
+  - id: file_permissions_sshd_pub_key
+    state: Active
+    text: Rule 'file_permissions_sshd_pub_key' MUST be verified
+    applicability: *id002
+  - id: file_permissions_unauthorized_world_writable
+    state: Active
+    text: Rule 'file_permissions_unauthorized_world_writable' MUST be verified
+    applicability: *id002
+  - id: grub2_enable_selinux
+    state: Active
+    text: Rule 'grub2_enable_selinux' MUST be verified
+    applicability: *id002
+  - id: grub2_password
+    state: Active
+    text: Rule 'grub2_password' MUST be verified
+    applicability: *id002
+  - id: mount_option_dev_shm_nodev
+    state: Active
+    text: Rule 'mount_option_dev_shm_nodev' MUST be verified
+    applicability: *id002
+  - id: mount_option_dev_shm_noexec
+    state: Active
+    text: Rule 'mount_option_dev_shm_noexec' MUST be verified
+    applicability: *id002
+  - id: mount_option_dev_shm_nosuid
+    state: Active
+    text: Rule 'mount_option_dev_shm_nosuid' MUST be verified
+    applicability: *id002
+  - id: mount_option_home_nodev
+    state: Active
+    text: Rule 'mount_option_home_nodev' MUST be verified
+    applicability: *id002
+  - id: mount_option_home_nosuid
+    state: Active
+    text: Rule 'mount_option_home_nosuid' MUST be verified
+    applicability: *id002
+  - id: mount_option_tmp_noexec
+    state: Active
+    text: Rule 'mount_option_tmp_noexec' MUST be verified
+    applicability: *id002
+  - id: mount_option_tmp_nosuid
+    state: Active
+    text: Rule 'mount_option_tmp_nosuid' MUST be verified
+    applicability: *id002
+  - id: mount_option_var_log_audit_nodev
+    state: Active
+    text: Rule 'mount_option_var_log_audit_nodev' MUST be verified
+    applicability: *id002
+  - id: mount_option_var_log_audit_noexec
+    state: Active
+    text: Rule 'mount_option_var_log_audit_noexec' MUST be verified
+    applicability: *id002
+  - id: mount_option_var_log_audit_nosuid
+    state: Active
+    text: Rule 'mount_option_var_log_audit_nosuid' MUST be verified
+    applicability: *id002
+  - id: mount_option_var_log_nodev
+    state: Active
+    text: Rule 'mount_option_var_log_nodev' MUST be verified
+    applicability: *id002
+  - id: mount_option_var_log_noexec
+    state: Active
+    text: Rule 'mount_option_var_log_noexec' MUST be verified
+    applicability: *id002
+  - id: mount_option_var_log_nosuid
+    state: Active
+    text: Rule 'mount_option_var_log_nosuid' MUST be verified
+    applicability: *id002
+  - id: mount_option_var_nodev
+    state: Active
+    text: Rule 'mount_option_var_nodev' MUST be verified
+    applicability: *id002
+  - id: mount_option_var_nosuid
+    state: Active
+    text: Rule 'mount_option_var_nosuid' MUST be verified
+    applicability: *id002
+  - id: mount_option_var_tmp_nodev
+    state: Active
+    text: Rule 'mount_option_var_tmp_nodev' MUST be verified
+    applicability: *id002
+  - id: mount_option_var_tmp_noexec
+    state: Active
+    text: Rule 'mount_option_var_tmp_noexec' MUST be verified
+    applicability: *id002
+  - id: mount_option_var_tmp_nosuid
+    state: Active
+    text: Rule 'mount_option_var_tmp_nosuid' MUST be verified
+    applicability: *id002
+  - id: package_libselinux_installed
+    state: Active
+    text: Rule 'package_libselinux_installed' MUST be verified
+    applicability: *id002
+  - id: package_mcstrans_removed
+    state: Active
+    text: Rule 'package_mcstrans_removed' MUST be verified
+    applicability: *id002
+  - id: package_setroubleshoot_removed
+    state: Active
+    text: Rule 'package_setroubleshoot_removed' MUST be verified
+    applicability: *id002
+  - id: rsyslog_filecreatemode
+    state: Active
+    text: Rule 'rsyslog_filecreatemode' MUST be verified
+    applicability: *id002
+  - id: rsyslog_files_groupownership
+    state: Active
+    text: Rule 'rsyslog_files_groupownership' MUST be verified
+    applicability: *id002
+  - id: rsyslog_files_ownership
+    state: Active
+    text: Rule 'rsyslog_files_ownership' MUST be verified
+    applicability: *id002
+  - id: rsyslog_files_permissions
+    state: Active
+    text: Rule 'rsyslog_files_permissions' MUST be verified
+    applicability: *id002
+  - id: selinux_not_disabled
+    state: Active
+    text: Rule 'selinux_not_disabled' MUST be verified
+    applicability: *id002
+  - id: selinux_policytype
+    state: Active
+    text: Rule 'selinux_policytype' MUST be verified
+    applicability: *id002
+  - id: sshd_limit_user_access
+    state: Active
+    text: Rule 'sshd_limit_user_access' MUST be verified
+    applicability: *id002
+  - id: sysctl_fs_protected_hardlinks
+    state: Active
+    text: Rule 'sysctl_fs_protected_hardlinks' MUST be verified
+    applicability: *id002
+  - id: sysctl_fs_protected_symlinks
+    state: Active
+    text: Rule 'sysctl_fs_protected_symlinks' MUST be verified
+    applicability: *id002
+  - id: use_pam_wheel_group_for_su
+    state: Active
+    text: Rule 'use_pam_wheel_group_for_su' MUST be verified
+    applicability: *id002
+  - id: var_accounts_user_umask
+    state: Active
+    text: Variable 'var_accounts_user_umask' is set to '027'
+    applicability: *id002
+  - id: var_pam_wheel_group_for_su
+    state: Active
+    text: Variable 'var_pam_wheel_group_for_su' is set to 'cis'
+    applicability: *id002
+  - id: var_selinux_policy_name
+    state: Active
+    text: Variable 'var_selinux_policy_name' is set to 'targeted'
+    applicability: *id002
+  state: Active
+- id: ac-4.1
+  title: Object Security and Privacy Attributes
+  objective: 'Use {{ insert: param, ac-4.1_prm_1 }} associated with {{ insert: param, ac-4.1_prm_2 }} to enforce {{ insert:
+    param, ac-04.01_odp.09 }} as a basis for flow control decisions.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-4.2
+  title: Processing Domains
+  objective: 'Use protected processing domains to enforce {{ insert: param, ac-04.02_odp }} as a basis for flow control decisions.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-4.3
+  title: Dynamic Information Flow Control
+  objective: 'Enforce {{ insert: param, ac-04.03_odp }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-4.4
+  title: Flow Control of Encrypted Information
+  objective: 'Prevent encrypted information from bypassing {{ insert: param, ac-04.04_odp.01 }} by {{ insert: param, ac-04.04_odp.02
+    }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: ac-4.5
+  title: Embedded Data Types
+  objective: 'Enforce {{ insert: param, ac-04.05_odp }} on embedding data types within other data types.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-4.6
+  title: Metadata
+  objective: 'Enforce information flow control based on {{ insert: param, ac-04.06_odp }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-4.7
+  title: One-way Flow Mechanisms
+  objective: Enforce one-way information flows through hardware-based flow control mechanisms.
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-4.8
+  title: Security and Privacy Policy Filters
+  objective: 'Enforce information flow control using {{ insert: param, ac-4.8_prm_1 }} as a basis for flow control decisions
+    for {{ insert: param, ac-4.8_prm_2 }} ; and {{ insert: param, ac-04.08_odp.05 }} data after a filter processing failure
+    in accordance with {{ insert: param, ac-4.8_prm_4 }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-4.9
+  title: Human Reviews
+  objective: 'Enforce the use of human reviews for {{ insert: param, ac-04.09_odp.01 }} under the following conditions: {{
+    insert: param, ac-04.09_odp.02 }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-4.10
+  title: Enable and Disable Security or Privacy Policy Filters
+  objective: 'Provide the capability for privileged administrators to enable and disable {{ insert: param, ac-4.10_prm_1 }}
+    under the following conditions: {{ insert: param, ac-4.10_prm_2 }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-4.11
+  title: Configuration of Security or Privacy Policy Filters
+  objective: 'Provide the capability for privileged administrators to configure {{ insert: param, ac-4.11_prm_1 }} to support
+    different security or privacy policies.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-4.12
+  title: Data Type Identifiers
+  objective: 'When transferring information between different security domains, use {{ insert: param, ac-04.12_odp }} to validate
+    data essential for information flow decisions.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-4.13
+  title: Decomposition into Policy-relevant Subcomponents
+  objective: 'When transferring information between different security domains, decompose information into {{ insert: param,
+    ac-04.13_odp }} for submission to policy enforcement mechanisms.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-4.14
+  title: Security or Privacy Policy Filter Constraints
+  objective: 'When transferring information between different security domains, implement {{ insert: param, ac-4.14_prm_1
+    }} requiring fully enumerated formats that restrict data structure and content.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-4.15
+  title: Detection of Unsanctioned Information
+  objective: 'When transferring information between different security domains, examine the information for the presence of
+    {{ insert: param, ac-04.15_odp.01 }} and prohibit the transfer of such information in accordance with the {{ insert: param,
+    ac-4.15_prm_2 }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-4.16
+  title: Information Transfers on Interconnected Systems
+  objective: Information Transfers on Interconnected Systems
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-4.17
+  title: Domain Authentication
+  objective: 'Uniquely identify and authenticate source and destination points by {{ insert: param, ac-04.17_odp }} for information
+    transfer.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-4.18
+  title: Security Attribute Binding
+  objective: Security Attribute Binding
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-4.19
+  title: Validation of Metadata
+  objective: 'When transferring information between different security domains, implement {{ insert: param, ac-4.19_prm_1
+    }} on metadata.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-4.20
+  title: Approved Solutions
+  objective: 'Employ {{ insert: param, ac-04.20_odp.01 }} to control the flow of {{ insert: param, ac-04.20_odp.02 }} across
+    security domains.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-4.21
+  title: Physical or Logical Separation of Information Flows
+  objective: 'Separate information flows logically or physically using {{ insert: param, ac-4.21_prm_1 }} to accomplish {{
+    insert: param, ac-04.21_odp.03 }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-4.22
+  title: Access Only
+  objective: Provide access from a single device to computing platforms, applications, or data residing in multiple 
+    different security domains, while preventing information flow between the different security domains.
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-4.23
+  title: Modify Non-releasable Information
+  objective: 'When transferring information between different security domains, modify non-releasable information by implementing
+    {{ insert: param, ac-04.23_odp }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-4.24
+  title: Internal Normalized Format
+  objective: When transferring information between different security domains, parse incoming data into an internal 
+    normalized format and regenerate the data to be consistent with its intended specification.
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-4.25
+  title: Data Sanitization
+  objective: 'When transferring information between different security domains, sanitize data to minimize {{ insert: param,
+    ac-04.25_odp.01 }} in accordance with {{ insert: param, ac-04.25_odp.02 }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-4.26
+  title: Audit Filtering Actions
+  objective: When transferring information between different security domains, record and audit content filtering 
+    actions and results for the information being filtered.
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-4.27
+  title: Redundant/Independent Filtering Mechanisms
+  objective: When transferring information between different security domains, implement content filtering solutions 
+    that provide redundant and independent filtering mechanisms for each data type.
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-4.28
+  title: Linear Filter Pipelines
+  objective: When transferring information between different security domains, implement a linear content filter 
+    pipeline that is enforced with discretionary and mandatory access controls.
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-4.29
+  title: Filter Orchestration Engines
+  objective: 'When transferring information between different security domains, employ content filter orchestration engines
+    to ensure that:'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-4.30
+  title: Filter Mechanisms Using Multiple Processes
+  objective: When transferring information between different security domains, implement content filtering mechanisms 
+    using multiple processes.
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-4.31
+  title: Failed Content Transfer Prevention
+  objective: When transferring information between different security domains, prevent the transfer of failed content to
+    the receiving domain.
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-4.32
+  title: Process Requirements for Information Transfer
+  objective: 'When transferring information between different security domains, the process that transfers information between
+    filter pipelines:'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-4
+  title: Information Flow Enforcement
+  objective: 'Enforce approved authorizations for controlling the flow of information within the system and between connected
+    systems based on {{ insert: param, ac-04_odp }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-5
+  title: Separation of Duties
+  objective: 'Identify and document {{ insert: param, ac-05_odp }} ; and Define system access authorizations to support separation
+    of duties.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-6.1
+  title: Authorize Access to Security Functions
+  objective: 'Authorize access for {{ insert: param, ac-06.01_odp.01 }} to:'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-6.2
+  title: Non-privileged Access for Nonsecurity Functions
+  objective: 'Require that users of system accounts (or roles) with access to {{ insert: param, ac-06.02_odp }} use non-privileged
+    accounts or roles, when accessing nonsecurity functions.'
+  group: ac
+  assessment-requirements:
+  - id: package_sudo_installed
+    state: Active
+    text: Rule 'package_sudo_installed' MUST be verified
+    applicability:
+    - fedora-moderate
+  state: Active
+- id: ac-6.3
+  title: Network Access to Privileged Commands
+  objective: 'Authorize network access to {{ insert: param, ac-06.03_odp.01 }} only for {{ insert: param, ac-06.03_odp.02
+    }} and document the rationale for such access in the security plan for the system.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: ac-6.4
+  title: Separate Processing Domains
+  objective: Provide separate processing domains to enable finer-grained allocation of user privileges.
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-6.5
+  title: Privileged Accounts
+  objective: 'Restrict privileged accounts on the system to {{ insert: param, ac-06.05_odp }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-6.6
+  title: Privileged Access by Non-organizational Users
+  objective: Prohibit privileged access to the system by non-organizational users.
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-6.7
+  title: Review of User Privileges
+  objective: 'Review {{ insert: param, ac-06.07_odp.01 }} the privileges assigned to {{ insert: param, ac-06.07_odp.02 }}
+    to validate the need for such privileges; and Reassign or remove privileges, if necessary, to correctly reflect organizational
+    mission and business needs.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-6.8
+  title: Privilege Levels for Code Execution
+  objective: 'Prevent the following software from executing at higher privilege levels than users executing the software:
+    {{ insert: param, ac-06.08_odp }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-6.9
+  title: Log Use of Privileged Functions
+  objective: Log the execution of privileged functions.
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-6.10
+  title: Prohibit Non-privileged Users from Executing Privileged Functions
+  objective: Prevent non-privileged users from executing privileged functions.
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-6
+  title: Least Privilege
+  objective: Employ the principle of least privilege, allowing only authorized accesses for users (or processes acting 
+    on behalf of users) that are necessary to accomplish assigned organizational tasks.
+  group: ac
+  assessment-requirements:
+  - id: sshd_disable_root_login
+    state: Active
+    text: Rule 'sshd_disable_root_login' MUST be verified
+    applicability: &id003
+    - fedora-moderate
+  - id: sudo_add_use_pty
+    state: Active
+    text: Rule 'sudo_add_use_pty' MUST be verified
+    applicability: *id003
+  - id: sudo_remove_no_authenticate
+    state: Active
+    text: Rule 'sudo_remove_no_authenticate' MUST be verified
+    applicability: *id003
+  - id: sudo_remove_nopasswd
+    state: Active
+    text: Rule 'sudo_remove_nopasswd' MUST be verified
+    applicability: *id003
+  state: Active
+- id: ac-7.1
+  title: Automatic Account Lock
+  objective: Automatic Account Lock
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-7.2
+  title: Purge or Wipe Mobile Device
+  objective: 'Purge or wipe information from {{ insert: param, ac-07.02_odp.01 }} based on {{ insert: param, ac-07.02_odp.02
+    }} after {{ insert: param, ac-07.02_odp.03 }} consecutive, unsuccessful device logon attempts.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-7.3
+  title: Biometric Attempt Limiting
+  objective: 'Limit the number of unsuccessful biometric logon attempts to {{ insert: param, ac-07.03_odp }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-7.4
+  title: Use of Alternate Authentication Factor
+  objective: 'Allow the use of {{ insert: param, ac-07.04_odp.01 }} that are different from the primary authentication factors
+    after the number of organization-defined consecutive invalid logon attempts have been exceeded; and Enforce a limit of
+    {{ insert: param, ac-07.04_odp.02 }} consecutive invalid logon attempts through use of the alternative factors by a user
+    during a {{ insert: param, ac-07.04_odp.03 }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-7
+  title: Unsuccessful Logon Attempts
+  objective: 'Enforce a limit of {{ insert: param, ac-07_odp.01 }} consecutive invalid logon attempts by a user during a {{
+    insert: param, ac-07_odp.02 }} ; and Automatically {{ insert: param, ac-07_odp.03 }} when the maximum number of unsuccessful
+    attempts is exceeded.'
+  group: ac
+  assessment-requirements:
+  - id: account_password_pam_faillock_password_auth
+    state: Active
+    text: Rule 'account_password_pam_faillock_password_auth' MUST be verified
+    applicability: &id004
+    - fedora-low
+  - id: account_password_pam_faillock_system_auth
+    state: Active
+    text: Rule 'account_password_pam_faillock_system_auth' MUST be verified
+    applicability: *id004
+  - id: accounts_passwords_pam_faillock_deny
+    state: Active
+    text: Rule 'accounts_passwords_pam_faillock_deny' MUST be verified
+    applicability: *id004
+  - id: accounts_passwords_pam_faillock_even_deny_root_or_root_unlock_time
+    state: Active
+    text: Rule 'accounts_passwords_pam_faillock_even_deny_root_or_root_unlock_time' MUST be verified
+    applicability: *id004
+  - id: accounts_passwords_pam_faillock_unlock_time_with_zero
+    state: Active
+    text: Rule 'accounts_passwords_pam_faillock_unlock_time_with_zero' MUST be verified
+    applicability: *id004
+  - id: var_accounts_passwords_pam_faillock_deny
+    state: Active
+    text: Variable 'var_accounts_passwords_pam_faillock_deny' is set to '5'
+    applicability: *id004
+  - id: var_accounts_passwords_pam_faillock_dir
+    state: Active
+    text: Variable 'var_accounts_passwords_pam_faillock_dir' is set to 'run'
+    applicability: *id004
+  - id: var_accounts_passwords_pam_faillock_root_unlock_time
+    state: Active
+    text: Variable 'var_accounts_passwords_pam_faillock_root_unlock_time' is set to '60'
+    applicability: *id004
+  - id: var_accounts_passwords_pam_faillock_unlock_time
+    state: Active
+    text: Variable 'var_accounts_passwords_pam_faillock_unlock_time' is set to '900'
+    applicability: *id004
+  state: Active
+- id: ac-8
+  title: System Use Notification
+  objective: 'Display {{ insert: param, ac-08_odp.01 }} to users before granting access to the system that provides privacy
+    and security notices consistent with applicable laws, executive orders, directives, regulations, policies, standards,
+    and guidelines and state that: Retain the notification message or banner on the screen until users acknowledge the usage
+    conditions and take explicit actions to log on to or further access the system; and For publicly accessible systems:'
+  group: ac
+  assessment-requirements:
+  - id: dconf_gnome_banner_enabled
+    state: Active
+    text: Rule 'dconf_gnome_banner_enabled' MUST be verified
+    applicability: &id005
+    - fedora-low
+  - id: dconf_gnome_login_banner_text
+    state: Active
+    text: Rule 'dconf_gnome_login_banner_text' MUST be verified
+    applicability: *id005
+  state: Active
+- id: ac-9.1
+  title: Unsuccessful Logons
+  objective: Notify the user, upon successful logon, of the number of unsuccessful logon attempts since the last 
+    successful logon.
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-9.2
+  title: Successful and Unsuccessful Logons
+  objective: 'Notify the user, upon successful logon, of the number of {{ insert: param, ac-09.02_odp.01 }} during {{ insert:
+    param, ac-09.02_odp.02 }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-9.3
+  title: Notification of Account Changes
+  objective: 'Notify the user, upon successful logon, of changes to {{ insert: param, ac-09.03_odp.01 }} during {{ insert:
+    param, ac-09.03_odp.02 }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-9.4
+  title: Additional Logon Information
+  objective: 'Notify the user, upon successful logon, of the following additional information: {{ insert: param, ac-09.04_odp
+    }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-9
+  title: Previous Logon Notification
+  objective: Notify the user, upon successful logon to the system, of the date and time of the last logon.
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-10
+  title: Concurrent Session Control
+  objective: 'Limit the number of concurrent sessions for each {{ insert: param, ac-10_odp.01 }} to {{ insert: param, ac-10_odp.02
+    }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: ac-11.1
+  title: Pattern-hiding Displays
+  objective: Conceal, via the device lock, information previously visible on the display with a publicly viewable image.
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-11
+  title: Device Lock
+  objective: 'Prevent further access to the system by {{ insert: param, ac-11_odp.01 }} ; and Retain the device lock until
+    the user reestablishes access using established identification and authentication procedures.'
+  group: ac
+  assessment-requirements:
+  - id: dconf_gnome_screensaver_idle_delay
+    state: Active
+    text: Rule 'dconf_gnome_screensaver_idle_delay' MUST be verified
+    applicability: &id006
+    - fedora-moderate
+  - id: dconf_gnome_screensaver_lock_delay
+    state: Active
+    text: Rule 'dconf_gnome_screensaver_lock_delay' MUST be verified
+    applicability: *id006
+  - id: dconf_gnome_screensaver_user_locks
+    state: Active
+    text: Rule 'dconf_gnome_screensaver_user_locks' MUST be verified
+    applicability: *id006
+  - id: dconf_gnome_session_idle_user_locks
+    state: Active
+    text: Rule 'dconf_gnome_session_idle_user_locks' MUST be verified
+    applicability: *id006
+  - id: var_screensaver_lock_delay
+    state: Active
+    text: Variable 'var_screensaver_lock_delay' is set to '5_seconds'
+    applicability: *id006
+  state: Active
+- id: ac-12.1
+  title: User-initiated Logouts
+  objective: 'Provide a logout capability for user-initiated communications sessions whenever authentication is used to gain
+    access to {{ insert: param, ac-12.01_odp }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-12.2
+  title: Termination Message
+  objective: Display an explicit logout message to users indicating the termination of authenticated communications 
+    sessions.
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-12.3
+  title: Timeout Warning Message
+  objective: 'Display an explicit message to users indicating that the session will end in {{ insert: param, ac-12.03_odp
+    }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-12
+  title: Session Termination
+  objective: 'Automatically terminate a user session after {{ insert: param, ac-12_odp }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-13
+  title: Supervision and Review — Access Control
+  objective: Supervision and Review — Access Control
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-14.1
+  title: Necessary Uses
+  objective: Necessary Uses
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-14
+  title: Permitted Actions Without Identification or Authentication
+  objective: 'Identify {{ insert: param, ac-14_odp }} that can be performed on the system without identification or authentication
+    consistent with organizational mission and business functions; and Document and provide supporting rationale in the security
+    plan for the system, user actions not requiring identification or authentication.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-15
+  title: Automated Marking
+  objective: Automated Marking
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-16.1
+  title: Dynamic Attribute Association
+  objective: 'Dynamically associate security and privacy attributes with {{ insert: param, ac-16.1_prm_1 }} in accordance
+    with the following security and privacy policies as information is created and combined: {{ insert: param, ac-16.1_prm_2
+    }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-16.2
+  title: Attribute Value Changes by Authorized Individuals
+  objective: Provide authorized individuals (or processes acting on behalf of individuals) the capability to define or 
+    change the value of associated security and privacy attributes.
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-16.3
+  title: Maintenance of Attribute Associations by System
+  objective: 'Maintain the association and integrity of {{ insert: param, ac-16.3_prm_1 }} to {{ insert: param, ac-16.3_prm_2
+    }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-16.4
+  title: Association of Attributes by Authorized Individuals
+  objective: 'Provide the capability to associate {{ insert: param, ac-16.4_prm_1 }} with {{ insert: param, ac-16.4_prm_2
+    }} by authorized individuals (or processes acting on behalf of individuals).'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-16.5
+  title: Attribute Displays on Objects to Be Output
+  objective: 'Display security and privacy attributes in human-readable form on each object that the system transmits to output
+    devices to identify {{ insert: param, ac-16.05_odp.01 }} using {{ insert: param, ac-16.05_odp.02 }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-16.6
+  title: Maintenance of Attribute Association
+  objective: 'Require personnel to associate and maintain the association of {{ insert: param, ac-16.6_prm_1 }} with {{ insert:
+    param, ac-16.6_prm_2 }} in accordance with {{ insert: param, ac-16.6_prm_3 }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-16.7
+  title: Consistent Attribute Interpretation
+  objective: Provide a consistent interpretation of security and privacy attributes transmitted between distributed 
+    system components.
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-16.8
+  title: Association Techniques and Technologies
+  objective: 'Implement {{ insert: param, ac-16.8_prm_1 }} in associating security and privacy attributes to information.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-16.9
+  title: Attribute Reassignment — Regrading Mechanisms
+  objective: 'Change security and privacy attributes associated with information only via regrading mechanisms validated using
+    {{ insert: param, ac-16.9_prm_1 }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-16.10
+  title: Attribute Configuration by Authorized Individuals
+  objective: Provide authorized individuals the capability to define or change the type and value of security and 
+    privacy attributes available for association with subjects and objects.
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-16
+  title: Security and Privacy Attributes
+  objective: 'Provide the means to associate {{ insert: param, ac-16_prm_1 }} with {{ insert: param, ac-16_prm_2 }} for information
+    in storage, in process, and/or in transmission; Ensure that the attribute associations are made and retained with the
+    information; Establish the following permitted security and privacy attributes from the attributes defined in [AC-16a](#ac-16_smt.a)
+    for {{ insert: param, ac-16_prm_3 }}: {{ insert: param, ac-16_prm_4 }}; Determine the following permitted attribute values
+    or ranges for each of the established attributes: {{ insert: param, ac-16_odp.09 }}; Audit changes to attributes; and
+    Review {{ insert: param, ac-16_prm_6 }} for applicability {{ insert: param, ac-16_prm_7 }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-17.1
+  title: Monitoring and Control
+  objective: Employ automated mechanisms to monitor and control remote access methods.
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-17.2
+  title: Protection of Confidentiality and Integrity Using Encryption
+  objective: Implement cryptographic mechanisms to protect the confidentiality and integrity of remote access sessions.
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-17.3
+  title: Managed Access Control Points
+  objective: Route remote accesses through authorized and managed network access control points.
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-17.4
+  title: Privileged Commands and Access
+  objective: 'Authorize the execution of privileged commands and access to security-relevant information via remote access
+    only in a format that provides assessable evidence and for the following needs: {{ insert: param, ac-17.4_prm_1 }} ; and
+    Document the rationale for remote access in the security plan for the system.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-17.5
+  title: Monitoring for Unauthorized Connections
+  objective: Monitoring for Unauthorized Connections
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-17.6
+  title: Protection of Mechanism Information
+  objective: Protect information about remote access mechanisms from unauthorized use and disclosure.
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-17.7
+  title: Additional Protection for Security Function Access
+  objective: Additional Protection for Security Function Access
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-17.8
+  title: Disable Nonsecure Network Protocols
+  objective: Disable Nonsecure Network Protocols
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-17.9
+  title: Disconnect or Disable Access
+  objective: 'Provide the capability to disconnect or disable remote access to the system within {{ insert: param, ac-17.09_odp
+    }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-17.10
+  title: Authenticate Remote Commands
+  objective: 'Implement {{ insert: param, ac-17.10_odp.01 }} to authenticate {{ insert: param, ac-17.10_odp.02 }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-17
+  title: Remote Access
+  objective: Establish and document usage restrictions, configuration/connection requirements, and implementation 
+    guidance for each type of remote access allowed; and Authorize each type of remote access to the system prior to 
+    allowing such connections.
+  group: ac
+  assessment-requirements:
+  - id: configure_custom_crypto_policy_cis
+    state: Active
+    text: Rule 'configure_custom_crypto_policy_cis' MUST be verified
+    applicability:
+    - fedora-low
+  state: Active
+- id: ac-18.1
+  title: Authentication and Encryption
+  objective: 'Protect wireless access to the system using authentication of {{ insert: param, ac-18.01_odp }} and encryption.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-18.2
+  title: Monitoring Unauthorized Connections
+  objective: Monitoring Unauthorized Connections
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-18.3
+  title: Disable Wireless Networking
+  objective: Disable, when not intended for use, wireless networking capabilities embedded within system components 
+    prior to issuance and deployment.
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-18.4
+  title: Restrict Configurations by Users
+  objective: Identify and explicitly authorize users allowed to independently configure wireless networking 
+    capabilities.
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: ac-18.5
+  title: Antennas and Transmission Power Levels
+  objective: Select radio antennas and calibrate transmission power levels to reduce the probability that signals from 
+    wireless access points can be received outside of organization-controlled boundaries.
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: ac-18
+  title: Wireless Access
+  objective: Establish configuration requirements, connection requirements, and implementation guidance for each type of
+    wireless access; and Authorize each type of wireless access to the system prior to allowing such connections.
+  group: ac
+  assessment-requirements:
+  - id: wireless_disable_interfaces
+    state: Active
+    text: Rule 'wireless_disable_interfaces' MUST be verified
+    applicability:
+    - fedora-low
+  state: Active
+- id: ac-19.1
+  title: Use of Writable and Portable Storage Devices
+  objective: Use of Writable and Portable Storage Devices
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-19.2
+  title: Use of Personally Owned Portable Storage Devices
+  objective: Use of Personally Owned Portable Storage Devices
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-19.3
+  title: Use of Portable Storage Devices with No Identifiable Owner
+  objective: Use of Portable Storage Devices with No Identifiable Owner
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-19.4
+  title: Restrictions for Classified Information
+  objective: 'Prohibit the use of unclassified mobile devices in facilities containing systems processing, storing, or transmitting
+    classified information unless specifically permitted by the authorizing official; and Enforce the following restrictions
+    on individuals permitted by the authorizing official to use unclassified mobile devices in facilities containing systems
+    processing, storing, or transmitting classified information: Restrict the connection of classified mobile devices to classified
+    systems in accordance with {{ insert: param, ac-19.04_odp.02 }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-19.5
+  title: Full Device or Container-based Encryption
+  objective: 'Employ {{ insert: param, ac-19.05_odp.01 }} to protect the confidentiality and integrity of information on {{
+    insert: param, ac-19.05_odp.02 }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-19
+  title: Access Control for Mobile Devices
+  objective: Establish configuration requirements, connection requirements, and implementation guidance for 
+    organization-controlled mobile devices, to include when such devices are outside of controlled areas; and Authorize 
+    the connection of mobile devices to organizational systems.
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-20.1
+  title: Limits on Authorized Use
+  objective: 'Permit authorized individuals to use an external system to access the system or to process, store, or transmit
+    organization-controlled information only after:'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-20.2
+  title: Portable Storage Devices — Restricted Use
+  objective: 'Restrict the use of organization-controlled portable storage devices by authorized individuals on external systems
+    using {{ insert: param, ac-20.02_odp }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-20.3
+  title: Non-organizationally Owned Systems — Restricted Use
+  objective: 'Restrict the use of non-organizationally owned systems or system components to process, store, or transmit organizational
+    information using {{ insert: param, ac-20.03_odp }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-20.4
+  title: Network Accessible Storage Devices — Prohibited Use
+  objective: 'Prohibit the use of {{ insert: param, ac-20.04_odp }} in external systems.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-20.5
+  title: Portable Storage Devices — Prohibited Use
+  objective: Prohibit the use of organization-controlled portable storage devices by authorized individuals on external 
+    systems.
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-20
+  title: Use of External Systems
+  objective: '{{ insert: param, ac-20_odp.01 }} , consistent with the trust relationships established with other organizations
+    owning, operating, and/or maintaining external systems, allowing authorized individuals to: Prohibit the use of {{ insert:
+    param, ac-20_odp.04 }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-21.1
+  title: Automated Decision Support
+  objective: 'Employ {{ insert: param, ac-21.01_odp }} to enforce information-sharing decisions by authorized users based
+    on access authorizations of sharing partners and access restrictions on information to be shared.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-21.2
+  title: Information Search and Retrieval
+  objective: 'Implement information search and retrieval services that enforce {{ insert: param, ac-21.02_odp }}.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-21
+  title: Information Sharing
+  objective: 'Enable authorized users to determine whether access authorizations assigned to a sharing partner match the information’s
+    access and use restrictions for {{ insert: param, ac-21_odp.01 }} ; and Employ {{ insert: param, ac-21_odp.02 }} to assist
+    users in making information sharing and collaboration decisions.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ac-22
+  title: Publicly Accessible Content
+  objective: 'Designate individuals authorized to make information publicly accessible; Train authorized individuals to ensure
+    that publicly accessible information does not contain nonpublic information; Review the proposed content of information
+    prior to posting onto the publicly accessible system to ensure that nonpublic information is not included; and Review
+    the content on the publicly accessible system for nonpublic information {{ insert: param, ac-22_odp }} and remove such
+    information, if discovered.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-23
+  title: Data Mining Protection
+  objective: 'Employ {{ insert: param, ac-23_odp.01 }} for {{ insert: param, ac-23_odp.02 }} to detect and protect against
+    unauthorized data mining.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-24.1
+  title: Transmit Access Authorization Information
+  objective: 'Transmit {{ insert: param, ac-24.01_odp.01 }} using {{ insert: param, ac-24.01_odp.02 }} to {{ insert: param,
+    ac-24.01_odp.03 }} that enforce access control decisions.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-24.2
+  title: No User or Process Identity
+  objective: 'Enforce access control decisions based on {{ insert: param, ac-24.2_prm_1 }} that do not include the identity
+    of the user or process acting on behalf of the user.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-24
+  title: Access Control Decisions
+  objective: '{{ insert: param, ac-24_odp.01 }} to ensure {{ insert: param, ac-24_odp.02 }} are applied to each access request
+    prior to access enforcement.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ac-25
+  title: Reference Monitor
+  objective: 'Implement a reference monitor for {{ insert: param, ac-25_odp }} that is tamperproof, always invoked, and small
+    enough to be subject to analysis and testing, the completeness of which can be assured.'
+  group: ac
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: at-1
+  title: Policy and Procedures
+  objective: 'Develop, document, and disseminate to {{ insert: param, at-1_prm_1 }}: Designate an {{ insert: param, at-01_odp.04
+    }} to manage the development, documentation, and dissemination of the awareness and training policy and procedures; and
+    Review and update the current awareness and training:'
+  group: at
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: at-2.1
+  title: Practical Exercises
+  objective: Provide practical exercises in literacy training that simulate events and incidents.
+  group: at
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: at-2.2
+  title: Insider Threat
+  objective: Provide literacy training on recognizing and reporting potential indicators of insider threat.
+  group: at
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: at-2.3
+  title: Social Engineering and Mining
+  objective: Provide literacy training on recognizing and reporting potential and actual instances of social engineering
+    and social mining.
+  group: at
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: at-2.4
+  title: Suspicious Communications and Anomalous System Behavior
+  objective: 'Provide literacy training on recognizing suspicious communications and anomalous behavior in organizational
+    systems using {{ insert: param, at-02.04_odp }}.'
+  group: at
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: at-2.5
+  title: Advanced Persistent Threat
+  objective: Provide literacy training on the advanced persistent threat.
+  group: at
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: at-2.6
+  title: Cyber Threat Environment
+  objective: Provide literacy training on the cyber threat environment; and Reflect current cyber threat information in 
+    system operations.
+  group: at
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: at-2
+  title: Literacy Training and Awareness
+  objective: 'Provide security and privacy literacy training to system users (including managers, senior executives, and contractors):
+    Employ the following techniques to increase the security and privacy awareness of system users {{ insert: param, at-02_odp.05
+    }}; Update literacy training and awareness content {{ insert: param, at-02_odp.06 }} and following {{ insert: param, at-02_odp.07
+    }} ; and Incorporate lessons learned from internal or external security incidents or breaches into literacy training and
+    awareness techniques.'
+  group: at
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: at-3.1
+  title: Environmental Controls
+  objective: 'Provide {{ insert: param, at-03.01_odp.01 }} with initial and {{ insert: param, at-03.01_odp.02 }} training
+    in the employment and operation of environmental controls.'
+  group: at
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: at-3.2
+  title: Physical Security Controls
+  objective: 'Provide {{ insert: param, at-03.02_odp.01 }} with initial and {{ insert: param, at-03.02_odp.02 }} training
+    in the employment and operation of physical security controls.'
+  group: at
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: at-3.3
+  title: Practical Exercises
+  objective: Provide practical exercises in security and privacy training that reinforce training objectives.
+  group: at
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: at-3.4
+  title: Suspicious Communications and Anomalous System Behavior
+  objective: Suspicious Communications and Anomalous System Behavior
+  group: at
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: at-3.5
+  title: Processing Personally Identifiable Information
+  objective: 'Provide {{ insert: param, at-03.05_odp.01 }} with initial and {{ insert: param, at-03.05_odp.02 }} training
+    in the employment and operation of personally identifiable information processing and transparency controls.'
+  group: at
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: at-3
+  title: Role-based Training
+  objective: 'Provide role-based security and privacy training to personnel with the following roles and responsibilities:
+    {{ insert: param, at-3_prm_1 }}: Update role-based training content {{ insert: param, at-03_odp.04 }} and following {{
+    insert: param, at-03_odp.05 }} ; and Incorporate lessons learned from internal or external security incidents or breaches
+    into role-based training.'
+  group: at
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: at-4
+  title: Training Records
+  objective: 'Document and monitor information security and privacy training activities, including security and privacy awareness
+    training and specific role-based security and privacy training; and Retain individual training records for {{ insert:
+    param, at-04_odp }}.'
+  group: at
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: at-5
+  title: Contacts with Security Groups and Associations
+  objective: Contacts with Security Groups and Associations
+  group: at
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: at-6
+  title: Training Feedback
+  objective: 'Provide feedback on organizational training results to the following personnel {{ insert: param, at-06_odp.01
+    }}: {{ insert: param, at-06_odp.02 }}.'
+  group: at
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-1
+  title: Policy and Procedures
+  objective: 'Develop, document, and disseminate to {{ insert: param, au-1_prm_1 }}: Designate an {{ insert: param, au-01_odp.04
+    }} to manage the development, documentation, and dissemination of the audit and accountability policy and procedures;
+    and Review and update the current audit and accountability:'
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-2.1
+  title: Compilation of Audit Records from Multiple Sources
+  objective: Compilation of Audit Records from Multiple Sources
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-2.2
+  title: Selection of Audit Events by Component
+  objective: Selection of Audit Events by Component
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-2.3
+  title: Reviews and Updates
+  objective: Reviews and Updates
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-2.4
+  title: Privileged Functions
+  objective: Privileged Functions
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-2
+  title: Event Logging
+  objective: 'Identify the types of events that the system is capable of logging in support of the audit function: {{ insert:
+    param, au-02_odp.01 }}; Coordinate the event logging function with other organizational entities requiring audit-related
+    information to guide and inform the selection criteria for events to be logged; Specify the following event types for
+    logging within the system: {{ insert: param, au-2_prm_2 }}; Provide a rationale for why the event types selected for logging
+    are deemed to be adequate to support after-the-fact investigations of incidents; and Review and update the event types
+    selected for logging {{ insert: param, au-02_odp.04 }}.'
+  group: au
+  assessment-requirements:
+  - id: aide_build_database
+    state: Active
+    text: Rule 'aide_build_database' MUST be verified
+    applicability: &id007
+    - fedora-low
+  - id: aide_periodic_cron_checking
+    state: Active
+    text: Rule 'aide_periodic_cron_checking' MUST be verified
+    applicability: *id007
+  - id: audit_rules_execution_chacl
+    state: Active
+    text: Rule 'audit_rules_execution_chacl' MUST be verified
+    applicability: *id007
+  - id: audit_rules_execution_chcon
+    state: Active
+    text: Rule 'audit_rules_execution_chcon' MUST be verified
+    applicability: *id007
+  - id: audit_rules_execution_setfacl
+    state: Active
+    text: Rule 'audit_rules_execution_setfacl' MUST be verified
+    applicability: *id007
+  - id: audit_rules_privileged_commands_usermod
+    state: Active
+    text: Rule 'audit_rules_privileged_commands_usermod' MUST be verified
+    applicability: *id007
+  - id: auditd_data_disk_error_action
+    state: Active
+    text: Rule 'auditd_data_disk_error_action' MUST be verified
+    applicability: *id007
+  - id: auditd_data_disk_full_action
+    state: Active
+    text: Rule 'auditd_data_disk_full_action' MUST be verified
+    applicability: *id007
+  - id: auditd_data_retention_action_mail_acct
+    state: Active
+    text: Rule 'auditd_data_retention_action_mail_acct' MUST be verified
+    applicability: *id007
+  - id: auditd_data_retention_admin_space_left_action
+    state: Active
+    text: Rule 'auditd_data_retention_admin_space_left_action' MUST be verified
+    applicability: *id007
+  - id: auditd_data_retention_space_left_action
+    state: Active
+    text: Rule 'auditd_data_retention_space_left_action' MUST be verified
+    applicability: *id007
+  - id: grub2_audit_backlog_limit_argument
+    state: Active
+    text: Rule 'grub2_audit_backlog_limit_argument' MUST be verified
+    applicability: *id007
+  - id: journald_disable_forward_to_syslog
+    state: Active
+    text: Rule 'journald_disable_forward_to_syslog' MUST be verified
+    applicability: *id007
+  - id: package_aide_installed
+    state: Active
+    text: Rule 'package_aide_installed' MUST be verified
+    applicability: *id007
+  - id: package_audit-libs_installed
+    state: Active
+    text: Rule 'package_audit-libs_installed' MUST be verified
+    applicability: *id007
+  - id: package_audit_installed
+    state: Active
+    text: Rule 'package_audit_installed' MUST be verified
+    applicability: *id007
+  - id: package_systemd-journal-remote_installed
+    state: Active
+    text: Rule 'package_systemd-journal-remote_installed' MUST be verified
+    applicability: *id007
+  - id: service_auditd_enabled
+    state: Active
+    text: Rule 'service_auditd_enabled' MUST be verified
+    applicability: *id007
+  - id: service_systemd-journal-upload_enabled
+    state: Active
+    text: Rule 'service_systemd-journal-upload_enabled' MUST be verified
+    applicability: *id007
+  - id: service_systemd-journald_enabled
+    state: Active
+    text: Rule 'service_systemd-journald_enabled' MUST be verified
+    applicability: *id007
+  - id: socket_systemd-journal-remote_disabled
+    state: Active
+    text: Rule 'socket_systemd-journal-remote_disabled' MUST be verified
+    applicability: *id007
+  - id: ensure_journald_and_rsyslog_not_active_together
+    state: Active
+    text: Rule 'ensure_journald_and_rsyslog_not_active_together' MUST be verified
+    applicability: *id007
+  - id: var_audit_backlog_limit
+    state: Active
+    text: Variable 'var_audit_backlog_limit' is set to '8192'
+    applicability: *id007
+  - id: var_auditd_action_mail_acct
+    state: Active
+    text: Variable 'var_auditd_action_mail_acct' is set to 'root'
+    applicability: *id007
+  - id: var_auditd_admin_space_left_action
+    state: Active
+    text: Variable 'var_auditd_admin_space_left_action' is set to 'cis_fedora'
+    applicability: *id007
+  - id: var_auditd_space_left_action
+    state: Active
+    text: Variable 'var_auditd_space_left_action' is set to 'cis_fedora'
+    applicability: *id007
+  state: Active
+- id: au-3.1
+  title: Additional Audit Information
+  objective: 'Generate audit records containing the following additional information: {{ insert: param, au-03.01_odp }}.'
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: au-3.2
+  title: Centralized Management of Planned Audit Record Content
+  objective: Centralized Management of Planned Audit Record Content
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-3.3
+  title: Limit Personally Identifiable Information Elements
+  objective: 'Limit personally identifiable information contained in audit records to the following elements identified in
+    the privacy risk assessment: {{ insert: param, au-03.03_odp }}.'
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-3
+  title: Content of Audit Records
+  objective: 'Ensure that audit records contain information that establishes the following:'
+  group: au
+  assessment-requirements:
+  - id: audit_rules_dac_modification_chmod
+    state: Active
+    text: Rule 'audit_rules_dac_modification_chmod' MUST be verified
+    applicability: &id008
+    - fedora-low
+  - id: audit_rules_dac_modification_chown
+    state: Active
+    text: Rule 'audit_rules_dac_modification_chown' MUST be verified
+    applicability: *id008
+  - id: audit_rules_dac_modification_fchmod
+    state: Active
+    text: Rule 'audit_rules_dac_modification_fchmod' MUST be verified
+    applicability: *id008
+  - id: audit_rules_dac_modification_fchmodat
+    state: Active
+    text: Rule 'audit_rules_dac_modification_fchmodat' MUST be verified
+    applicability: *id008
+  - id: audit_rules_dac_modification_fchown
+    state: Active
+    text: Rule 'audit_rules_dac_modification_fchown' MUST be verified
+    applicability: *id008
+  - id: audit_rules_dac_modification_fchownat
+    state: Active
+    text: Rule 'audit_rules_dac_modification_fchownat' MUST be verified
+    applicability: *id008
+  - id: audit_rules_dac_modification_fremovexattr
+    state: Active
+    text: Rule 'audit_rules_dac_modification_fremovexattr' MUST be verified
+    applicability: *id008
+  - id: audit_rules_dac_modification_fsetxattr
+    state: Active
+    text: Rule 'audit_rules_dac_modification_fsetxattr' MUST be verified
+    applicability: *id008
+  - id: audit_rules_dac_modification_lchown
+    state: Active
+    text: Rule 'audit_rules_dac_modification_lchown' MUST be verified
+    applicability: *id008
+  - id: audit_rules_dac_modification_lremovexattr
+    state: Active
+    text: Rule 'audit_rules_dac_modification_lremovexattr' MUST be verified
+    applicability: *id008
+  - id: audit_rules_dac_modification_lsetxattr
+    state: Active
+    text: Rule 'audit_rules_dac_modification_lsetxattr' MUST be verified
+    applicability: *id008
+  - id: audit_rules_dac_modification_removexattr
+    state: Active
+    text: Rule 'audit_rules_dac_modification_removexattr' MUST be verified
+    applicability: *id008
+  - id: audit_rules_dac_modification_setxattr
+    state: Active
+    text: Rule 'audit_rules_dac_modification_setxattr' MUST be verified
+    applicability: *id008
+  - id: audit_rules_kernel_module_loading_delete
+    state: Active
+    text: Rule 'audit_rules_kernel_module_loading_delete' MUST be verified
+    applicability: *id008
+  - id: audit_rules_kernel_module_loading_finit
+    state: Active
+    text: Rule 'audit_rules_kernel_module_loading_finit' MUST be verified
+    applicability: *id008
+  - id: audit_rules_kernel_module_loading_init
+    state: Active
+    text: Rule 'audit_rules_kernel_module_loading_init' MUST be verified
+    applicability: *id008
+  - id: audit_rules_kernel_module_loading_query
+    state: Active
+    text: Rule 'audit_rules_kernel_module_loading_query' MUST be verified
+    applicability: *id008
+  - id: audit_rules_login_events_faillock
+    state: Active
+    text: Rule 'audit_rules_login_events_faillock' MUST be verified
+    applicability: *id008
+  - id: audit_rules_login_events_lastlog
+    state: Active
+    text: Rule 'audit_rules_login_events_lastlog' MUST be verified
+    applicability: *id008
+  - id: audit_rules_mac_modification_etc_selinux
+    state: Active
+    text: Rule 'audit_rules_mac_modification_etc_selinux' MUST be verified
+    applicability: *id008
+  - id: audit_rules_mac_modification_usr_share
+    state: Active
+    text: Rule 'audit_rules_mac_modification_usr_share' MUST be verified
+    applicability: *id008
+  - id: audit_rules_networkconfig_modification_etc_hosts
+    state: Active
+    text: Rule 'audit_rules_networkconfig_modification_etc_hosts' MUST be verified
+    applicability: *id008
+  - id: audit_rules_networkconfig_modification_etc_issue
+    state: Active
+    text: Rule 'audit_rules_networkconfig_modification_etc_issue' MUST be verified
+    applicability: *id008
+  - id: audit_rules_networkconfig_modification_etc_issue_net
+    state: Active
+    text: Rule 'audit_rules_networkconfig_modification_etc_issue_net' MUST be verified
+    applicability: *id008
+  - id: audit_rules_networkconfig_modification_etc_networkmanager_system_connections
+    state: Active
+    text: Rule 'audit_rules_networkconfig_modification_etc_networkmanager_system_connections' MUST be verified
+    applicability: *id008
+  - id: audit_rules_networkconfig_modification_etc_sysconfig_network
+    state: Active
+    text: Rule 'audit_rules_networkconfig_modification_etc_sysconfig_network' MUST be verified
+    applicability: *id008
+  - id: audit_rules_networkconfig_modification_hostname_file
+    state: Active
+    text: Rule 'audit_rules_networkconfig_modification_hostname_file' MUST be verified
+    applicability: *id008
+  - id: audit_rules_networkconfig_modification_networkmanager
+    state: Active
+    text: Rule 'audit_rules_networkconfig_modification_networkmanager' MUST be verified
+    applicability: *id008
+  - id: audit_rules_networkconfig_modification_setdomainname
+    state: Active
+    text: Rule 'audit_rules_networkconfig_modification_setdomainname' MUST be verified
+    applicability: *id008
+  - id: audit_rules_networkconfig_modification_sethostname
+    state: Active
+    text: Rule 'audit_rules_networkconfig_modification_sethostname' MUST be verified
+    applicability: *id008
+  - id: audit_rules_privileged_commands
+    state: Active
+    text: Rule 'audit_rules_privileged_commands' MUST be verified
+    applicability: *id008
+  - id: audit_rules_privileged_commands_kmod
+    state: Active
+    text: Rule 'audit_rules_privileged_commands_kmod' MUST be verified
+    applicability: *id008
+  - id: audit_rules_session_events_btmp
+    state: Active
+    text: Rule 'audit_rules_session_events_btmp' MUST be verified
+    applicability: *id008
+  - id: audit_rules_session_events_utmp
+    state: Active
+    text: Rule 'audit_rules_session_events_utmp' MUST be verified
+    applicability: *id008
+  - id: audit_rules_session_events_wtmp
+    state: Active
+    text: Rule 'audit_rules_session_events_wtmp' MUST be verified
+    applicability: *id008
+  - id: audit_rules_suid_auid_privilege_function
+    state: Active
+    text: Rule 'audit_rules_suid_auid_privilege_function' MUST be verified
+    applicability: *id008
+  - id: audit_rules_sysadmin_actions
+    state: Active
+    text: Rule 'audit_rules_sysadmin_actions' MUST be verified
+    applicability: *id008
+  - id: audit_rules_time_adjtimex
+    state: Active
+    text: Rule 'audit_rules_time_adjtimex' MUST be verified
+    applicability: *id008
+  - id: audit_rules_time_clock_settime
+    state: Active
+    text: Rule 'audit_rules_time_clock_settime' MUST be verified
+    applicability: *id008
+  - id: audit_rules_time_settimeofday
+    state: Active
+    text: Rule 'audit_rules_time_settimeofday' MUST be verified
+    applicability: *id008
+  - id: audit_rules_time_watch_localtime
+    state: Active
+    text: Rule 'audit_rules_time_watch_localtime' MUST be verified
+    applicability: *id008
+  - id: audit_rules_unsuccessful_file_modification_creat
+    state: Active
+    text: Rule 'audit_rules_unsuccessful_file_modification_creat' MUST be verified
+    applicability: *id008
+  - id: audit_rules_unsuccessful_file_modification_ftruncate
+    state: Active
+    text: Rule 'audit_rules_unsuccessful_file_modification_ftruncate' MUST be verified
+    applicability: *id008
+  - id: audit_rules_unsuccessful_file_modification_open
+    state: Active
+    text: Rule 'audit_rules_unsuccessful_file_modification_open' MUST be verified
+    applicability: *id008
+  - id: audit_rules_unsuccessful_file_modification_openat
+    state: Active
+    text: Rule 'audit_rules_unsuccessful_file_modification_openat' MUST be verified
+    applicability: *id008
+  - id: audit_rules_unsuccessful_file_modification_truncate
+    state: Active
+    text: Rule 'audit_rules_unsuccessful_file_modification_truncate' MUST be verified
+    applicability: *id008
+  - id: audit_rules_usergroup_modification_group
+    state: Active
+    text: Rule 'audit_rules_usergroup_modification_group' MUST be verified
+    applicability: *id008
+  - id: audit_rules_usergroup_modification_gshadow
+    state: Active
+    text: Rule 'audit_rules_usergroup_modification_gshadow' MUST be verified
+    applicability: *id008
+  - id: audit_rules_usergroup_modification_nsswitch_conf
+    state: Active
+    text: Rule 'audit_rules_usergroup_modification_nsswitch_conf' MUST be verified
+    applicability: *id008
+  - id: audit_rules_usergroup_modification_opasswd
+    state: Active
+    text: Rule 'audit_rules_usergroup_modification_opasswd' MUST be verified
+    applicability: *id008
+  - id: audit_rules_usergroup_modification_pam_conf
+    state: Active
+    text: Rule 'audit_rules_usergroup_modification_pam_conf' MUST be verified
+    applicability: *id008
+  - id: audit_rules_usergroup_modification_pamd
+    state: Active
+    text: Rule 'audit_rules_usergroup_modification_pamd' MUST be verified
+    applicability: *id008
+  - id: audit_rules_usergroup_modification_passwd
+    state: Active
+    text: Rule 'audit_rules_usergroup_modification_passwd' MUST be verified
+    applicability: *id008
+  - id: audit_rules_usergroup_modification_shadow
+    state: Active
+    text: Rule 'audit_rules_usergroup_modification_shadow' MUST be verified
+    applicability: *id008
+  - id: chronyd_specify_remote_server
+    state: Active
+    text: Rule 'chronyd_specify_remote_server' MUST be verified
+    applicability: *id008
+  - id: directory_permissions_var_log_audit
+    state: Active
+    text: Rule 'directory_permissions_var_log_audit' MUST be verified
+    applicability: *id008
+  - id: file_groupownership_audit_binaries
+    state: Active
+    text: Rule 'file_groupownership_audit_binaries' MUST be verified
+    applicability: *id008
+  - id: file_ownership_var_log_audit_stig
+    state: Active
+    text: Rule 'file_ownership_var_log_audit_stig' MUST be verified
+    applicability: *id008
+  - id: file_permissions_audit_binaries
+    state: Active
+    text: Rule 'file_permissions_audit_binaries' MUST be verified
+    applicability: *id008
+  - id: journald_storage
+    state: Active
+    text: Rule 'journald_storage' MUST be verified
+    applicability: *id008
+  - id: sshd_set_loglevel_verbose
+    state: Active
+    text: Rule 'sshd_set_loglevel_verbose' MUST be verified
+    applicability: *id008
+  - id: sshd_set_max_auth_tries
+    state: Active
+    text: Rule 'sshd_set_max_auth_tries' MUST be verified
+    applicability: *id008
+  - id: sudo_custom_logfile
+    state: Active
+    text: Rule 'sudo_custom_logfile' MUST be verified
+    applicability: *id008
+  - id: sysctl_net_ipv4_conf_all_log_martians
+    state: Active
+    text: Rule 'sysctl_net_ipv4_conf_all_log_martians' MUST be verified
+    applicability: *id008
+  - id: sysctl_net_ipv4_conf_default_log_martians
+    state: Active
+    text: Rule 'sysctl_net_ipv4_conf_default_log_martians' MUST be verified
+    applicability: *id008
+  - id: chronyd_run_as_chrony_user
+    state: Active
+    text: Rule 'chronyd_run_as_chrony_user' MUST be verified
+    applicability: *id008
+  - id: sshd_max_auth_tries_value
+    state: Active
+    text: Variable 'sshd_max_auth_tries_value' is set to '4'
+    applicability: *id008
+  - id: var_multiple_time_servers
+    state: Active
+    text: Variable 'var_multiple_time_servers' is set to 'fedora'
+    applicability: *id008
+  state: Active
+- id: au-4.1
+  title: Transfer to Alternate Storage
+  objective: 'Transfer audit logs {{ insert: param, au-04.01_odp }} to a different system, system component, or media other
+    than the system or system component conducting the logging.'
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-4
+  title: Audit Log Storage Capacity
+  objective: 'Allocate audit log storage capacity to accommodate {{ insert: param, au-04_odp }}.'
+  group: au
+  assessment-requirements:
+  - id: journald_compress
+    state: Active
+    text: Rule 'journald_compress' MUST be verified
+    applicability:
+    - fedora-low
+  state: Active
+- id: au-5.1
+  title: Storage Capacity Warning
+  objective: 'Provide a warning to {{ insert: param, au-05.01_odp.01 }} within {{ insert: param, au-05.01_odp.02 }} when allocated
+    audit log storage volume reaches {{ insert: param, au-05.01_odp.03 }} of repository maximum audit log storage capacity.'
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: au-5.2
+  title: Real-time Alerts
+  objective: 'Provide an alert within {{ insert: param, au-05.02_odp.01 }} to {{ insert: param, au-05.02_odp.02 }} when the
+    following audit failure events occur: {{ insert: param, au-05.02_odp.03 }}.'
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: au-5.3
+  title: Configurable Traffic Volume Thresholds
+  objective: 'Enforce configurable network communications traffic volume thresholds reflecting limits on audit log storage
+    capacity and {{ insert: param, au-05.03_odp }} network traffic above those thresholds.'
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-5.4
+  title: Shutdown on Failure
+  objective: 'Invoke a {{ insert: param, au-05.04_odp.01 }} in the event of {{ insert: param, au-05.04_odp.02 }} , unless
+    an alternate audit logging capability exists.'
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-5.5
+  title: Alternate Audit Logging Capability
+  objective: 'Provide an alternate audit logging capability in the event of a failure in primary audit logging capability
+    that implements {{ insert: param, au-05.05_odp }}.'
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-5
+  title: Response to Audit Logging Process Failures
+  objective: 'Alert {{ insert: param, au-05_odp.01 }} within {{ insert: param, au-05_odp.02 }} in the event of an audit logging
+    process failure; and Take the following additional actions: {{ insert: param, au-05_odp.03 }}.'
+  group: au
+  assessment-requirements:
+  - id: auditd_data_disk_error_action
+    state: Active
+    text: Rule 'auditd_data_disk_error_action' MUST be verified
+    applicability: &id009
+    - fedora-low
+  - id: auditd_data_disk_full_action
+    state: Active
+    text: Rule 'auditd_data_disk_full_action' MUST be verified
+    applicability: *id009
+  - id: var_auditd_disk_error_action
+    state: Active
+    text: Variable 'var_auditd_disk_error_action' is set to 'cis_fedora'
+    applicability: *id009
+  - id: var_auditd_disk_full_action
+    state: Active
+    text: Variable 'var_auditd_disk_full_action' is set to 'cis_fedora'
+    applicability: *id009
+  state: Active
+- id: au-6.1
+  title: Automated Process Integration
+  objective: 'Integrate audit record review, analysis, and reporting processes using {{ insert: param, au-06.01_odp }}.'
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: au-6.2
+  title: Automated Security Alerts
+  objective: Automated Security Alerts
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-6.3
+  title: Correlate Audit Record Repositories
+  objective: Analyze and correlate audit records across different repositories to gain organization-wide situational 
+    awareness.
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: au-6.4
+  title: Central Review and Analysis
+  objective: Provide and implement the capability to centrally review and analyze audit records from multiple components
+    within the system.
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-6.5
+  title: Integrated Analysis of Audit Records
+  objective: 'Integrate analysis of audit records with analysis of {{ insert: param, au-06.05_odp.01 }} to further enhance
+    the ability to identify inappropriate or unusual activity.'
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: au-6.6
+  title: Correlation with Physical Monitoring
+  objective: Correlate information from audit records with information obtained from monitoring physical access to 
+    further enhance the ability to identify suspicious, inappropriate, unusual, or malevolent activity.
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: au-6.7
+  title: Permitted Actions
+  objective: 'Specify the permitted actions for each {{ insert: param, au-06.07_odp }} associated with the review, analysis,
+    and reporting of audit record information.'
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-6.8
+  title: Full Text Analysis of Privileged Commands
+  objective: Perform a full text analysis of logged privileged commands in a physically distinct component or subsystem 
+    of the system, or other system that is dedicated to that analysis.
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-6.9
+  title: Correlation with Information from Nontechnical Sources
+  objective: Correlate information from nontechnical sources with audit record information to enhance organization-wide 
+    situational awareness.
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-6.10
+  title: Audit Level Adjustment
+  objective: Audit Level Adjustment
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-6
+  title: Audit Record Review, Analysis, and Reporting
+  objective: 'Review and analyze system audit records {{ insert: param, au-06_odp.01 }} for indications of {{ insert: param,
+    au-06_odp.02 }} and the potential impact of the inappropriate or unusual activity; Report findings to {{ insert: param,
+    au-06_odp.03 }} ; and Adjust the level of audit record review, analysis, and reporting within the system when there is
+    a change in risk based on law enforcement information, intelligence information, or other credible sources of information.'
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-7.1
+  title: Automatic Processing
+  objective: 'Provide and implement the capability to process, sort, and search audit records for events of interest based
+    on the following content: {{ insert: param, au-07.01_odp }}.'
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: au-7.2
+  title: Automatic Sort and Search
+  objective: Automatic Sort and Search
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: au-7
+  title: Audit Record Reduction and Report Generation
+  objective: 'Provide and implement an audit record reduction and report generation capability that:'
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: au-8.1
+  title: Synchronization with Authoritative Time Source
+  objective: Synchronization with Authoritative Time Source
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-8.2
+  title: Secondary Authoritative Time Source
+  objective: Secondary Authoritative Time Source
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-8
+  title: Time Stamps
+  objective: 'Use internal system clocks to generate time stamps for audit records; and Record time stamps for audit records
+    that meet {{ insert: param, au-08_odp }} and that use Coordinated Universal Time, have a fixed local time offset from
+    Coordinated Universal Time, or that include the local time offset as part of the time stamp.'
+  group: au
+  assessment-requirements:
+  - id: auditd_data_retention_max_log_file
+    state: Active
+    text: Rule 'auditd_data_retention_max_log_file' MUST be verified
+    applicability: &id010
+    - fedora-low
+  - id: auditd_data_retention_max_log_file_action
+    state: Active
+    text: Rule 'auditd_data_retention_max_log_file_action' MUST be verified
+    applicability: *id010
+  - id: var_auditd_max_log_file
+    state: Active
+    text: Variable 'var_auditd_max_log_file' is set to '8'
+    applicability: *id010
+  - id: var_auditd_max_log_file_action
+    state: Active
+    text: Variable 'var_auditd_max_log_file_action' is set to 'keep_logs'
+    applicability: *id010
+  state: Active
+- id: au-9.1
+  title: Hardware Write-once Media
+  objective: Write audit trails to hardware-enforced, write-once media.
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-9.2
+  title: Store on Separate Physical Systems or Components
+  objective: 'Store audit records {{ insert: param, au-09.02_odp }} in a repository that is part of a physically different
+    system or system component than the system or component being audited.'
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: au-9.3
+  title: Cryptographic Protection
+  objective: Implement cryptographic mechanisms to protect the integrity of audit information and audit tools.
+  group: au
+  assessment-requirements:
+  - id: aide_check_audit_tools
+    state: Active
+    text: Rule 'aide_check_audit_tools' MUST be verified
+    applicability:
+    - fedora-high
+  state: Active
+- id: au-9.4
+  title: Access by Subset of Privileged Users
+  objective: 'Authorize access to management of audit logging functionality to only {{ insert: param, au-09.04_odp }}.'
+  group: au
+  assessment-requirements:
+  - id: file_group_ownership_var_log_audit
+    state: Active
+    text: Rule 'file_group_ownership_var_log_audit' MUST be verified
+    applicability: &id011
+    - fedora-moderate
+  - id: file_permissions_var_log_audit
+    state: Active
+    text: Rule 'file_permissions_var_log_audit' MUST be verified
+    applicability: *id011
+  state: Active
+- id: au-9.5
+  title: Dual Authorization
+  objective: 'Enforce dual authorization for {{ insert: param, au-09.05_odp.01 }} of {{ insert: param, au-09.05_odp.02 }}.'
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-9.6
+  title: Read-only Access
+  objective: 'Authorize read-only access to audit information to {{ insert: param, au-09.06_odp }}.'
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-9.7
+  title: Store on Component with Different Operating System
+  objective: Store audit information on a component running a different operating system than the system or component 
+    being audited.
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-9
+  title: Protection of Audit Information
+  objective: 'Protect audit information and audit logging tools from unauthorized access, modification, and deletion; and
+    Alert {{ insert: param, au-09_odp }} upon detection of unauthorized access, modification, or deletion of audit information.'
+  group: au
+  assessment-requirements:
+  - id: audit_rules_immutable
+    state: Active
+    text: Rule 'audit_rules_immutable' MUST be verified
+    applicability: &id012
+    - fedora-low
+  - id: file_groupownership_audit_configuration
+    state: Active
+    text: Rule 'file_groupownership_audit_configuration' MUST be verified
+    applicability: *id012
+  - id: file_ownership_audit_binaries
+    state: Active
+    text: Rule 'file_ownership_audit_binaries' MUST be verified
+    applicability: *id012
+  - id: file_ownership_audit_configuration
+    state: Active
+    text: Rule 'file_ownership_audit_configuration' MUST be verified
+    applicability: *id012
+  state: Active
+- id: au-10.1
+  title: Association of Identities
+  objective: 'Bind the identity of the information producer with the information to {{ insert: param, au-10.01_odp }} ; and
+    Provide the means for authorized individuals to determine the identity of the producer of the information.'
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: au-10.2
+  title: Validate Binding of Information Producer Identity
+  objective: 'Validate the binding of the information producer identity to the information at {{ insert: param, au-10.02_odp.01
+    }} ; and Perform {{ insert: param, au-10.02_odp.02 }} in the event of a validation error.'
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: au-10.3
+  title: Chain of Custody
+  objective: Maintain reviewer or releaser credentials within the established chain of custody for information reviewed 
+    or released.
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: au-10.4
+  title: Validate Binding of Information Reviewer Identity
+  objective: 'Validate the binding of the information reviewer identity to the information at the transfer or release points
+    prior to release or transfer between {{ insert: param, au-10.04_odp.01 }} ; and Perform {{ insert: param, au-10.04_odp.02
+    }} in the event of a validation error.'
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: au-10.5
+  title: Digital Signatures
+  objective: Digital Signatures
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: au-10
+  title: Non-repudiation
+  objective: 'Provide irrefutable evidence that an individual (or process acting on behalf of an individual) has performed
+    {{ insert: param, au-10_odp }}.'
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: au-11.1
+  title: Long-term Retrieval Capability
+  objective: 'Employ {{ insert: param, au-11.01_odp }} to ensure that long-term audit records generated by the system can
+    be retrieved.'
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-11
+  title: Audit Record Retention
+  objective: 'Retain audit records for {{ insert: param, au-11_odp }} to provide support for after-the-fact investigations
+    of incidents and to meet regulatory and organizational information retention requirements.'
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-12.1
+  title: System-wide and Time-correlated Audit Trail
+  objective: 'Compile audit records from {{ insert: param, au-12.01_odp.01 }} into a system-wide (logical or physical) audit
+    trail that is time-correlated to within {{ insert: param, au-12.01_odp.02 }}.'
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: au-12.2
+  title: Standardized Formats
+  objective: Produce a system-wide (logical or physical) audit trail composed of audit records in a standardized format.
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-12.3
+  title: Changes by Authorized Individuals
+  objective: 'Provide and implement the capability for {{ insert: param, au-12.03_odp.01 }} to change the logging to be performed
+    on {{ insert: param, au-12.03_odp.02 }} based on {{ insert: param, au-12.03_odp.03 }} within {{ insert: param, au-12.03_odp.04
+    }}.'
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: au-12.4
+  title: Query Parameter Audits of Personally Identifiable Information
+  objective: Provide and implement the capability for auditing the parameters of user query events for data sets 
+    containing personally identifiable information.
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-12
+  title: Audit Record Generation
+  objective: 'Provide audit record generation capability for the event types the system is capable of auditing as defined
+    in [AU-2a](#au-2_smt.a) on {{ insert: param, au-12_odp.01 }}; Allow {{ insert: param, au-12_odp.02 }} to select the event
+    types that are to be logged by specific components of the system; and Generate audit records for the event types defined
+    in [AU-2c](#au-2_smt.c) that include the audit record content defined in [AU-3](#au-3).'
+  group: au
+  assessment-requirements:
+  - id: audit_rules_dac_modification_chmod
+    state: Active
+    text: Rule 'audit_rules_dac_modification_chmod' MUST be verified
+    applicability: &id013
+    - fedora-low
+  - id: audit_rules_dac_modification_chown
+    state: Active
+    text: Rule 'audit_rules_dac_modification_chown' MUST be verified
+    applicability: *id013
+  - id: audit_rules_dac_modification_fchmod
+    state: Active
+    text: Rule 'audit_rules_dac_modification_fchmod' MUST be verified
+    applicability: *id013
+  - id: audit_rules_dac_modification_fchmodat
+    state: Active
+    text: Rule 'audit_rules_dac_modification_fchmodat' MUST be verified
+    applicability: *id013
+  - id: audit_rules_dac_modification_fchmodat2
+    state: Active
+    text: Rule 'audit_rules_dac_modification_fchmodat2' MUST be verified
+    applicability: *id013
+  - id: audit_rules_dac_modification_fchown
+    state: Active
+    text: Rule 'audit_rules_dac_modification_fchown' MUST be verified
+    applicability: *id013
+  - id: audit_rules_dac_modification_fchownat
+    state: Active
+    text: Rule 'audit_rules_dac_modification_fchownat' MUST be verified
+    applicability: *id013
+  - id: audit_rules_dac_modification_fremovexattr
+    state: Active
+    text: Rule 'audit_rules_dac_modification_fremovexattr' MUST be verified
+    applicability: *id013
+  - id: audit_rules_dac_modification_fsetxattr
+    state: Active
+    text: Rule 'audit_rules_dac_modification_fsetxattr' MUST be verified
+    applicability: *id013
+  - id: audit_rules_dac_modification_lchown
+    state: Active
+    text: Rule 'audit_rules_dac_modification_lchown' MUST be verified
+    applicability: *id013
+  - id: audit_rules_dac_modification_lremovexattr
+    state: Active
+    text: Rule 'audit_rules_dac_modification_lremovexattr' MUST be verified
+    applicability: *id013
+  - id: audit_rules_dac_modification_lsetxattr
+    state: Active
+    text: Rule 'audit_rules_dac_modification_lsetxattr' MUST be verified
+    applicability: *id013
+  - id: audit_rules_dac_modification_removexattr
+    state: Active
+    text: Rule 'audit_rules_dac_modification_removexattr' MUST be verified
+    applicability: *id013
+  - id: audit_rules_dac_modification_setxattr
+    state: Active
+    text: Rule 'audit_rules_dac_modification_setxattr' MUST be verified
+    applicability: *id013
+  - id: audit_rules_continue_loading
+    state: Active
+    text: Rule 'audit_rules_continue_loading' MUST be verified
+    applicability: *id013
+  - id: audit_rules_execution_chcon
+    state: Active
+    text: Rule 'audit_rules_execution_chcon' MUST be verified
+    applicability: *id013
+  - id: audit_rules_file_deletion_events_rename
+    state: Active
+    text: Rule 'audit_rules_file_deletion_events_rename' MUST be verified
+    applicability: *id013
+  - id: audit_rules_file_deletion_events_renameat
+    state: Active
+    text: Rule 'audit_rules_file_deletion_events_renameat' MUST be verified
+    applicability: *id013
+  - id: audit_rules_file_deletion_events_renameat2
+    state: Active
+    text: Rule 'audit_rules_file_deletion_events_renameat2' MUST be verified
+    applicability: *id013
+  - id: audit_rules_file_deletion_events_unlink
+    state: Active
+    text: Rule 'audit_rules_file_deletion_events_unlink' MUST be verified
+    applicability: *id013
+  - id: audit_rules_file_deletion_events_unlinkat
+    state: Active
+    text: Rule 'audit_rules_file_deletion_events_unlinkat' MUST be verified
+    applicability: *id013
+  - id: audit_rules_kernel_module_loading_delete
+    state: Active
+    text: Rule 'audit_rules_kernel_module_loading_delete' MUST be verified
+    applicability: *id013
+  - id: audit_rules_kernel_module_loading_finit
+    state: Active
+    text: Rule 'audit_rules_kernel_module_loading_finit' MUST be verified
+    applicability: *id013
+  - id: audit_rules_kernel_module_loading_init
+    state: Active
+    text: Rule 'audit_rules_kernel_module_loading_init' MUST be verified
+    applicability: *id013
+  - id: audit_rules_kernel_module_loading_query
+    state: Active
+    text: Rule 'audit_rules_kernel_module_loading_query' MUST be verified
+    applicability: *id013
+  - id: audit_rules_login_events_faillock
+    state: Active
+    text: Rule 'audit_rules_login_events_faillock' MUST be verified
+    applicability: *id013
+  - id: audit_rules_login_events_lastlog
+    state: Active
+    text: Rule 'audit_rules_login_events_lastlog' MUST be verified
+    applicability: *id013
+  - id: audit_rules_media_export
+    state: Active
+    text: Rule 'audit_rules_media_export' MUST be verified
+    applicability: *id013
+  - id: audit_rules_privileged_commands_kmod
+    state: Active
+    text: Rule 'audit_rules_privileged_commands_kmod' MUST be verified
+    applicability: *id013
+  - id: audit_rules_privileged_commands_usermod
+    state: Active
+    text: Rule 'audit_rules_privileged_commands_usermod' MUST be verified
+    applicability: *id013
+  - id: audit_rules_sysadmin_actions
+    state: Active
+    text: Rule 'audit_rules_sysadmin_actions' MUST be verified
+    applicability: *id013
+  - id: audit_rules_unsuccessful_file_modification_creat
+    state: Active
+    text: Rule 'audit_rules_unsuccessful_file_modification_creat' MUST be verified
+    applicability: *id013
+  - id: audit_rules_unsuccessful_file_modification_ftruncate
+    state: Active
+    text: Rule 'audit_rules_unsuccessful_file_modification_ftruncate' MUST be verified
+    applicability: *id013
+  - id: audit_rules_unsuccessful_file_modification_open
+    state: Active
+    text: Rule 'audit_rules_unsuccessful_file_modification_open' MUST be verified
+    applicability: *id013
+  - id: audit_rules_unsuccessful_file_modification_openat
+    state: Active
+    text: Rule 'audit_rules_unsuccessful_file_modification_openat' MUST be verified
+    applicability: *id013
+  - id: audit_rules_unsuccessful_file_modification_truncate
+    state: Active
+    text: Rule 'audit_rules_unsuccessful_file_modification_truncate' MUST be verified
+    applicability: *id013
+  - id: audit_rules_usergroup_modification_group
+    state: Active
+    text: Rule 'audit_rules_usergroup_modification_group' MUST be verified
+    applicability: *id013
+  - id: audit_rules_usergroup_modification_gshadow
+    state: Active
+    text: Rule 'audit_rules_usergroup_modification_gshadow' MUST be verified
+    applicability: *id013
+  - id: audit_rules_usergroup_modification_nsswitch_conf
+    state: Active
+    text: Rule 'audit_rules_usergroup_modification_nsswitch_conf' MUST be verified
+    applicability: *id013
+  - id: audit_rules_usergroup_modification_opasswd
+    state: Active
+    text: Rule 'audit_rules_usergroup_modification_opasswd' MUST be verified
+    applicability: *id013
+  - id: audit_rules_usergroup_modification_pam_conf
+    state: Active
+    text: Rule 'audit_rules_usergroup_modification_pam_conf' MUST be verified
+    applicability: *id013
+  - id: audit_rules_usergroup_modification_pamd
+    state: Active
+    text: Rule 'audit_rules_usergroup_modification_pamd' MUST be verified
+    applicability: *id013
+  - id: audit_rules_usergroup_modification_passwd
+    state: Active
+    text: Rule 'audit_rules_usergroup_modification_passwd' MUST be verified
+    applicability: *id013
+  - id: audit_rules_usergroup_modification_shadow
+    state: Active
+    text: Rule 'audit_rules_usergroup_modification_shadow' MUST be verified
+    applicability: *id013
+  - id: audit_sudo_log_events
+    state: Active
+    text: Rule 'audit_sudo_log_events' MUST be verified
+    applicability: *id013
+  - id: file_permissions_audit_configuration
+    state: Active
+    text: Rule 'file_permissions_audit_configuration' MUST be verified
+    applicability: *id013
+  - id: grub2_audit_argument
+    state: Active
+    text: Rule 'grub2_audit_argument' MUST be verified
+    applicability: *id013
+  - id: service_auditd_enabled
+    state: Active
+    text: Rule 'service_auditd_enabled' MUST be verified
+    applicability: *id013
+  state: Active
+- id: au-13.1
+  title: Use of Automated Tools
+  objective: 'Monitor open-source information and information sites using {{ insert: param, au-13.01_odp }}.'
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-13.2
+  title: Review of Monitored Sites
+  objective: 'Review the list of open-source information sites being monitored {{ insert: param, au-13.02_odp }}.'
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-13.3
+  title: Unauthorized Replication of Information
+  objective: Employ discovery techniques, processes, and tools to determine if external entities are replicating 
+    organizational information in an unauthorized manner.
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-13
+  title: Monitoring for Information Disclosure
+  objective: 'Monitor {{ insert: param, au-13_odp.01 }} {{ insert: param, au-13_odp.02 }} for evidence of unauthorized disclosure
+    of organizational information; and If an information disclosure is discovered:'
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-14.1
+  title: System Start-up
+  objective: Initiate session audits automatically at system start-up.
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-14.2
+  title: Capture and Record Content
+  objective: Capture and Record Content
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-14.3
+  title: Remote Viewing and Listening
+  objective: Provide and implement the capability for authorized users to remotely view and hear content related to an 
+    established user session in real time.
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-14
+  title: Session Audit
+  objective: 'Provide and implement the capability for {{ insert: param, au-14_odp.01 }} to {{ insert: param, au-14_odp.02
+    }} the content of a user session under {{ insert: param, au-14_odp.03 }} ; and Develop, integrate, and use session auditing
+    activities in consultation with legal counsel and in accordance with applicable laws, executive orders, directives, regulations,
+    policies, standards, and guidelines.'
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-15
+  title: Alternate Audit Logging Capability
+  objective: Alternate Audit Logging Capability
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-16.1
+  title: Identity Preservation
+  objective: Preserve the identity of individuals in cross-organizational audit trails.
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-16.2
+  title: Sharing of Audit Information
+  objective: 'Provide cross-organizational audit information to {{ insert: param, au-16.02_odp.01 }} based on {{ insert: param,
+    au-16.02_odp.02 }}.'
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-16.3
+  title: Disassociability
+  objective: 'Implement {{ insert: param, au-16.03_odp }} to disassociate individuals from audit information transmitted across
+    organizational boundaries.'
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: au-16
+  title: Cross-organizational Audit Logging
+  objective: 'Employ {{ insert: param, au-16_odp.01 }} for coordinating {{ insert: param, au-16_odp.02 }} among external organizations
+    when audit information is transmitted across organizational boundaries.'
+  group: au
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ca-1
+  title: Policy and Procedures
+  objective: 'Develop, document, and disseminate to {{ insert: param, ca-1_prm_1 }}: Designate an {{ insert: param, ca-01_odp.04
+    }} to manage the development, documentation, and dissemination of the assessment, authorization, and monitoring policy
+    and procedures; and Review and update the current assessment, authorization, and monitoring:'
+  group: ca
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ca-2.1
+  title: Independent Assessors
+  objective: Employ independent assessors or assessment teams to conduct control assessments.
+  group: ca
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ca-2.2
+  title: Specialized Assessments
+  objective: 'Include as part of control assessments, {{ insert: param, ca-02.02_odp.01 }}, {{ insert: param, ca-02.02_odp.02
+    }}, {{ insert: param, ca-02.02_odp.03 }}.'
+  group: ca
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: ca-2.3
+  title: Leveraging Results from External Organizations
+  objective: 'Leverage the results of control assessments performed by {{ insert: param, ca-02.03_odp.01 }} on {{ insert:
+    param, ca-02.03_odp.02 }} when the assessment meets {{ insert: param, ca-02.03_odp.03 }}.'
+  group: ca
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ca-2
+  title: Control Assessments
+  objective: 'Select the appropriate assessor or assessment team for the type of assessment to be conducted; Develop a control
+    assessment plan that describes the scope of the assessment including: Ensure the control assessment plan is reviewed and
+    approved by the authorizing official or designated representative prior to conducting the assessment; Assess the controls
+    in the system and its environment of operation {{ insert: param, ca-02_odp.01 }} to determine the extent to which the
+    controls are implemented correctly, operating as intended, and producing the desired outcome with respect to meeting established
+    security and privacy requirements; Produce a control assessment report that document the results of the assessment; and
+    Provide the results of the control assessment to {{ insert: param, ca-02_odp.02 }}.'
+  group: ca
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ca-3.1
+  title: Unclassified National Security System Connections
+  objective: Unclassified National Security System Connections
+  group: ca
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ca-3.2
+  title: Classified National Security System Connections
+  objective: Classified National Security System Connections
+  group: ca
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ca-3.3
+  title: Unclassified Non-national Security System Connections
+  objective: Unclassified Non-national Security System Connections
+  group: ca
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ca-3.4
+  title: Connections to Public Networks
+  objective: Connections to Public Networks
+  group: ca
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ca-3.5
+  title: Restrictions on External System Connections
+  objective: Restrictions on External System Connections
+  group: ca
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ca-3.6
+  title: Transfer Authorizations
+  objective: Verify that individuals or systems transferring data between interconnecting systems have the requisite 
+    authorizations (i.e., write permissions or privileges) prior to accepting such data.
+  group: ca
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: ca-3.7
+  title: Transitive Information Exchanges
+  objective: Identify transitive (downstream) information exchanges with other systems through the systems identified in
+    [CA-3a](#ca-3_smt.a) ; and Take measures to ensure that transitive (downstream) information exchanges cease when the
+    controls on identified transitive (downstream) systems cannot be verified or validated.
+  group: ca
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ca-3
+  title: Information Exchange
+  objective: 'Approve and manage the exchange of information between the system and other systems using {{ insert: param,
+    ca-03_odp.01 }}; Document, as part of each exchange agreement, the interface characteristics, security and privacy requirements,
+    controls, and responsibilities for each system, and the impact level of the information communicated; and Review and update
+    the agreements {{ insert: param, ca-03_odp.03 }}.'
+  group: ca
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ca-4
+  title: Security Certification
+  objective: Security Certification
+  group: ca
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ca-5.1
+  title: Automation Support for Accuracy and Currency
+  objective: 'Ensure the accuracy, currency, and availability of the plan of action and milestones for the system using {{
+    insert: param, ca-05.01_odp }}.'
+  group: ca
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ca-5
+  title: Plan of Action and Milestones
+  objective: 'Develop a plan of action and milestones for the system to document the planned remediation actions of the organization
+    to correct weaknesses or deficiencies noted during the assessment of the controls and to reduce or eliminate known vulnerabilities
+    in the system; and Update existing plan of action and milestones {{ insert: param, ca-05_odp }} based on the findings
+    from control assessments, independent audits or reviews, and continuous monitoring activities.'
+  group: ca
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ca-6.1
+  title: Joint Authorization — Intra-organization
+  objective: Employ a joint authorization process for the system that includes multiple authorizing officials from the 
+    same organization conducting the authorization.
+  group: ca
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ca-6.2
+  title: Joint Authorization — Inter-organization
+  objective: Employ a joint authorization process for the system that includes multiple authorizing officials with at 
+    least one authorizing official from an organization external to the organization conducting the authorization.
+  group: ca
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ca-6
+  title: Authorization
+  objective: 'Assign a senior official as the authorizing official for the system; Assign a senior official as the authorizing
+    official for common controls available for inheritance by organizational systems; Ensure that the authorizing official
+    for the system, before commencing operations: Ensure that the authorizing official for common controls authorizes the
+    use of those controls for inheritance by organizational systems; Update the authorizations {{ insert: param, ca-06_odp
+    }}.'
+  group: ca
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ca-7.1
+  title: Independent Assessment
+  objective: Employ independent assessors or assessment teams to monitor the controls in the system on an ongoing basis.
+  group: ca
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ca-7.2
+  title: Types of Assessments
+  objective: Types of Assessments
+  group: ca
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ca-7.3
+  title: Trend Analyses
+  objective: Employ trend analyses to determine if control implementations, the frequency of continuous monitoring 
+    activities, and the types of activities used in the continuous monitoring process need to be modified based on 
+    empirical data.
+  group: ca
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ca-7.4
+  title: Risk Monitoring
+  objective: 'Ensure risk monitoring is an integral part of the continuous monitoring strategy that includes the following:'
+  group: ca
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ca-7.5
+  title: Consistency Analysis
+  objective: 'Employ the following actions to validate that policies are established and implemented controls are operating
+    in a consistent manner: {{ insert: param, ca-7.5_prm_1 }}.'
+  group: ca
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ca-7.6
+  title: Automation Support for Monitoring
+  objective: 'Ensure the accuracy, currency, and availability of monitoring results for the system using {{ insert: param,
+    ca-07.06_odp }}.'
+  group: ca
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ca-7
+  title: Continuous Monitoring
+  objective: 'Develop a system-level continuous monitoring strategy and implement continuous monitoring in accordance with
+    the organization-level continuous monitoring strategy that includes:'
+  group: ca
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ca-8.1
+  title: Independent Penetration Testing Agent or Team
+  objective: Employ an independent penetration testing agent or team to perform penetration testing on the system or 
+    system components.
+  group: ca
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: ca-8.2
+  title: Red Team Exercises
+  objective: 'Employ the following red-team exercises to simulate attempts by adversaries to compromise organizational systems
+    in accordance with applicable rules of engagement: {{ insert: param, ca-08.02_odp }}.'
+  group: ca
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: ca-8.3
+  title: Facility Penetration Testing
+  objective: 'Employ a penetration testing process that includes {{ insert: param, ca-08.03_odp.01 }} {{ insert: param, ca-08.03_odp.02
+    }} attempts to bypass or circumvent controls associated with physical access points to the facility.'
+  group: ca
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: ca-8
+  title: Penetration Testing
+  objective: 'Conduct penetration testing {{ insert: param, ca-08_odp.01 }} on {{ insert: param, ca-08_odp.02 }}.'
+  group: ca
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: ca-9.1
+  title: Compliance Checks
+  objective: Perform security and privacy compliance checks on constituent system components prior to the establishment 
+    of the internal connection.
+  group: ca
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ca-9
+  title: Internal System Connections
+  objective: 'Authorize internal connections of {{ insert: param, ca-09_odp.01 }} to the system; Document, for each internal
+    connection, the interface characteristics, security and privacy requirements, and the nature of the information communicated;
+    Terminate internal system connections after {{ insert: param, ca-09_odp.02 }} ; and Review {{ insert: param, ca-09_odp.03
+    }} the continued need for each internal connection.'
+  group: ca
+  assessment-requirements:
+  - id: firewalld-backend
+    state: Active
+    text: Rule 'firewalld-backend' MUST be verified
+    applicability: &id014
+    - fedora-low
+  - id: firewalld_loopback_traffic_trusted
+    state: Active
+    text: Rule 'firewalld_loopback_traffic_trusted' MUST be verified
+    applicability: *id014
+  - id: package_firewalld_installed
+    state: Active
+    text: Rule 'package_firewalld_installed' MUST be verified
+    applicability: *id014
+  state: Active
+- id: cm-1
+  title: Policy and Procedures
+  objective: 'Develop, document, and disseminate to {{ insert: param, cm-1_prm_1 }}: Designate an {{ insert: param, cm-01_odp.04
+    }} to manage the development, documentation, and dissemination of the configuration management policy and procedures;
+    and Review and update the current configuration management:'
+  group: cm
+  assessment-requirements:
+  - id: account_password_pam_faillock_password_auth
+    state: Active
+    text: Rule 'account_password_pam_faillock_password_auth' MUST be verified
+    applicability: &id015
+    - fedora-low
+  - id: account_password_pam_faillock_system_auth
+    state: Active
+    text: Rule 'account_password_pam_faillock_system_auth' MUST be verified
+    applicability: *id015
+  - id: account_unique_id
+    state: Active
+    text: Rule 'account_unique_id' MUST be verified
+    applicability: *id015
+  - id: account_unique_name
+    state: Active
+    text: Rule 'account_unique_name' MUST be verified
+    applicability: *id015
+  - id: accounts_maximum_age_login_defs
+    state: Active
+    text: Rule 'accounts_maximum_age_login_defs' MUST be verified
+    applicability: *id015
+  - id: accounts_no_uid_except_zero
+    state: Active
+    text: Rule 'accounts_no_uid_except_zero' MUST be verified
+    applicability: *id015
+  - id: accounts_password_set_max_life_existing
+    state: Active
+    text: Rule 'accounts_password_set_max_life_existing' MUST be verified
+    applicability: *id015
+  - id: accounts_root_gid_zero
+    state: Active
+    text: Rule 'accounts_root_gid_zero' MUST be verified
+    applicability: *id015
+  - id: accounts_root_path_dirs_no_write
+    state: Active
+    text: Rule 'accounts_root_path_dirs_no_write' MUST be verified
+    applicability: *id015
+  - id: accounts_user_dot_group_ownership
+    state: Active
+    text: Rule 'accounts_user_dot_group_ownership' MUST be verified
+    applicability: *id015
+  - id: accounts_user_dot_user_ownership
+    state: Active
+    text: Rule 'accounts_user_dot_user_ownership' MUST be verified
+    applicability: *id015
+  - id: configure_custom_crypto_policy_cis
+    state: Active
+    text: Rule 'configure_custom_crypto_policy_cis' MUST be verified
+    applicability: *id015
+  - id: disable_host_auth
+    state: Active
+    text: Rule 'disable_host_auth' MUST be verified
+    applicability: *id015
+  - id: file_permission_user_bash_history
+    state: Active
+    text: Rule 'file_permission_user_bash_history' MUST be verified
+    applicability: *id015
+  - id: file_permission_user_init_files
+    state: Active
+    text: Rule 'file_permission_user_init_files' MUST be verified
+    applicability: *id015
+  - id: gid_passwd_group_same
+    state: Active
+    text: Rule 'gid_passwd_group_same' MUST be verified
+    applicability: *id015
+  - id: group_unique_id
+    state: Active
+    text: Rule 'group_unique_id' MUST be verified
+    applicability: *id015
+  - id: group_unique_name
+    state: Active
+    text: Rule 'group_unique_name' MUST be verified
+    applicability: *id015
+  - id: groups_no_zero_gid_except_root
+    state: Active
+    text: Rule 'groups_no_zero_gid_except_root' MUST be verified
+    applicability: *id015
+  - id: no_forward_files
+    state: Active
+    text: Rule 'no_forward_files' MUST be verified
+    applicability: *id015
+  - id: no_netrc_files
+    state: Active
+    text: Rule 'no_netrc_files' MUST be verified
+    applicability: *id015
+  - id: no_nologin_in_shells
+    state: Active
+    text: Rule 'no_nologin_in_shells' MUST be verified
+    applicability: *id015
+  - id: no_rhost_files
+    state: Active
+    text: Rule 'no_rhost_files' MUST be verified
+    applicability: *id015
+  - id: package_cron_installed
+    state: Active
+    text: Rule 'package_cron_installed' MUST be verified
+    applicability: *id015
+  - id: root_path_no_dot
+    state: Active
+    text: Rule 'root_path_no_dot' MUST be verified
+    applicability: *id015
+  - id: service_crond_enabled
+    state: Active
+    text: Rule 'service_crond_enabled' MUST be verified
+    applicability: *id015
+  - id: sshd_disable_empty_passwords
+    state: Active
+    text: Rule 'sshd_disable_empty_passwords' MUST be verified
+    applicability: *id015
+  - id: sshd_disable_gssapi_auth
+    state: Active
+    text: Rule 'sshd_disable_gssapi_auth' MUST be verified
+    applicability: *id015
+  - id: sshd_disable_rhosts
+    state: Active
+    text: Rule 'sshd_disable_rhosts' MUST be verified
+    applicability: *id015
+  - id: sshd_do_not_permit_user_env
+    state: Active
+    text: Rule 'sshd_do_not_permit_user_env' MUST be verified
+    applicability: *id015
+  - id: sshd_enable_pam
+    state: Active
+    text: Rule 'sshd_enable_pam' MUST be verified
+    applicability: *id015
+  - id: sshd_enable_warning_banner_net
+    state: Active
+    text: Rule 'sshd_enable_warning_banner_net' MUST be verified
+    applicability: *id015
+  - id: sshd_set_idle_timeout
+    state: Active
+    text: Rule 'sshd_set_idle_timeout' MUST be verified
+    applicability: *id015
+  - id: sshd_set_keepalive
+    state: Active
+    text: Rule 'sshd_set_keepalive' MUST be verified
+    applicability: *id015
+  - id: sshd_set_max_sessions
+    state: Active
+    text: Rule 'sshd_set_max_sessions' MUST be verified
+    applicability: *id015
+  - id: sshd_set_maxstartups
+    state: Active
+    text: Rule 'sshd_set_maxstartups' MUST be verified
+    applicability: *id015
+  - id: sysctl_net_ipv4_conf_all_accept_redirects
+    state: Active
+    text: Rule 'sysctl_net_ipv4_conf_all_accept_redirects' MUST be verified
+    applicability: *id015
+  - id: sysctl_net_ipv4_conf_all_accept_source_route
+    state: Active
+    text: Rule 'sysctl_net_ipv4_conf_all_accept_source_route' MUST be verified
+    applicability: *id015
+  - id: sysctl_net_ipv4_conf_all_rp_filter
+    state: Active
+    text: Rule 'sysctl_net_ipv4_conf_all_rp_filter' MUST be verified
+    applicability: *id015
+  - id: sysctl_net_ipv4_conf_all_secure_redirects
+    state: Active
+    text: Rule 'sysctl_net_ipv4_conf_all_secure_redirects' MUST be verified
+    applicability: *id015
+  - id: sysctl_net_ipv4_conf_all_send_redirects
+    state: Active
+    text: Rule 'sysctl_net_ipv4_conf_all_send_redirects' MUST be verified
+    applicability: *id015
+  - id: sysctl_net_ipv4_conf_default_accept_redirects
+    state: Active
+    text: Rule 'sysctl_net_ipv4_conf_default_accept_redirects' MUST be verified
+    applicability: *id015
+  - id: sysctl_net_ipv4_conf_default_accept_source_route
+    state: Active
+    text: Rule 'sysctl_net_ipv4_conf_default_accept_source_route' MUST be verified
+    applicability: *id015
+  - id: sysctl_net_ipv4_conf_default_rp_filter
+    state: Active
+    text: Rule 'sysctl_net_ipv4_conf_default_rp_filter' MUST be verified
+    applicability: *id015
+  - id: sysctl_net_ipv4_conf_default_secure_redirects
+    state: Active
+    text: Rule 'sysctl_net_ipv4_conf_default_secure_redirects' MUST be verified
+    applicability: *id015
+  - id: sysctl_net_ipv4_conf_default_send_redirects
+    state: Active
+    text: Rule 'sysctl_net_ipv4_conf_default_send_redirects' MUST be verified
+    applicability: *id015
+  - id: sysctl_net_ipv4_icmp_echo_ignore_broadcasts
+    state: Active
+    text: Rule 'sysctl_net_ipv4_icmp_echo_ignore_broadcasts' MUST be verified
+    applicability: *id015
+  - id: sysctl_net_ipv4_icmp_ignore_bogus_error_responses
+    state: Active
+    text: Rule 'sysctl_net_ipv4_icmp_ignore_bogus_error_responses' MUST be verified
+    applicability: *id015
+  - id: sysctl_net_ipv4_ip_forward
+    state: Active
+    text: Rule 'sysctl_net_ipv4_ip_forward' MUST be verified
+    applicability: *id015
+  - id: sysctl_net_ipv4_tcp_syncookies
+    state: Active
+    text: Rule 'sysctl_net_ipv4_tcp_syncookies' MUST be verified
+    applicability: *id015
+  - id: sysctl_net_ipv6_conf_all_accept_ra
+    state: Active
+    text: Rule 'sysctl_net_ipv6_conf_all_accept_ra' MUST be verified
+    applicability: *id015
+  - id: sysctl_net_ipv6_conf_all_accept_redirects
+    state: Active
+    text: Rule 'sysctl_net_ipv6_conf_all_accept_redirects' MUST be verified
+    applicability: *id015
+  - id: sysctl_net_ipv6_conf_all_accept_source_route
+    state: Active
+    text: Rule 'sysctl_net_ipv6_conf_all_accept_source_route' MUST be verified
+    applicability: *id015
+  - id: sysctl_net_ipv6_conf_all_forwarding
+    state: Active
+    text: Rule 'sysctl_net_ipv6_conf_all_forwarding' MUST be verified
+    applicability: *id015
+  - id: sysctl_net_ipv6_conf_default_accept_ra
+    state: Active
+    text: Rule 'sysctl_net_ipv6_conf_default_accept_ra' MUST be verified
+    applicability: *id015
+  - id: sysctl_net_ipv6_conf_default_accept_redirects
+    state: Active
+    text: Rule 'sysctl_net_ipv6_conf_default_accept_redirects' MUST be verified
+    applicability: *id015
+  - id: sysctl_net_ipv6_conf_default_accept_source_route
+    state: Active
+    text: Rule 'sysctl_net_ipv6_conf_default_accept_source_route' MUST be verified
+    applicability: *id015
+  - id: sshd_idle_timeout_value
+    state: Active
+    text: Variable 'sshd_idle_timeout_value' is set to '5_minutes'
+    applicability: *id015
+  - id: sysctl_net_ipv4_tcp_syncookies_value
+    state: Active
+    text: Variable 'sysctl_net_ipv4_tcp_syncookies_value' is set to 'enabled'
+    applicability: *id015
+  - id: var_accounts_maximum_age_login_defs
+    state: Active
+    text: Variable 'var_accounts_maximum_age_login_defs' is set to '365'
+    applicability: *id015
+  - id: var_sshd_max_sessions
+    state: Active
+    text: Variable 'var_sshd_max_sessions' is set to '10'
+    applicability: *id015
+  - id: var_sshd_set_keepalive
+    state: Active
+    text: Variable 'var_sshd_set_keepalive' is set to '1'
+    applicability: *id015
+  - id: var_sshd_set_maxstartups
+    state: Active
+    text: Variable 'var_sshd_set_maxstartups' is set to '10:30:60'
+    applicability: *id015
+  - id: var_user_initialization_files_regex
+    state: Active
+    text: Variable 'var_user_initialization_files_regex' is set to 'all_dotfiles'
+    applicability: *id015
+  state: Active
+- id: cm-2.1
+  title: Reviews and Updates
+  objective: Reviews and Updates
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cm-2.2
+  title: Automation Support for Accuracy and Currency
+  objective: 'Maintain the currency, completeness, accuracy, and availability of the baseline configuration of the system
+    using {{ insert: param, cm-02.02_odp }}.'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cm-2.3
+  title: Retention of Previous Configurations
+  objective: 'Retain {{ insert: param, cm-02.03_odp }} of previous versions of baseline configurations of the system to support
+    rollback.'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cm-2.4
+  title: Unauthorized Software
+  objective: Unauthorized Software
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cm-2.5
+  title: Authorized Software
+  objective: Authorized Software
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cm-2.6
+  title: Development and Test Environments
+  objective: Maintain a baseline configuration for system development and test environments that is managed separately 
+    from the operational baseline configuration.
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cm-2.7
+  title: Configure Systems and Components for High-risk Areas
+  objective: 'Issue {{ insert: param, cm-02.07_odp.01 }} with {{ insert: param, cm-02.07_odp.02 }} to individuals traveling
+    to locations that the organization deems to be of significant risk; and Apply the following controls to the systems or
+    components when the individuals return from travel: {{ insert: param, cm-02.07_odp.03 }}.'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cm-2
+  title: Baseline Configuration
+  objective: 'Develop, document, and maintain under configuration control, a current baseline configuration of the system;
+    and Review and update the baseline configuration of the system:'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cm-3.1
+  title: Automated Documentation, Notification, and Prohibition of Changes
+  objective: 'Use {{ insert: param, cm-03.01_odp.01 }} to:'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: cm-3.2
+  title: Testing, Validation, and Documentation of Changes
+  objective: Test, validate, and document changes to the system before finalizing the implementation of the changes.
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cm-3.3
+  title: Automated Change Implementation
+  objective: 'Implement changes to the current system baseline and deploy the updated baseline across the installed base using
+    {{ insert: param, cm-03.03_odp }}.'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cm-3.4
+  title: Security and Privacy Representatives
+  objective: 'Require {{ insert: param, cm-3.4_prm_1 }} to be members of the {{ insert: param, cm-03.04_odp.03 }}.'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cm-3.5
+  title: Automated Security Response
+  objective: 'Implement the following security responses automatically if baseline configurations are changed in an unauthorized
+    manner: {{ insert: param, cm-03.05_odp }}.'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cm-3.6
+  title: Cryptography Management
+  objective: 'Ensure that cryptographic mechanisms used to provide the following controls are under configuration management:
+    {{ insert: param, cm-03.06_odp }}.'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: cm-3.7
+  title: Review System Changes
+  objective: 'Review changes to the system {{ insert: param, cm-03.07_odp.01 }} or when {{ insert: param, cm-03.07_odp.02
+    }} to determine whether unauthorized changes have occurred.'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cm-3.8
+  title: Prevent or Restrict Configuration Changes
+  objective: 'Prevent or restrict changes to the configuration of the system under the following circumstances: {{ insert:
+    param, cm-03.08_odp }}.'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cm-3
+  title: Configuration Change Control
+  objective: 'Determine and document the types of changes to the system that are configuration-controlled; Review proposed
+    configuration-controlled changes to the system and approve or disapprove such changes with explicit consideration for
+    security and privacy impact analyses; Document configuration change decisions associated with the system; Implement approved
+    configuration-controlled changes to the system; Retain records of configuration-controlled changes to the system for {{
+    insert: param, cm-03_odp.01 }}; Monitor and review activities associated with configuration-controlled changes to the
+    system; and Coordinate and provide oversight for configuration change control activities through {{ insert: param, cm-03_odp.02
+    }} that convenes {{ insert: param, cm-03_odp.03 }}.'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cm-4.1
+  title: Separate Test Environments
+  objective: Analyze changes to the system in a separate test environment before implementation in an operational 
+    environment, looking for security and privacy impacts due to flaws, weaknesses, incompatibility, or intentional 
+    malice.
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: cm-4.2
+  title: Verification of Controls
+  objective: After system changes, verify that the impacted controls are implemented correctly, operating as intended, 
+    and producing the desired outcome with regard to meeting the security and privacy requirements for the system.
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cm-4
+  title: Impact Analyses
+  objective: Analyze changes to the system to determine potential security and privacy impacts prior to change 
+    implementation.
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cm-5.1
+  title: Automated Access Enforcement and Audit Records
+  objective: 'Enforce access restrictions using {{ insert: param, cm-05.01_odp }} ; and Automatically generate audit records
+    of the enforcement actions.'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: cm-5.2
+  title: Review System Changes
+  objective: Review System Changes
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cm-5.3
+  title: Signed Components
+  objective: Signed Components
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cm-5.4
+  title: Dual Authorization
+  objective: 'Enforce dual authorization for implementing changes to {{ insert: param, cm-5.4_prm_1 }}.'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cm-5.5
+  title: Privilege Limitation for Production and Operation
+  objective: 'Limit privileges to change system components and system-related information within a production or operational
+    environment; and Review and reevaluate privileges {{ insert: param, cm-5.5_prm_1 }}.'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cm-5.6
+  title: Limit Library Privileges
+  objective: Limit privileges to change software resident within software libraries.
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cm-5.7
+  title: Automatic Implementation of Security Safeguards
+  objective: Automatic Implementation of Security Safeguards
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cm-5
+  title: Access Restrictions for Change
+  objective: Define, document, approve, and enforce physical and logical access restrictions associated with changes to 
+    the system.
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cm-6.1
+  title: Automated Management, Application, and Verification
+  objective: 'Manage, apply, and verify configuration settings for {{ insert: param, cm-06.01_odp.01 }} using {{ insert: param,
+    cm-6.1_prm_2 }}.'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: cm-6.2
+  title: Respond to Unauthorized Changes
+  objective: 'Take the following actions in response to unauthorized changes to {{ insert: param, cm-06.02_odp.02 }}: {{ insert:
+    param, cm-06.02_odp.01 }}.'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: cm-6.3
+  title: Unauthorized Change Detection
+  objective: Unauthorized Change Detection
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cm-6.4
+  title: Conformance Demonstration
+  objective: Conformance Demonstration
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cm-6
+  title: Configuration Settings
+  objective: 'Establish and document configuration settings for components employed within the system that reflect the most
+    restrictive mode consistent with operational requirements using {{ insert: param, cm-06_odp.01 }}; Implement the configuration
+    settings; Identify, document, and approve any deviations from established configuration settings for {{ insert: param,
+    cm-06_odp.02 }} based on {{ insert: param, cm-06_odp.03 }} ; and Monitor and control changes to the configuration settings
+    in accordance with organizational policies and procedures.'
+  group: cm
+  assessment-requirements:
+  - id: accounts_password_pam_pwquality_password_auth
+    state: Active
+    text: Rule 'accounts_password_pam_pwquality_password_auth' MUST be verified
+    applicability: &id016
+    - fedora-low
+  - id: accounts_password_pam_pwquality_system_auth
+    state: Active
+    text: Rule 'accounts_password_pam_pwquality_system_auth' MUST be verified
+    applicability: *id016
+  - id: accounts_umask_etc_bashrc
+    state: Active
+    text: Rule 'accounts_umask_etc_bashrc' MUST be verified
+    applicability: *id016
+  - id: accounts_umask_etc_login_defs
+    state: Active
+    text: Rule 'accounts_umask_etc_login_defs' MUST be verified
+    applicability: *id016
+  - id: accounts_umask_etc_profile
+    state: Active
+    text: Rule 'accounts_umask_etc_profile' MUST be verified
+    applicability: *id016
+  - id: accounts_user_interactive_home_directory_exists
+    state: Active
+    text: Rule 'accounts_user_interactive_home_directory_exists' MUST be verified
+    applicability: *id016
+  - id: audit_rules_media_export
+    state: Active
+    text: Rule 'audit_rules_media_export' MUST be verified
+    applicability: *id016
+  - id: banner_etc_issue_cis
+    state: Active
+    text: Rule 'banner_etc_issue_cis' MUST be verified
+    applicability: *id016
+  - id: banner_etc_issue_net_cis
+    state: Active
+    text: Rule 'banner_etc_issue_net_cis' MUST be verified
+    applicability: *id016
+  - id: banner_etc_motd_cis
+    state: Active
+    text: Rule 'banner_etc_motd_cis' MUST be verified
+    applicability: *id016
+  - id: coredump_disable_backtraces
+    state: Active
+    text: Rule 'coredump_disable_backtraces' MUST be verified
+    applicability: *id016
+  - id: coredump_disable_storage
+    state: Active
+    text: Rule 'coredump_disable_storage' MUST be verified
+    applicability: *id016
+  - id: dconf_db_up_to_date
+    state: Active
+    text: Rule 'dconf_db_up_to_date' MUST be verified
+    applicability: *id016
+  - id: dconf_gnome_disable_user_list
+    state: Active
+    text: Rule 'dconf_gnome_disable_user_list' MUST be verified
+    applicability: *id016
+  - id: disable_host_auth
+    state: Active
+    text: Rule 'disable_host_auth' MUST be verified
+    applicability: *id016
+  - id: disable_users_coredumps
+    state: Active
+    text: Rule 'disable_users_coredumps' MUST be verified
+    applicability: *id016
+  - id: file_groupowner_boot_grub2
+    state: Active
+    text: Rule 'file_groupowner_boot_grub2' MUST be verified
+    applicability: *id016
+  - id: file_groupownership_sshd_private_key
+    state: Active
+    text: Rule 'file_groupownership_sshd_private_key' MUST be verified
+    applicability: *id016
+  - id: file_groupownership_sshd_pub_key
+    state: Active
+    text: Rule 'file_groupownership_sshd_pub_key' MUST be verified
+    applicability: *id016
+  - id: file_owner_boot_grub2
+    state: Active
+    text: Rule 'file_owner_boot_grub2' MUST be verified
+    applicability: *id016
+  - id: file_ownership_home_directories
+    state: Active
+    text: Rule 'file_ownership_home_directories' MUST be verified
+    applicability: *id016
+  - id: file_ownership_sshd_private_key
+    state: Active
+    text: Rule 'file_ownership_sshd_private_key' MUST be verified
+    applicability: *id016
+  - id: file_ownership_sshd_pub_key
+    state: Active
+    text: Rule 'file_ownership_sshd_pub_key' MUST be verified
+    applicability: *id016
+  - id: file_permissions_boot_grub2
+    state: Active
+    text: Rule 'file_permissions_boot_grub2' MUST be verified
+    applicability: *id016
+  - id: file_permissions_home_directories
+    state: Active
+    text: Rule 'file_permissions_home_directories' MUST be verified
+    applicability: *id016
+  - id: file_permissions_sshd_private_key
+    state: Active
+    text: Rule 'file_permissions_sshd_private_key' MUST be verified
+    applicability: *id016
+  - id: file_permissions_sshd_pub_key
+    state: Active
+    text: Rule 'file_permissions_sshd_pub_key' MUST be verified
+    applicability: *id016
+  - id: no_empty_passwords
+    state: Active
+    text: Rule 'no_empty_passwords' MUST be verified
+    applicability: *id016
+  - id: no_empty_passwords_etc_shadow
+    state: Active
+    text: Rule 'no_empty_passwords_etc_shadow' MUST be verified
+    applicability: *id016
+  - id: no_files_or_dirs_ungroupowned
+    state: Active
+    text: Rule 'no_files_or_dirs_ungroupowned' MUST be verified
+    applicability: *id016
+  - id: no_files_or_dirs_unowned_by_user
+    state: Active
+    text: Rule 'no_files_or_dirs_unowned_by_user' MUST be verified
+    applicability: *id016
+  - id: package_pam_pwquality_installed
+    state: Active
+    text: Rule 'package_pam_pwquality_installed' MUST be verified
+    applicability: *id016
+  - id: package_rsync_removed
+    state: Active
+    text: Rule 'package_rsync_removed' MUST be verified
+    applicability: *id016
+  - id: package_samba_removed
+    state: Active
+    text: Rule 'package_samba_removed' MUST be verified
+    applicability: *id016
+  - id: package_squid_removed
+    state: Active
+    text: Rule 'package_squid_removed' MUST be verified
+    applicability: *id016
+  - id: partition_for_tmp
+    state: Active
+    text: Rule 'partition_for_tmp' MUST be verified
+    applicability: *id016
+  - id: partition_for_var_log
+    state: Active
+    text: Rule 'partition_for_var_log' MUST be verified
+    applicability: *id016
+  - id: service_nfs_disabled
+    state: Active
+    text: Rule 'service_nfs_disabled' MUST be verified
+    applicability: *id016
+  - id: service_rpcbind_disabled
+    state: Active
+    text: Rule 'service_rpcbind_disabled' MUST be verified
+    applicability: *id016
+  - id: sshd_disable_gssapi_auth
+    state: Active
+    text: Rule 'sshd_disable_gssapi_auth' MUST be verified
+    applicability: *id016
+  - id: sshd_set_login_grace_time
+    state: Active
+    text: Rule 'sshd_set_login_grace_time' MUST be verified
+    applicability: *id016
+  - id: sysctl_fs_suid_dumpable
+    state: Active
+    text: Rule 'sysctl_fs_suid_dumpable' MUST be verified
+    applicability: *id016
+  - id: sysctl_kernel_kptr_restrict
+    state: Active
+    text: Rule 'sysctl_kernel_kptr_restrict' MUST be verified
+    applicability: *id016
+  - id: sysctl_kernel_randomize_va_space
+    state: Active
+    text: Rule 'sysctl_kernel_randomize_va_space' MUST be verified
+    applicability: *id016
+  - id: sysctl_kernel_yama_ptrace_scope
+    state: Active
+    text: Rule 'sysctl_kernel_yama_ptrace_scope' MUST be verified
+    applicability: *id016
+  - id: sysctl_net_ipv4_conf_all_accept_redirects
+    state: Active
+    text: Rule 'sysctl_net_ipv4_conf_all_accept_redirects' MUST be verified
+    applicability: *id016
+  - id: sysctl_net_ipv4_conf_all_accept_source_route
+    state: Active
+    text: Rule 'sysctl_net_ipv4_conf_all_accept_source_route' MUST be verified
+    applicability: *id016
+  - id: sysctl_net_ipv4_conf_all_forwarding
+    state: Active
+    text: Rule 'sysctl_net_ipv4_conf_all_forwarding' MUST be verified
+    applicability: *id016
+  - id: sysctl_net_ipv4_conf_all_log_martians
+    state: Active
+    text: Rule 'sysctl_net_ipv4_conf_all_log_martians' MUST be verified
+    applicability: *id016
+  - id: sysctl_net_ipv4_conf_all_rp_filter
+    state: Active
+    text: Rule 'sysctl_net_ipv4_conf_all_rp_filter' MUST be verified
+    applicability: *id016
+  - id: sysctl_net_ipv4_conf_all_secure_redirects
+    state: Active
+    text: Rule 'sysctl_net_ipv4_conf_all_secure_redirects' MUST be verified
+    applicability: *id016
+  - id: sysctl_net_ipv4_conf_all_send_redirects
+    state: Active
+    text: Rule 'sysctl_net_ipv4_conf_all_send_redirects' MUST be verified
+    applicability: *id016
+  - id: sysctl_net_ipv4_conf_default_accept_redirects
+    state: Active
+    text: Rule 'sysctl_net_ipv4_conf_default_accept_redirects' MUST be verified
+    applicability: *id016
+  - id: sysctl_net_ipv4_conf_default_accept_source_route
+    state: Active
+    text: Rule 'sysctl_net_ipv4_conf_default_accept_source_route' MUST be verified
+    applicability: *id016
+  - id: sysctl_net_ipv4_conf_default_forwarding
+    state: Active
+    text: Rule 'sysctl_net_ipv4_conf_default_forwarding' MUST be verified
+    applicability: *id016
+  - id: sysctl_net_ipv4_conf_default_log_martians
+    state: Active
+    text: Rule 'sysctl_net_ipv4_conf_default_log_martians' MUST be verified
+    applicability: *id016
+  - id: sysctl_net_ipv4_conf_default_rp_filter
+    state: Active
+    text: Rule 'sysctl_net_ipv4_conf_default_rp_filter' MUST be verified
+    applicability: *id016
+  - id: sysctl_net_ipv4_conf_default_secure_redirects
+    state: Active
+    text: Rule 'sysctl_net_ipv4_conf_default_secure_redirects' MUST be verified
+    applicability: *id016
+  - id: sysctl_net_ipv4_conf_default_send_redirects
+    state: Active
+    text: Rule 'sysctl_net_ipv4_conf_default_send_redirects' MUST be verified
+    applicability: *id016
+  - id: sysctl_net_ipv4_icmp_echo_ignore_broadcasts
+    state: Active
+    text: Rule 'sysctl_net_ipv4_icmp_echo_ignore_broadcasts' MUST be verified
+    applicability: *id016
+  - id: sysctl_net_ipv4_icmp_ignore_bogus_error_responses
+    state: Active
+    text: Rule 'sysctl_net_ipv4_icmp_ignore_bogus_error_responses' MUST be verified
+    applicability: *id016
+  - id: sysctl_net_ipv4_ip_forward
+    state: Active
+    text: Rule 'sysctl_net_ipv4_ip_forward' MUST be verified
+    applicability: *id016
+  - id: sysctl_net_ipv6_conf_all_accept_ra
+    state: Active
+    text: Rule 'sysctl_net_ipv6_conf_all_accept_ra' MUST be verified
+    applicability: *id016
+  - id: sysctl_net_ipv6_conf_all_accept_redirects
+    state: Active
+    text: Rule 'sysctl_net_ipv6_conf_all_accept_redirects' MUST be verified
+    applicability: *id016
+  - id: sysctl_net_ipv6_conf_all_accept_source_route
+    state: Active
+    text: Rule 'sysctl_net_ipv6_conf_all_accept_source_route' MUST be verified
+    applicability: *id016
+  - id: sysctl_net_ipv6_conf_all_forwarding
+    state: Active
+    text: Rule 'sysctl_net_ipv6_conf_all_forwarding' MUST be verified
+    applicability: *id016
+  - id: sysctl_net_ipv6_conf_default_accept_ra
+    state: Active
+    text: Rule 'sysctl_net_ipv6_conf_default_accept_ra' MUST be verified
+    applicability: *id016
+  - id: sysctl_net_ipv6_conf_default_accept_redirects
+    state: Active
+    text: Rule 'sysctl_net_ipv6_conf_default_accept_redirects' MUST be verified
+    applicability: *id016
+  - id: sysctl_net_ipv6_conf_default_accept_source_route
+    state: Active
+    text: Rule 'sysctl_net_ipv6_conf_default_accept_source_route' MUST be verified
+    applicability: *id016
+  - id: sysctl_net_ipv6_conf_default_forwarding
+    state: Active
+    text: Rule 'sysctl_net_ipv6_conf_default_forwarding' MUST be verified
+    applicability: *id016
+  - id: cis_banner_text
+    state: Active
+    text: Variable 'cis_banner_text' is set to 'cis'
+    applicability: *id016
+  - id: dconf_login_banner_contents
+    state: Active
+    text: Variable 'dconf_login_banner_contents' is set to 'cis_default'
+    applicability: *id016
+  - id: dconf_login_banner_text
+    state: Active
+    text: Variable 'dconf_login_banner_text' is set to 'cis_banners'
+    applicability: *id016
+  - id: sysctl_net_ipv4_conf_all_accept_redirects_value
+    state: Active
+    text: Variable 'sysctl_net_ipv4_conf_all_accept_redirects_value' is set to 'disabled'
+    applicability: *id016
+  - id: sysctl_net_ipv4_conf_all_accept_source_route_value
+    state: Active
+    text: Variable 'sysctl_net_ipv4_conf_all_accept_source_route_value' is set to 'disabled'
+    applicability: *id016
+  - id: sysctl_net_ipv4_conf_all_log_martians_value
+    state: Active
+    text: Variable 'sysctl_net_ipv4_conf_all_log_martians_value' is set to 'enabled'
+    applicability: *id016
+  - id: sysctl_net_ipv4_conf_all_rp_filter_value
+    state: Active
+    text: Variable 'sysctl_net_ipv4_conf_all_rp_filter_value' is set to 'enabled'
+    applicability: *id016
+  - id: sysctl_net_ipv4_conf_all_secure_redirects_value
+    state: Active
+    text: Variable 'sysctl_net_ipv4_conf_all_secure_redirects_value' is set to 'disabled'
+    applicability: *id016
+  - id: sysctl_net_ipv4_conf_default_accept_redirects_value
+    state: Active
+    text: Variable 'sysctl_net_ipv4_conf_default_accept_redirects_value' is set to 'disabled'
+    applicability: *id016
+  - id: sysctl_net_ipv4_conf_default_accept_source_route_value
+    state: Active
+    text: Variable 'sysctl_net_ipv4_conf_default_accept_source_route_value' is set to 'disabled'
+    applicability: *id016
+  - id: sysctl_net_ipv4_conf_default_forwarding_value
+    state: Active
+    text: Variable 'sysctl_net_ipv4_conf_default_forwarding_value' is set to 'disabled'
+    applicability: *id016
+  - id: sysctl_net_ipv4_conf_default_log_martians_value
+    state: Active
+    text: Variable 'sysctl_net_ipv4_conf_default_log_martians_value' is set to 'enabled'
+    applicability: *id016
+  - id: sysctl_net_ipv4_conf_default_rp_filter_value
+    state: Active
+    text: Variable 'sysctl_net_ipv4_conf_default_rp_filter_value' is set to 'enabled'
+    applicability: *id016
+  - id: sysctl_net_ipv4_conf_default_secure_redirects_value
+    state: Active
+    text: Variable 'sysctl_net_ipv4_conf_default_secure_redirects_value' is set to 'disabled'
+    applicability: *id016
+  - id: sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value
+    state: Active
+    text: Variable 'sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value' is set to 'enabled'
+    applicability: *id016
+  - id: sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value
+    state: Active
+    text: Variable 'sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value' is set to 'enabled'
+    applicability: *id016
+  - id: sysctl_net_ipv6_conf_all_accept_ra_value
+    state: Active
+    text: Variable 'sysctl_net_ipv6_conf_all_accept_ra_value' is set to 'disabled'
+    applicability: *id016
+  - id: sysctl_net_ipv6_conf_all_accept_redirects_value
+    state: Active
+    text: Variable 'sysctl_net_ipv6_conf_all_accept_redirects_value' is set to 'disabled'
+    applicability: *id016
+  - id: sysctl_net_ipv6_conf_all_accept_source_route_value
+    state: Active
+    text: Variable 'sysctl_net_ipv6_conf_all_accept_source_route_value' is set to 'disabled'
+    applicability: *id016
+  - id: sysctl_net_ipv6_conf_all_forwarding_value
+    state: Active
+    text: Variable 'sysctl_net_ipv6_conf_all_forwarding_value' is set to 'disabled'
+    applicability: *id016
+  - id: sysctl_net_ipv6_conf_default_accept_ra_value
+    state: Active
+    text: Variable 'sysctl_net_ipv6_conf_default_accept_ra_value' is set to 'disabled'
+    applicability: *id016
+  - id: sysctl_net_ipv6_conf_default_accept_redirects_value
+    state: Active
+    text: Variable 'sysctl_net_ipv6_conf_default_accept_redirects_value' is set to 'disabled'
+    applicability: *id016
+  - id: sysctl_net_ipv6_conf_default_accept_source_route_value
+    state: Active
+    text: Variable 'sysctl_net_ipv6_conf_default_accept_source_route_value' is set to 'disabled'
+    applicability: *id016
+  - id: sysctl_net_ipv6_conf_default_forwarding_value
+    state: Active
+    text: Variable 'sysctl_net_ipv6_conf_default_forwarding_value' is set to 'disabled'
+    applicability: *id016
+  - id: var_accounts_user_umask
+    state: Active
+    text: Variable 'var_accounts_user_umask' is set to '027'
+    applicability: *id016
+  - id: var_sshd_set_login_grace_time
+    state: Active
+    text: Variable 'var_sshd_set_login_grace_time' is set to '60'
+    applicability: *id016
+  state: Active
+- id: cm-7.1
+  title: Periodic Review
+  objective: 'Review the system {{ insert: param, cm-07.01_odp.01 }} to identify unnecessary and/or nonsecure functions, ports,
+    protocols, software, and services; and Disable or remove {{ insert: param, cm-7.1_prm_2 }}.'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cm-7.2
+  title: Prevent Program Execution
+  objective: 'Prevent program execution in accordance with {{ insert: param, cm-07.02_odp.01 }}.'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cm-7.3
+  title: Registration Compliance
+  objective: 'Ensure compliance with {{ insert: param, cm-07.03_odp }}.'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cm-7.4
+  title: Unauthorized Software — Deny-by-exception
+  objective: 'Identify {{ insert: param, cm-07.04_odp.01 }}; Employ an allow-all, deny-by-exception policy to prohibit the
+    execution of unauthorized software programs on the system; and Review and update the list of unauthorized software programs
+    {{ insert: param, cm-07.04_odp.02 }}.'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cm-7.5
+  title: Authorized Software — Allow-by-exception
+  objective: 'Identify {{ insert: param, cm-07.05_odp.01 }}; Employ a deny-all, permit-by-exception policy to allow the execution
+    of authorized software programs on the system; and Review and update the list of authorized software programs {{ insert:
+    param, cm-07.05_odp.02 }}.'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cm-7.6
+  title: Confined Environments with Limited Privileges
+  objective: 'Require that the following user-installed software execute in a confined physical or virtual machine environment
+    with limited privileges: {{ insert: param, cm-07.06_odp }}.'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cm-7.7
+  title: Code Execution in Protected Environments
+  objective: 'Allow execution of binary or machine-executable code only in confined physical or virtual machine environments
+    and with the explicit approval of {{ insert: param, cm-07.07_odp }} when such code is:'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cm-7.8
+  title: Binary or Machine Executable Code
+  objective: Prohibit the use of binary or machine-executable code from sources with limited or no warranty or without 
+    the provision of source code; and Allow exceptions only for compelling mission or operational requirements and with 
+    the approval of the authorizing official.
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cm-7.9
+  title: Prohibiting The Use of Unauthorized Hardware
+  objective: 'Identify {{ insert: param, cm-07.09_odp.01 }}; Prohibit the use or connection of unauthorized hardware components;
+    Review and update the list of authorized hardware components {{ insert: param, cm-07.09_odp.02 }}.'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cm-7
+  title: Least Functionality
+  objective: 'Configure the system to provide only {{ insert: param, cm-07_odp.01 }} ; and Prohibit or restrict the use of
+    the following functions, ports, protocols, software, and/or services: {{ insert: param, cm-7_prm_2 }}.'
+  group: cm
+  assessment-requirements:
+  - id: dconf_gnome_disable_autorun
+    state: Active
+    text: Rule 'dconf_gnome_disable_autorun' MUST be verified
+    applicability: &id017
+    - fedora-low
+  - id: disable_weak_deps
+    state: Active
+    text: Rule 'disable_weak_deps' MUST be verified
+    applicability: *id017
+  - id: file_ownership_var_log_audit_stig
+    state: Active
+    text: Rule 'file_ownership_var_log_audit_stig' MUST be verified
+    applicability: *id017
+  - id: has_nonlocal_mta
+    state: Active
+    text: Rule 'has_nonlocal_mta' MUST be verified
+    applicability: *id017
+  - id: kernel_module_atm_disabled
+    state: Active
+    text: Rule 'kernel_module_atm_disabled' MUST be verified
+    applicability: *id017
+  - id: kernel_module_can_disabled
+    state: Active
+    text: Rule 'kernel_module_can_disabled' MUST be verified
+    applicability: *id017
+  - id: kernel_module_cramfs_disabled
+    state: Active
+    text: Rule 'kernel_module_cramfs_disabled' MUST be verified
+    applicability: *id017
+  - id: kernel_module_dccp_disabled
+    state: Active
+    text: Rule 'kernel_module_dccp_disabled' MUST be verified
+    applicability: *id017
+  - id: kernel_module_firewire-core_disabled
+    state: Active
+    text: Rule 'kernel_module_firewire-core_disabled' MUST be verified
+    applicability: *id017
+  - id: kernel_module_freevxfs_disabled
+    state: Active
+    text: Rule 'kernel_module_freevxfs_disabled' MUST be verified
+    applicability: *id017
+  - id: kernel_module_hfs_disabled
+    state: Active
+    text: Rule 'kernel_module_hfs_disabled' MUST be verified
+    applicability: *id017
+  - id: kernel_module_hfsplus_disabled
+    state: Active
+    text: Rule 'kernel_module_hfsplus_disabled' MUST be verified
+    applicability: *id017
+  - id: kernel_module_jffs2_disabled
+    state: Active
+    text: Rule 'kernel_module_jffs2_disabled' MUST be verified
+    applicability: *id017
+  - id: kernel_module_overlayfs_disabled
+    state: Active
+    text: Rule 'kernel_module_overlayfs_disabled' MUST be verified
+    applicability: *id017
+  - id: kernel_module_rds_disabled
+    state: Active
+    text: Rule 'kernel_module_rds_disabled' MUST be verified
+    applicability: *id017
+  - id: kernel_module_sctp_disabled
+    state: Active
+    text: Rule 'kernel_module_sctp_disabled' MUST be verified
+    applicability: *id017
+  - id: kernel_module_squashfs_disabled
+    state: Active
+    text: Rule 'kernel_module_squashfs_disabled' MUST be verified
+    applicability: *id017
+  - id: kernel_module_tipc_disabled
+    state: Active
+    text: Rule 'kernel_module_tipc_disabled' MUST be verified
+    applicability: *id017
+  - id: kernel_module_udf_disabled
+    state: Active
+    text: Rule 'kernel_module_udf_disabled' MUST be verified
+    applicability: *id017
+  - id: mount_option_dev_shm_nodev
+    state: Active
+    text: Rule 'mount_option_dev_shm_nodev' MUST be verified
+    applicability: *id017
+  - id: mount_option_dev_shm_noexec
+    state: Active
+    text: Rule 'mount_option_dev_shm_noexec' MUST be verified
+    applicability: *id017
+  - id: mount_option_dev_shm_nosuid
+    state: Active
+    text: Rule 'mount_option_dev_shm_nosuid' MUST be verified
+    applicability: *id017
+  - id: mount_option_tmp_nodev
+    state: Active
+    text: Rule 'mount_option_tmp_nodev' MUST be verified
+    applicability: *id017
+  - id: mount_option_tmp_noexec
+    state: Active
+    text: Rule 'mount_option_tmp_noexec' MUST be verified
+    applicability: *id017
+  - id: mount_option_tmp_nosuid
+    state: Active
+    text: Rule 'mount_option_tmp_nosuid' MUST be verified
+    applicability: *id017
+  - id: package_bind_removed
+    state: Active
+    text: Rule 'package_bind_removed' MUST be verified
+    applicability: *id017
+  - id: package_cyrus-imapd_removed
+    state: Active
+    text: Rule 'package_cyrus-imapd_removed' MUST be verified
+    applicability: *id017
+  - id: package_dovecot_removed
+    state: Active
+    text: Rule 'package_dovecot_removed' MUST be verified
+    applicability: *id017
+  - id: package_ftp_removed
+    state: Active
+    text: Rule 'package_ftp_removed' MUST be verified
+    applicability: *id017
+  - id: package_gdm_removed
+    state: Active
+    text: Rule 'package_gdm_removed' MUST be verified
+    applicability: *id017
+  - id: package_httpd_removed
+    state: Active
+    text: Rule 'package_httpd_removed' MUST be verified
+    applicability: *id017
+  - id: package_kea_removed
+    state: Active
+    text: Rule 'package_kea_removed' MUST be verified
+    applicability: *id017
+  - id: package_net-snmp_removed
+    state: Active
+    text: Rule 'package_net-snmp_removed' MUST be verified
+    applicability: *id017
+  - id: package_nginx_removed
+    state: Active
+    text: Rule 'package_nginx_removed' MUST be verified
+    applicability: *id017
+  - id: package_openldap-clients_removed
+    state: Active
+    text: Rule 'package_openldap-clients_removed' MUST be verified
+    applicability: *id017
+  - id: package_postfix_installed
+    state: Active
+    text: Rule 'package_postfix_installed' MUST be verified
+    applicability: *id017
+  - id: package_sequoia-sq_installed
+    state: Active
+    text: Rule 'package_sequoia-sq_installed' MUST be verified
+    applicability: *id017
+  - id: package_telnet-server_removed
+    state: Active
+    text: Rule 'package_telnet-server_removed' MUST be verified
+    applicability: *id017
+  - id: package_telnet_removed
+    state: Active
+    text: Rule 'package_telnet_removed' MUST be verified
+    applicability: *id017
+  - id: package_tftp-server_removed
+    state: Active
+    text: Rule 'package_tftp-server_removed' MUST be verified
+    applicability: *id017
+  - id: package_tftp_removed
+    state: Active
+    text: Rule 'package_tftp_removed' MUST be verified
+    applicability: *id017
+  - id: package_vsftpd_removed
+    state: Active
+    text: Rule 'package_vsftpd_removed' MUST be verified
+    applicability: *id017
+  - id: partition_for_dev_shm
+    state: Active
+    text: Rule 'partition_for_dev_shm' MUST be verified
+    applicability: *id017
+  - id: partition_for_home
+    state: Active
+    text: Rule 'partition_for_home' MUST be verified
+    applicability: *id017
+  - id: partition_for_tmp
+    state: Active
+    text: Rule 'partition_for_tmp' MUST be verified
+    applicability: *id017
+  - id: partition_for_var
+    state: Active
+    text: Rule 'partition_for_var' MUST be verified
+    applicability: *id017
+  - id: partition_for_var_log
+    state: Active
+    text: Rule 'partition_for_var_log' MUST be verified
+    applicability: *id017
+  - id: partition_for_var_log_audit
+    state: Active
+    text: Rule 'partition_for_var_log_audit' MUST be verified
+    applicability: *id017
+  - id: partition_for_var_tmp
+    state: Active
+    text: Rule 'partition_for_var_tmp' MUST be verified
+    applicability: *id017
+  - id: postfix_network_listening_disabled
+    state: Active
+    text: Rule 'postfix_network_listening_disabled' MUST be verified
+    applicability: *id017
+  - id: service_bluetooth_disabled
+    state: Active
+    text: Rule 'service_bluetooth_disabled' MUST be verified
+    applicability: *id017
+  - id: service_cockpit_disabled
+    state: Active
+    text: Rule 'service_cockpit_disabled' MUST be verified
+    applicability: *id017
+  - id: service_cups_disabled
+    state: Active
+    text: Rule 'service_cups_disabled' MUST be verified
+    applicability: *id017
+  - id: service_dnsmasq_disabled
+    state: Active
+    text: Rule 'service_dnsmasq_disabled' MUST be verified
+    applicability: *id017
+  - id: sshd_disable_forwarding
+    state: Active
+    text: Rule 'sshd_disable_forwarding' MUST be verified
+    applicability: *id017
+  - id: wireless_disable_interfaces
+    state: Active
+    text: Rule 'wireless_disable_interfaces' MUST be verified
+    applicability: *id017
+  - id: xwayland_disabled
+    state: Active
+    text: Rule 'xwayland_disabled' MUST be verified
+    applicability: *id017
+  - id: var_postfix_inet_interfaces
+    state: Active
+    text: Variable 'var_postfix_inet_interfaces' is set to 'loopback-only'
+    applicability: *id017
+  state: Active
+- id: cm-8.1
+  title: Updates During Installation and Removal
+  objective: Update the inventory of system components as part of component installations, removals, and system updates.
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cm-8.2
+  title: Automated Maintenance
+  objective: 'Maintain the currency, completeness, accuracy, and availability of the inventory of system components using
+    {{ insert: param, cm-8.2_prm_1 }}.'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: cm-8.3
+  title: Automated Unauthorized Component Detection
+  objective: 'Detect the presence of unauthorized hardware, software, and firmware components within the system using {{ insert:
+    param, cm-8.3_prm_1 }} {{ insert: param, cm-08.03_odp.04 }} ; and Take the following actions when unauthorized components
+    are detected: {{ insert: param, cm-08.03_odp.05 }}.'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cm-8.4
+  title: Accountability Information
+  objective: 'Include in the system component inventory information, a means for identifying by {{ insert: param, cm-08.04_odp
+    }} , individuals responsible and accountable for administering those components.'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: cm-8.5
+  title: No Duplicate Accounting of Components
+  objective: No Duplicate Accounting of Components
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cm-8.6
+  title: Assessed Configurations and Approved Deviations
+  objective: Include assessed component configurations and any approved deviations to current deployed configurations in
+    the system component inventory.
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cm-8.7
+  title: Centralized Repository
+  objective: Provide a centralized repository for the inventory of system components.
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cm-8.8
+  title: Automated Location Tracking
+  objective: 'Support the tracking of system components by geographic location using {{ insert: param, cm-08.08_odp }}.'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cm-8.9
+  title: Assignment of Components to Systems
+  objective: 'Assign system components to a system; and Receive an acknowledgement from {{ insert: param, cm-08.09_odp }}
+    of this assignment.'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cm-8
+  title: System Component Inventory
+  objective: 'Develop and document an inventory of system components that: Review and update the system component inventory
+    {{ insert: param, cm-08_odp.02 }}.'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cm-9.1
+  title: Assignment of Responsibility
+  objective: Assign responsibility for developing the configuration management process to organizational personnel that 
+    are not directly involved in system development.
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cm-9
+  title: Configuration Management Plan
+  objective: 'Develop, document, and implement a configuration management plan for the system that:'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cm-10.1
+  title: Open-source Software
+  objective: 'Establish the following restrictions on the use of open-source software: {{ insert: param, cm-10.01_odp }}.'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cm-10
+  title: Software Usage Restrictions
+  objective: Use software and associated documentation in accordance with contract agreements and copyright laws; Track 
+    the use of software and associated documentation protected by quantity licenses to control copying and distribution;
+    and Control and document the use of peer-to-peer file sharing technology to ensure that this capability is not used 
+    for the unauthorized distribution, display, performance, or reproduction of copyrighted work.
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cm-11.1
+  title: Alerts for Unauthorized Installations
+  objective: Alerts for Unauthorized Installations
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cm-11.2
+  title: Software Installation with Privileged Status
+  objective: Allow user installation of software only with explicit privileged status.
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cm-11.3
+  title: Automated Enforcement and Monitoring
+  objective: 'Enforce and monitor compliance with software installation policies using {{ insert: param, cm-11.3_prm_1 }}.'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cm-11
+  title: User-installed Software
+  objective: 'Establish {{ insert: param, cm-11_odp.01 }} governing the installation of software by users; Enforce software
+    installation policies through the following methods: {{ insert: param, cm-11_odp.02 }} ; and Monitor policy compliance
+    {{ insert: param, cm-11_odp.03 }}.'
+  group: cm
+  assessment-requirements:
+  - id: package_xorg-x11-server-Xwayland_removed
+    state: Active
+    text: Rule 'package_xorg-x11-server-Xwayland_removed' MUST be verified
+    applicability:
+    - fedora-low
+  state: Active
+- id: cm-12.1
+  title: Automated Tools to Support Information Location
+  objective: 'Use automated tools to identify {{ insert: param, cm-12.01_odp.01 }} on {{ insert: param, cm-12.01_odp.02 }}
+    to ensure controls are in place to protect organizational information and individual privacy.'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cm-12
+  title: Information Location
+  objective: 'Identify and document the location of {{ insert: param, cm-12_odp }} and the specific system components on which
+    the information is processed and stored; Identify and document the users who have access to the system and system components
+    where the information is processed and stored; and Document changes to the location (i.e., system or system components)
+    where the information is processed and stored.'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cm-13
+  title: Data Action Mapping
+  objective: Develop and document a map of system data actions.
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cm-14
+  title: Signed Components
+  objective: 'Prevent the installation of {{ insert: param, cm-14_prm_1 }} without verification that the component has been
+    digitally signed using a certificate that is recognized and approved by the organization.'
+  group: cm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cp-1
+  title: Policy and Procedures
+  objective: 'Develop, document, and disseminate to {{ insert: param, cp-1_prm_1 }}: Designate an {{ insert: param, cp-01_odp.04
+    }} to manage the development, documentation, and dissemination of the contingency planning policy and procedures; and
+    Review and update the current contingency planning:'
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cp-2.1
+  title: Coordinate with Related Plans
+  objective: Coordinate contingency plan development with organizational elements responsible for related plans.
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cp-2.2
+  title: Capacity Planning
+  objective: Conduct capacity planning so that necessary capacity for information processing, telecommunications, and 
+    environmental support exists during contingency operations.
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: cp-2.3
+  title: Resume Mission and Business Functions
+  objective: 'Plan for the resumption of {{ insert: param, cp-02.03_odp.01 }} mission and business functions within {{ insert:
+    param, cp-02.03_odp.02 }} of contingency plan activation.'
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cp-2.4
+  title: Resume All Mission and Business Functions
+  objective: Resume All Mission and Business Functions
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cp-2.5
+  title: Continue Mission and Business Functions
+  objective: 'Plan for the continuance of {{ insert: param, cp-02.05_odp }} mission and business functions with minimal or
+    no loss of operational continuity and sustains that continuity until full system restoration at primary processing and/or
+    storage sites.'
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: cp-2.6
+  title: Alternate Processing and Storage Sites
+  objective: 'Plan for the transfer of {{ insert: param, cp-02.06_odp }} mission and business functions to alternate processing
+    and/or storage sites with minimal or no loss of operational continuity and sustain that continuity through system restoration
+    to primary processing and/or storage sites.'
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cp-2.7
+  title: Coordinate with External Service Providers
+  objective: Coordinate the contingency plan with the contingency plans of external service providers to ensure that 
+    contingency requirements can be satisfied.
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cp-2.8
+  title: Identify Critical Assets
+  objective: 'Identify critical system assets supporting {{ insert: param, cp-02.08_odp }} mission and business functions.'
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cp-2
+  title: Contingency Plan
+  objective: 'Develop a contingency plan for the system that: Distribute copies of the contingency plan to {{ insert: param,
+    cp-2_prm_2 }}; Coordinate contingency planning activities with incident handling activities; Review the contingency plan
+    for the system {{ insert: param, cp-02_odp.05 }}; Update the contingency plan to address changes to the organization,
+    system, or environment of operation and problems encountered during contingency plan implementation, execution, or testing;
+    Communicate contingency plan changes to {{ insert: param, cp-2_prm_4 }}; Incorporate lessons learned from contingency
+    plan testing, training, or actual contingency activities into contingency testing and training; and Protect the contingency
+    plan from unauthorized disclosure and modification.'
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cp-3.1
+  title: Simulated Events
+  objective: Incorporate simulated events into contingency training to facilitate effective response by personnel in 
+    crisis situations.
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: cp-3.2
+  title: Mechanisms Used in Training Environments
+  objective: Employ mechanisms used in operations to provide a more thorough and realistic contingency training 
+    environment.
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cp-3
+  title: Contingency Training
+  objective: 'Provide contingency training to system users consistent with assigned roles and responsibilities: Review and
+    update contingency training content {{ insert: param, cp-03_odp.03 }} and following {{ insert: param, cp-03_odp.04 }}.'
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cp-4.1
+  title: Coordinate with Related Plans
+  objective: Coordinate contingency plan testing with organizational elements responsible for related plans.
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cp-4.2
+  title: Alternate Processing Site
+  objective: 'Test the contingency plan at the alternate processing site:'
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: cp-4.3
+  title: Automated Testing
+  objective: 'Test the contingency plan using {{ insert: param, cp-04.03_odp }}.'
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cp-4.4
+  title: Full Recovery and Reconstitution
+  objective: Include a full recovery and reconstitution of the system to a known state as part of contingency plan 
+    testing.
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cp-4.5
+  title: Self-challenge
+  objective: 'Employ {{ insert: param, cp-04.05_odp.01 }} to {{ insert: param, cp-04.05_odp.02 }} to disrupt and adversely
+    affect the system or system component.'
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cp-4
+  title: Contingency Plan Testing
+  objective: 'Test the contingency plan for the system {{ insert: param, cp-04_odp.01 }} using the following tests to determine
+    the effectiveness of the plan and the readiness to execute the plan: {{ insert: param, cp-4_prm_2 }}. Review the contingency
+    plan test results; and Initiate corrective actions, if needed.'
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cp-5
+  title: Contingency Plan Update
+  objective: Contingency Plan Update
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cp-6.1
+  title: Separation from Primary Site
+  objective: Identify an alternate storage site that is sufficiently separated from the primary storage site to reduce 
+    susceptibility to the same threats.
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cp-6.2
+  title: Recovery Time and Recovery Point Objectives
+  objective: Configure the alternate storage site to facilitate recovery operations in accordance with recovery time and
+    recovery point objectives.
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: cp-6.3
+  title: Accessibility
+  objective: Identify potential accessibility problems to the alternate storage site in the event of an area-wide 
+    disruption or disaster and outline explicit mitigation actions.
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cp-6
+  title: Alternate Storage Site
+  objective: Establish an alternate storage site, including necessary agreements to permit the storage and retrieval of 
+    system backup information; and Ensure that the alternate storage site provides controls equivalent to that of the 
+    primary site.
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cp-7.1
+  title: Separation from Primary Site
+  objective: Identify an alternate processing site that is sufficiently separated from the primary processing site to 
+    reduce susceptibility to the same threats.
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cp-7.2
+  title: Accessibility
+  objective: Identify potential accessibility problems to alternate processing sites in the event of an area-wide 
+    disruption or disaster and outlines explicit mitigation actions.
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cp-7.3
+  title: Priority of Service
+  objective: Develop alternate processing site agreements that contain priority-of-service provisions in accordance with
+    availability requirements (including recovery time objectives).
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cp-7.4
+  title: Preparation for Use
+  objective: Prepare the alternate processing site so that the site can serve as the operational site supporting 
+    essential mission and business functions.
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: cp-7.5
+  title: Equivalent Information Security Safeguards
+  objective: Equivalent Information Security Safeguards
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cp-7.6
+  title: Inability to Return to Primary Site
+  objective: Plan and prepare for circumstances that preclude returning to the primary processing site.
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cp-7
+  title: Alternate Processing Site
+  objective: 'Establish an alternate processing site, including necessary agreements to permit the transfer and resumption
+    of {{ insert: param, cp-07_odp.01 }} for essential mission and business functions within {{ insert: param, cp-07_odp.02
+    }} when the primary processing capabilities are unavailable; Make available at the alternate processing site, the equipment
+    and supplies required to transfer and resume operations or put contracts in place to support delivery to the site within
+    the organization-defined time period for transfer and resumption; and Provide controls at the alternate processing site
+    that are equivalent to those at the primary site.'
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cp-8.1
+  title: Priority of Service Provisions
+  objective: Develop primary and alternate telecommunications service agreements that contain priority-of-service 
+    provisions in accordance with availability requirements (including recovery time objectives); and Request 
+    Telecommunications Service Priority for all telecommunications services used for national security emergency 
+    preparedness if the primary and/or alternate telecommunications services are provided by a common carrier.
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cp-8.2
+  title: Single Points of Failure
+  objective: Obtain alternate telecommunications services to reduce the likelihood of sharing a single point of failure 
+    with primary telecommunications services.
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cp-8.3
+  title: Separation of Primary and Alternate Providers
+  objective: Obtain alternate telecommunications services from providers that are separated from primary service 
+    providers to reduce susceptibility to the same threats.
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: cp-8.4
+  title: Provider Contingency Plan
+  objective: 'Require primary and alternate telecommunications service providers to have contingency plans; Review provider
+    contingency plans to ensure that the plans meet organizational contingency requirements; and Obtain evidence of contingency
+    testing and training by providers {{ insert: param, cp-8.4_prm_1 }}.'
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: cp-8.5
+  title: Alternate Telecommunication Service Testing
+  objective: 'Test alternate telecommunication services {{ insert: param, cp-08.05_odp }}.'
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cp-8
+  title: Telecommunications Services
+  objective: 'Establish alternate telecommunications services, including necessary agreements to permit the resumption of
+    {{ insert: param, cp-08_odp.01 }} for essential mission and business functions within {{ insert: param, cp-08_odp.02 }}
+    when the primary telecommunications capabilities are unavailable at either the primary or alternate processing or storage
+    sites.'
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cp-9.1
+  title: Testing for Reliability and Integrity
+  objective: 'Test backup information {{ insert: param, cp-9.1_prm_1 }} to verify media reliability and information integrity.'
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cp-9.2
+  title: Test Restoration Using Sampling
+  objective: Use a sample of backup information in the restoration of selected system functions as part of contingency 
+    plan testing.
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: cp-9.3
+  title: Separate Storage for Critical Information
+  objective: 'Store backup copies of {{ insert: param, cp-09.03_odp }} in a separate facility or in a fire rated container
+    that is not collocated with the operational system.'
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: cp-9.4
+  title: Protection from Unauthorized Modification
+  objective: Protection from Unauthorized Modification
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cp-9.5
+  title: Transfer to Alternate Storage Site
+  objective: 'Transfer system backup information to the alternate storage site {{ insert: param, cp-9.5_prm_1 }}.'
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: cp-9.6
+  title: Redundant Secondary System
+  objective: Conduct system backup by maintaining a redundant secondary system that is not collocated with the primary 
+    system and that can be activated without loss of information or disruption to operations.
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cp-9.7
+  title: Dual Authorization for Deletion or Destruction
+  objective: 'Enforce dual authorization for the deletion or destruction of {{ insert: param, cp-09.07_odp }}.'
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cp-9.8
+  title: Cryptographic Protection
+  objective: 'Implement cryptographic mechanisms to prevent unauthorized disclosure and modification of {{ insert: param,
+    cp-09.08_odp }}.'
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cp-9
+  title: System Backup
+  objective: 'Conduct backups of user-level information contained in {{ insert: param, cp-09_odp.01 }} {{ insert: param, cp-09_odp.02
+    }}; Conduct backups of system-level information contained in the system {{ insert: param, cp-09_odp.03 }}; Conduct backups
+    of system documentation, including security- and privacy-related documentation {{ insert: param, cp-09_odp.04 }} ; and
+    Protect the confidentiality, integrity, and availability of backup information.'
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cp-10.1
+  title: Contingency Plan Testing
+  objective: Contingency Plan Testing
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cp-10.2
+  title: Transaction Recovery
+  objective: Implement transaction recovery for systems that are transaction-based.
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: cp-10.3
+  title: Compensating Security Controls
+  objective: Addressed through tailoring.
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cp-10.4
+  title: Restore Within Time Period
+  objective: 'Provide the capability to restore system components within {{ insert: param, cp-10.04_odp }} from configuration-controlled
+    and integrity-protected information representing a known, operational state for the components.'
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: cp-10.5
+  title: Failover Capability
+  objective: Failover Capability
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cp-10.6
+  title: Component Protection
+  objective: Protect system components used for recovery and reconstitution.
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cp-10
+  title: System Recovery and Reconstitution
+  objective: 'Provide for the recovery and reconstitution of the system to a known state within {{ insert: param, cp-10_prm_1
+    }} after a disruption, compromise, or failure.'
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cp-11
+  title: Alternate Communications Protocols
+  objective: 'Provide the capability to employ {{ insert: param, cp-11_odp }} in support of maintaining continuity of operations.'
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cp-12
+  title: Safe Mode
+  objective: 'When {{ insert: param, cp-12_odp.02 }} are detected, enter a safe mode of operation with {{ insert: param, cp-12_odp.01
+    }}.'
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: cp-13
+  title: Alternative Security Mechanisms
+  objective: 'Employ {{ insert: param, cp-13_odp.01 }} for satisfying {{ insert: param, cp-13_odp.02 }} when the primary means
+    of implementing the security function is unavailable or compromised.'
+  group: cp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-1
+  title: Policy and Procedures
+  objective: 'Develop, document, and disseminate to {{ insert: param, ia-1_prm_1 }}: Designate an {{ insert: param, ia-01_odp.04
+    }} to manage the development, documentation, and dissemination of the identification and authentication policy and procedures;
+    and Review and update the current identification and authentication:'
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-2.1
+  title: Multi-factor Authentication to Privileged Accounts
+  objective: Implement multi-factor authentication for access to privileged accounts.
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-2.2
+  title: Multi-factor Authentication to Non-privileged Accounts
+  objective: Implement multi-factor authentication for access to non-privileged accounts.
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-2.3
+  title: Local Access to Privileged Accounts
+  objective: Local Access to Privileged Accounts
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-2.4
+  title: Local Access to Non-privileged Accounts
+  objective: Local Access to Non-privileged Accounts
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-2.5
+  title: Individual Authentication with Group Authentication
+  objective: When shared accounts or authenticators are employed, require users to be individually authenticated before 
+    granting access to the shared accounts or resources.
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: ia-2.6
+  title: Access to Accounts —separate Device
+  objective: 'Implement multi-factor authentication for {{ insert: param, ia-02.06_odp.01 }} access to {{ insert: param, ia-02.06_odp.02
+    }} such that:'
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-2.7
+  title: Network Access to Non-privileged Accounts — Separate Device
+  objective: Network Access to Non-privileged Accounts — Separate Device
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-2.8
+  title: Access to Accounts — Replay Resistant
+  objective: 'Implement replay-resistant authentication mechanisms for access to {{ insert: param, ia-02.08_odp }}.'
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-2.9
+  title: Network Access to Non-privileged Accounts — Replay Resistant
+  objective: Network Access to Non-privileged Accounts — Replay Resistant
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-2.10
+  title: Single Sign-on
+  objective: 'Provide a single sign-on capability for {{ insert: param, ia-02.10_odp }}.'
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-2.11
+  title: Remote Access — Separate Device
+  objective: Remote Access — Separate Device
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-2.12
+  title: Acceptance of PIV Credentials
+  objective: Accept and electronically verify Personal Identity Verification-compliant credentials.
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-2.13
+  title: Out-of-band Authentication
+  objective: 'Implement the following out-of-band authentication mechanisms under {{ insert: param, ia-02.13_odp.02 }}: {{
+    insert: param, ia-02.13_odp.01 }}.'
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-2
+  title: Identification and Authentication (Organizational Users)
+  objective: Uniquely identify and authenticate organizational users and associate that unique identification with 
+    processes acting on behalf of those users.
+  group: ia
+  assessment-requirements:
+  - id: account_unique_id
+    state: Active
+    text: Rule 'account_unique_id' MUST be verified
+    applicability:
+    - fedora-low
+  state: Active
+- id: ia-3.1
+  title: Cryptographic Bidirectional Authentication
+  objective: 'Authenticate {{ insert: param, ia-03.01_odp.01 }} before establishing {{ insert: param, ia-03.01_odp.02 }} connection
+    using bidirectional authentication that is cryptographically based.'
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ia-3.2
+  title: Cryptographic Bidirectional Network Authentication
+  objective: Cryptographic Bidirectional Network Authentication
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ia-3.3
+  title: Dynamic Address Allocation
+  objective: 'Where addresses are allocated dynamically, standardize dynamic address allocation lease information and the
+    lease duration assigned to devices in accordance with {{ insert: param, ia-3.3_prm_1 }} ; and Audit lease information
+    when assigned to a device.'
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ia-3.4
+  title: Device Attestation
+  objective: 'Handle device identification and authentication based on attestation by {{ insert: param, ia-03.04_odp }}.'
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ia-3
+  title: Device Identification and Authentication
+  objective: 'Uniquely identify and authenticate {{ insert: param, ia-03_odp.01 }} before establishing a {{ insert: param,
+    ia-03_odp.02 }} connection.'
+  group: ia
+  assessment-requirements:
+  - id: dconf_gnome_disable_automount
+    state: Active
+    text: Rule 'dconf_gnome_disable_automount' MUST be verified
+    applicability: &id018
+    - fedora-moderate
+  - id: dconf_gnome_disable_automount_open
+    state: Active
+    text: Rule 'dconf_gnome_disable_automount_open' MUST be verified
+    applicability: *id018
+  - id: kernel_module_usb-storage_disabled
+    state: Active
+    text: Rule 'kernel_module_usb-storage_disabled' MUST be verified
+    applicability: *id018
+  state: Active
+- id: ia-4.1
+  title: Prohibit Account Identifiers as Public Identifiers
+  objective: Prohibit the use of system account identifiers that are the same as public identifiers for individual 
+    accounts.
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-4.2
+  title: Supervisor Authorization
+  objective: Supervisor Authorization
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-4.3
+  title: Multiple Forms of Certification
+  objective: Multiple Forms of Certification
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-4.4
+  title: Identify User Status
+  objective: 'Manage individual identifiers by uniquely identifying each individual as {{ insert: param, ia-04.04_odp }}.'
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ia-4.5
+  title: Dynamic Management
+  objective: 'Manage individual identifiers dynamically in accordance with {{ insert: param, ia-04.05_odp }}.'
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-4.6
+  title: Cross-organization Management
+  objective: 'Coordinate with the following external organizations for cross-organization management of identifiers: {{ insert:
+    param, ia-04.06_odp }}.'
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-4.7
+  title: In-person Registration
+  objective: In-person Registration
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-4.8
+  title: Pairwise Pseudonymous Identifiers
+  objective: Generate pairwise pseudonymous identifiers.
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-4.9
+  title: Attribute Maintenance and Protection
+  objective: 'Maintain the attributes for each uniquely identified individual, device, or service in {{ insert: param, ia-04.09_odp
+    }}.'
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-4
+  title: Identifier Management
+  objective: 'Manage system identifiers by:'
+  group: ia
+  assessment-requirements:
+  - id: account_disable_post_pw_expiration
+    state: Active
+    text: Rule 'account_disable_post_pw_expiration' MUST be verified
+    applicability: &id019
+    - fedora-low
+  - id: accounts_set_post_pw_existing
+    state: Active
+    text: Rule 'accounts_set_post_pw_existing' MUST be verified
+    applicability: *id019
+  - id: var_account_disable_post_pw_expiration
+    state: Active
+    text: Variable 'var_account_disable_post_pw_expiration' is set to '45'
+    applicability: *id019
+  state: Active
+- id: ia-5.1
+  title: Password-based Authentication
+  objective: 'For password-based authentication:'
+  group: ia
+  assessment-requirements:
+  - id: accounts_password_pam_pwhistory_remember_password_auth
+    state: Active
+    text: Rule 'accounts_password_pam_pwhistory_remember_password_auth' MUST be verified
+    applicability: &id020
+    - fedora-low
+  - id: accounts_password_pam_pwhistory_remember_system_auth
+    state: Active
+    text: Rule 'accounts_password_pam_pwhistory_remember_system_auth' MUST be verified
+    applicability: *id020
+  - id: accounts_password_pam_unix_enabled
+    state: Active
+    text: Rule 'accounts_password_pam_unix_enabled' MUST be verified
+    applicability: *id020
+  - id: accounts_password_pam_unix_no_remember
+    state: Active
+    text: Rule 'accounts_password_pam_unix_no_remember' MUST be verified
+    applicability: *id020
+  - id: var_password_pam_remember
+    state: Active
+    text: Variable 'var_password_pam_remember' is set to '24'
+    applicability: *id020
+  - id: var_password_pam_remember_control_flag
+    state: Active
+    text: Variable 'var_password_pam_remember_control_flag' is set to 'requisite_or_required'
+    applicability: *id020
+  state: Active
+- id: ia-5.2
+  title: Public Key-based Authentication
+  objective: 'For public key-based authentication: When public key infrastructure (PKI) is used:'
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ia-5.3
+  title: In-person or Trusted External Party Registration
+  objective: In-person or Trusted External Party Registration
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-5.4
+  title: Automated Support for Password Strength Determination
+  objective: Automated Support for Password Strength Determination
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-5.5
+  title: Change Authenticators Prior to Delivery
+  objective: Require developers and installers of system components to provide unique authenticators or change default 
+    authenticators prior to delivery and installation.
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-5.6
+  title: Protection of Authenticators
+  objective: Protect authenticators commensurate with the security category of the information to which use of the 
+    authenticator permits access.
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ia-5.7
+  title: No Embedded Unencrypted Static Authenticators
+  objective: Ensure that unencrypted static authenticators are not embedded in applications or other forms of static 
+    storage.
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-5.8
+  title: Multiple System Accounts
+  objective: 'Implement {{ insert: param, ia-05.08_odp }} to manage the risk of compromise due to individuals having accounts
+    on multiple systems.'
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-5.9
+  title: Federated Credential Management
+  objective: 'Use the following external organizations to federate credentials: {{ insert: param, ia-05.09_odp }}.'
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-5.10
+  title: Dynamic Credential Binding
+  objective: 'Bind identities and authenticators dynamically using the following rules: {{ insert: param, ia-05.10_odp }}.'
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-5.11
+  title: Hardware Token-based Authentication
+  objective: Hardware Token-based Authentication
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-5.12
+  title: Biometric Authentication Performance
+  objective: 'For biometric-based authentication, employ mechanisms that satisfy the following biometric quality requirements
+    {{ insert: param, ia-05.12_odp }}.'
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-5.13
+  title: Expiration of Cached Authenticators
+  objective: 'Prohibit the use of cached authenticators after {{ insert: param, ia-05.13_odp }}.'
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-5.14
+  title: Managing Content of PKI Trust Stores
+  objective: For PKI-based authentication, employ an organization-wide methodology for managing the content of PKI trust
+    stores installed across all platforms, including networks, operating systems, browsers, and applications.
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-5.15
+  title: GSA-approved Products and Services
+  objective: Use only General Services Administration-approved products and services for identity, credential, and 
+    access management.
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-5.16
+  title: In-person or Trusted External Party Authenticator Issuance
+  objective: 'Require that the issuance of {{ insert: param, ia-05.16_odp.01 }} be conducted {{ insert: param, ia-05.16_odp.02
+    }} before {{ insert: param, ia-05.16_odp.03 }} with authorization by {{ insert: param, ia-05.16_odp.04 }}.'
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-5.17
+  title: Presentation Attack Detection for Biometric Authenticators
+  objective: Employ presentation attack detection mechanisms for biometric-based authentication.
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-5.18
+  title: Password Managers
+  objective: 'Employ {{ insert: param, ia-05.18_odp.01 }} to generate and manage passwords; and Protect the passwords using
+    {{ insert: param, ia-05.18_odp.02 }}.'
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-5
+  title: Authenticator Management
+  objective: 'Manage system authenticators by:'
+  group: ia
+  assessment-requirements:
+  - id: accounts_minimum_age_login_defs
+    state: Active
+    text: Rule 'accounts_minimum_age_login_defs' MUST be verified
+    applicability: &id021
+    - fedora-low
+  - id: accounts_password_all_shadowed
+    state: Active
+    text: Rule 'accounts_password_all_shadowed' MUST be verified
+    applicability: *id021
+  - id: accounts_password_last_change_is_in_past
+    state: Active
+    text: Rule 'accounts_password_last_change_is_in_past' MUST be verified
+    applicability: *id021
+  - id: accounts_password_pam_dictcheck
+    state: Active
+    text: Rule 'accounts_password_pam_dictcheck' MUST be verified
+    applicability: *id021
+  - id: accounts_password_pam_difok
+    state: Active
+    text: Rule 'accounts_password_pam_difok' MUST be verified
+    applicability: *id021
+  - id: accounts_password_pam_enforce_root
+    state: Active
+    text: Rule 'accounts_password_pam_enforce_root' MUST be verified
+    applicability: *id021
+  - id: accounts_password_pam_maxrepeat
+    state: Active
+    text: Rule 'accounts_password_pam_maxrepeat' MUST be verified
+    applicability: *id021
+  - id: accounts_password_pam_maxsequence
+    state: Active
+    text: Rule 'accounts_password_pam_maxsequence' MUST be verified
+    applicability: *id021
+  - id: accounts_password_pam_minclass
+    state: Active
+    text: Rule 'accounts_password_pam_minclass' MUST be verified
+    applicability: *id021
+  - id: accounts_password_pam_minlen
+    state: Active
+    text: Rule 'accounts_password_pam_minlen' MUST be verified
+    applicability: *id021
+  - id: accounts_password_pam_modules_in_authselect_profile
+    state: Active
+    text: Rule 'accounts_password_pam_modules_in_authselect_profile' MUST be verified
+    applicability: *id021
+  - id: accounts_password_pam_pwhistory_enforce_for_root
+    state: Active
+    text: Rule 'accounts_password_pam_pwhistory_enforce_for_root' MUST be verified
+    applicability: *id021
+  - id: accounts_password_pam_pwhistory_use_authtok
+    state: Active
+    text: Rule 'accounts_password_pam_pwhistory_use_authtok' MUST be verified
+    applicability: *id021
+  - id: accounts_password_pam_unix_authtok
+    state: Active
+    text: Rule 'accounts_password_pam_unix_authtok' MUST be verified
+    applicability: *id021
+  - id: accounts_password_set_min_life_existing
+    state: Active
+    text: Rule 'accounts_password_set_min_life_existing' MUST be verified
+    applicability: *id021
+  - id: accounts_password_set_warn_age_existing
+    state: Active
+    text: Rule 'accounts_password_set_warn_age_existing' MUST be verified
+    applicability: *id021
+  - id: accounts_password_warn_age_login_defs
+    state: Active
+    text: Rule 'accounts_password_warn_age_login_defs' MUST be verified
+    applicability: *id021
+  - id: ensure_root_password_configured
+    state: Active
+    text: Rule 'ensure_root_password_configured' MUST be verified
+    applicability: *id021
+  - id: no_empty_passwords_etc_shadow
+    state: Active
+    text: Rule 'no_empty_passwords_etc_shadow' MUST be verified
+    applicability: *id021
+  - id: set_password_hashing_algorithm_logindefs
+    state: Active
+    text: Rule 'set_password_hashing_algorithm_logindefs' MUST be verified
+    applicability: *id021
+  - id: set_password_hashing_algorithm_passwordauth
+    state: Active
+    text: Rule 'set_password_hashing_algorithm_passwordauth' MUST be verified
+    applicability: *id021
+  - id: set_password_hashing_algorithm_systemauth
+    state: Active
+    text: Rule 'set_password_hashing_algorithm_systemauth' MUST be verified
+    applicability: *id021
+  - id: var_accounts_minimum_age_login_defs
+    state: Active
+    text: Variable 'var_accounts_minimum_age_login_defs' is set to '1'
+    applicability: *id021
+  - id: var_accounts_password_warn_age_login_defs
+    state: Active
+    text: Variable 'var_accounts_password_warn_age_login_defs' is set to '7'
+    applicability: *id021
+  - id: var_password_hashing_algorithm
+    state: Active
+    text: Variable 'var_password_hashing_algorithm' is set to 'cis_fedora'
+    applicability: *id021
+  - id: var_password_hashing_algorithm_pam
+    state: Active
+    text: Variable 'var_password_hashing_algorithm_pam' is set to 'cis_fedora'
+    applicability: *id021
+  - id: var_password_pam_dictcheck
+    state: Active
+    text: Variable 'var_password_pam_dictcheck' is set to '1'
+    applicability: *id021
+  - id: var_password_pam_difok
+    state: Active
+    text: Variable 'var_password_pam_difok' is set to '2'
+    applicability: *id021
+  - id: var_password_pam_maxrepeat
+    state: Active
+    text: Variable 'var_password_pam_maxrepeat' is set to '3'
+    applicability: *id021
+  - id: var_password_pam_maxsequence
+    state: Active
+    text: Variable 'var_password_pam_maxsequence' is set to '3'
+    applicability: *id021
+  - id: var_password_pam_minclass
+    state: Active
+    text: Variable 'var_password_pam_minclass' is set to '4'
+    applicability: *id021
+  - id: var_password_pam_minlen
+    state: Active
+    text: Variable 'var_password_pam_minlen' is set to '14'
+    applicability: *id021
+  state: Active
+- id: ia-6
+  title: Authentication Feedback
+  objective: Obscure feedback of authentication information during the authentication process to protect the information
+    from possible exploitation and use by unauthorized individuals.
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-7
+  title: Cryptographic Module Authentication
+  objective: Implement mechanisms for authentication to a cryptographic module that meet the requirements of applicable 
+    laws, executive orders, directives, policies, regulations, standards, and guidelines for such authentication.
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-8.1
+  title: Acceptance of PIV Credentials from Other Agencies
+  objective: Accept and electronically verify Personal Identity Verification-compliant credentials from other federal 
+    agencies.
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-8.2
+  title: Acceptance of External Authenticators
+  objective: Accept only external authenticators that are NIST-compliant; and Document and maintain a list of accepted 
+    external authenticators.
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-8.3
+  title: Use of FICAM-approved Products
+  objective: Use of FICAM-approved Products
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-8.4
+  title: Use of Defined Profiles
+  objective: 'Conform to the following profiles for identity management {{ insert: param, ia-08.04_odp }}.'
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-8.5
+  title: Acceptance of PIV-I Credentials
+  objective: 'Accept and verify federated or PKI credentials that meet {{ insert: param, ia-08.05_odp }}.'
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-8.6
+  title: Disassociability
+  objective: 'Implement the following measures to disassociate user attributes or identifier assertion relationships among
+    individuals, credential service providers, and relying parties: {{ insert: param, ia-08.06_odp }}.'
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-8
+  title: Identification and Authentication (Non-organizational Users)
+  objective: Uniquely identify and authenticate non-organizational users or processes acting on behalf of 
+    non-organizational users.
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-9.1
+  title: Information Exchange
+  objective: Information Exchange
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-9.2
+  title: Transmission of Decisions
+  objective: Transmission of Decisions
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-9
+  title: Service Identification and Authentication
+  objective: 'Uniquely identify and authenticate {{ insert: param, ia-09_odp }} before establishing communications with devices,
+    users, or other services or applications.'
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-10
+  title: Adaptive Authentication
+  objective: 'Require individuals accessing the system to employ {{ insert: param, ia-10_odp.01 }} under specific {{ insert:
+    param, ia-10_odp.02 }}.'
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-11
+  title: Re-authentication
+  objective: 'Require users to re-authenticate when {{ insert: param, ia-11_odp }}.'
+  group: ia
+  assessment-requirements:
+  - id: sudo_require_reauthentication
+    state: Active
+    text: Rule 'sudo_require_reauthentication' MUST be verified
+    applicability: &id022
+    - fedora-low
+  - id: var_sudo_timestamp_timeout
+    state: Active
+    text: Variable 'var_sudo_timestamp_timeout' is set to '15_minutes'
+    applicability: *id022
+  state: Active
+- id: ia-12.1
+  title: Supervisor Authorization
+  objective: Require that the registration process to receive an account for logical access includes supervisor or 
+    sponsor authorization.
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ia-12.2
+  title: Identity Evidence
+  objective: Require evidence of individual identification be presented to the registration authority.
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ia-12.3
+  title: Identity Evidence Validation and Verification
+  objective: 'Require that the presented identity evidence be validated and verified through {{ insert: param, ia-12.03_odp
+    }}.'
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ia-12.4
+  title: In-person Validation and Verification
+  objective: Require that the validation and verification of identity evidence be conducted in person before a 
+    designated registration authority.
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: ia-12.5
+  title: Address Confirmation
+  objective: 'Require that a {{ insert: param, ia-12.05_odp }} be delivered through an out-of-band channel to verify the users
+    address (physical or digital) of record.'
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ia-12.6
+  title: Accept Externally-proofed Identities
+  objective: 'Accept externally-proofed identities at {{ insert: param, ia-12.06_odp }}.'
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ia-12
+  title: Identity Proofing
+  objective: Identity proof users that require accounts for logical access to systems based on appropriate identity 
+    assurance level requirements as specified in applicable standards and guidelines; Resolve user identities to a 
+    unique individual; and Collect, validate, and verify identity evidence.
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ia-13.1
+  title: Protection of Cryptographic Keys
+  objective: Cryptographic keys that protect access tokens are generated, managed, and protected from disclosure and 
+    misuse.
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-13.2
+  title: Verification of Identity Assertions and Access Tokens
+  objective: The source and integrity of identity assertions and access tokens are verified before granting access to 
+    system and information resources.
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-13.3
+  title: Token Management
+  objective: 'In accordance with {{ insert: param, ia-13_odp.01 }}, assertions and access tokens are:'
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ia-13
+  title: Identity Providers and Authorization Servers
+  objective: 'Employ identity providers and authorization servers to manage user, device, and non-person entity (NPE) identities,
+    attributes, and access rights supporting authentication and authorization decisions in accordance with {{ insert: param,
+    ia-13_odp.01 }} using {{ insert: param, ia-13_odp.02 }}.'
+  group: ia
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ir-1
+  title: Policy and Procedures
+  objective: 'Develop, document, and disseminate to {{ insert: param, ir-1_prm_1 }}: Designate an {{ insert: param, ir-01_odp.04
+    }} to manage the development, documentation, and dissemination of the incident response policy and procedures; and Review
+    and update the current incident response:'
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ir-2.1
+  title: Simulated Events
+  objective: Incorporate simulated events into incident response training to facilitate the required response by 
+    personnel in crisis situations.
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: ir-2.2
+  title: Automated Training Environments
+  objective: 'Provide an incident response training environment using {{ insert: param, ir-02.02_odp }}.'
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: ir-2.3
+  title: Breach
+  objective: Provide incident response training on how to identify and respond to a breach, including the organization’s
+    process for reporting a breach.
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ir-2
+  title: Incident Response Training
+  objective: 'Provide incident response training to system users consistent with assigned roles and responsibilities: Review
+    and update incident response training content {{ insert: param, ir-02_odp.03 }} and following {{ insert: param, ir-02_odp.04
+    }}.'
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ir-3.1
+  title: Automated Testing
+  objective: 'Test the incident response capability using {{ insert: param, ir-03.01_odp }}.'
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ir-3.2
+  title: Coordination with Related Plans
+  objective: Coordinate incident response testing with organizational elements responsible for related plans.
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ir-3.3
+  title: Continuous Improvement
+  objective: 'Use qualitative and quantitative data from testing to:'
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ir-3
+  title: Incident Response Testing
+  objective: 'Test the effectiveness of the incident response capability for the system {{ insert: param, ir-03_odp.01 }}
+    using the following tests: {{ insert: param, ir-03_odp.02 }}.'
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ir-4.1
+  title: Automated Incident Handling Processes
+  objective: 'Support the incident handling process using {{ insert: param, ir-04.01_odp }}.'
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ir-4.2
+  title: Dynamic Reconfiguration
+  objective: 'Include the following types of dynamic reconfiguration for {{ insert: param, ir-04.02_odp.02 }} as part of the
+    incident response capability: {{ insert: param, ir-04.02_odp.01 }}.'
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ir-4.3
+  title: Continuity of Operations
+  objective: 'Identify {{ insert: param, ir-04.03_odp.01 }} and take the following actions in response to those incidents
+    to ensure continuation of organizational mission and business functions: {{ insert: param, ir-04.03_odp.02 }}.'
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ir-4.4
+  title: Information Correlation
+  objective: Correlate incident information and individual incident responses to achieve an organization-wide 
+    perspective on incident awareness and response.
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: ir-4.5
+  title: Automatic Disabling of System
+  objective: 'Implement a configurable capability to automatically disable the system if {{ insert: param, ir-04.05_odp }}
+    are detected.'
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ir-4.6
+  title: Insider Threats
+  objective: Implement an incident handling capability for incidents involving insider threats.
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ir-4.7
+  title: Insider Threats — Intra-organization Coordination
+  objective: 'Coordinate an incident handling capability for insider threats that includes the following organizational entities
+    {{ insert: param, ir-04.07_odp }}.'
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ir-4.8
+  title: Correlation with External Organizations
+  objective: 'Coordinate with {{ insert: param, ir-04.08_odp.01 }} to correlate and share {{ insert: param, ir-04.08_odp.02
+    }} to achieve a cross-organization perspective on incident awareness and more effective incident responses.'
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ir-4.9
+  title: Dynamic Response Capability
+  objective: 'Employ {{ insert: param, ir-04.09_odp }} to respond to incidents.'
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ir-4.10
+  title: Supply Chain Coordination
+  objective: Coordinate incident handling activities involving supply chain events with other organizations involved in 
+    the supply chain.
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ir-4.11
+  title: Integrated Incident Response Team
+  objective: 'Establish and maintain an integrated incident response team that can be deployed to any location identified
+    by the organization in {{ insert: param, ir-04.11_odp }}.'
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: ir-4.12
+  title: Malicious Code and Forensic Analysis
+  objective: Analyze malicious code and/or other residual artifacts remaining in the system after the incident.
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ir-4.13
+  title: Behavior Analysis
+  objective: 'Analyze anomalous or suspected adversarial behavior in or related to {{ insert: param, ir-04.13_odp }}.'
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ir-4.14
+  title: Security Operations Center
+  objective: Establish and maintain a security operations center.
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ir-4.15
+  title: Public Relations and Reputation Repair
+  objective: Manage public relations associated with an incident; and Employ measures to repair the reputation of the 
+    organization.
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ir-4
+  title: Incident Handling
+  objective: Implement an incident handling capability for incidents that is consistent with the incident response plan 
+    and includes preparation, detection and analysis, containment, eradication, and recovery; Coordinate incident 
+    handling activities with contingency planning activities; Incorporate lessons learned from ongoing incident handling
+    activities into incident response procedures, training, and testing, and implement the resulting changes 
+    accordingly; and Ensure the rigor, intensity, scope, and results of incident handling activities are comparable and 
+    predictable across the organization.
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ir-5.1
+  title: Automated Tracking, Data Collection, and Analysis
+  objective: 'Track incidents and collect and analyze incident information using {{ insert: param, ir-5.1_prm_1 }}.'
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: ir-5
+  title: Incident Monitoring
+  objective: Track and document incidents.
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ir-6.1
+  title: Automated Reporting
+  objective: 'Report incidents using {{ insert: param, ir-06.01_odp }}.'
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ir-6.2
+  title: Vulnerabilities Related to Incidents
+  objective: 'Report system vulnerabilities associated with reported incidents to {{ insert: param, ir-06.02_odp }}.'
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ir-6.3
+  title: Supply Chain Coordination
+  objective: Provide incident information to the provider of the product or service and other organizations involved in 
+    the supply chain or supply chain governance for systems or system components related to the incident.
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ir-6
+  title: Incident Reporting
+  objective: 'Require personnel to report suspected incidents to the organizational incident response capability within {{
+    insert: param, ir-06_odp.01 }} ; and Report incident information to {{ insert: param, ir-06_odp.02 }}.'
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ir-7.1
+  title: Automation Support for Availability of Information and Support
+  objective: 'Increase the availability of incident response information and support using {{ insert: param, ir-07.01_odp
+    }}.'
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ir-7.2
+  title: Coordination with External Providers
+  objective: Establish a direct, cooperative relationship between its incident response capability and external 
+    providers of system protection capability; and Identify organizational incident response team members to the 
+    external providers.
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ir-7
+  title: Incident Response Assistance
+  objective: Provide an incident response support resource, integral to the organizational incident response capability,
+    that offers advice and assistance to users of the system for the handling and reporting of incidents.
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ir-8.1
+  title: Breaches
+  objective: 'Include the following in the Incident Response Plan for breaches involving personally identifiable information:'
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ir-8
+  title: Incident Response Plan
+  objective: 'Develop an incident response plan that: Distribute copies of the incident response plan to {{ insert: param,
+    ir-08_odp.04 }}; Update the incident response plan to address system and organizational changes or problems encountered
+    during plan implementation, execution, or testing; Communicate incident response plan changes to {{ insert: param, ir-8_prm_5
+    }} ; and Protect the incident response plan from unauthorized disclosure and modification.'
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ir-9.1
+  title: Responsible Personnel
+  objective: Responsible Personnel
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ir-9.2
+  title: Training
+  objective: 'Provide information spillage response training {{ insert: param, ir-09.02_odp }}.'
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ir-9.3
+  title: Post-spill Operations
+  objective: 'Implement the following procedures to ensure that organizational personnel impacted by information spills can
+    continue to carry out assigned tasks while contaminated systems are undergoing corrective actions: {{ insert: param, ir-09.03_odp
+    }}.'
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ir-9.4
+  title: Exposure to Unauthorized Personnel
+  objective: 'Employ the following controls for personnel exposed to information not within assigned access authorizations:
+    {{ insert: param, ir-09.04_odp }}.'
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ir-9
+  title: Information Spillage Response
+  objective: 'Respond to information spills by:'
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ir-10
+  title: Integrated Information Security Analysis Team
+  objective: Integrated Information Security Analysis Team
+  group: ir
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ma-1
+  title: Policy and Procedures
+  objective: 'Develop, document, and disseminate to {{ insert: param, ma-1_prm_1 }}: Designate an {{ insert: param, ma-01_odp.04
+    }} to manage the development, documentation, and dissemination of the maintenance policy and procedures; and Review and
+    update the current maintenance:'
+  group: ma
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ma-2.1
+  title: Record Content
+  objective: Record Content
+  group: ma
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ma-2.2
+  title: Automated Maintenance Activities
+  objective: 'Schedule, conduct, and document maintenance, repair, and replacement actions for the system using {{ insert:
+    param, ma-2.2_prm_1 }} ; and Produce up-to date, accurate, and complete records of all maintenance, repair, and replacement
+    actions requested, scheduled, in process, and completed.'
+  group: ma
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: ma-2
+  title: Controlled Maintenance
+  objective: 'Schedule, document, and review records of maintenance, repair, and replacement on system components in accordance
+    with manufacturer or vendor specifications and/or organizational requirements; Approve and monitor all maintenance activities,
+    whether performed on site or remotely and whether the system or system components are serviced on site or removed to another
+    location; Require that {{ insert: param, ma-02_odp.01 }} explicitly approve the removal of the system or system components
+    from organizational facilities for off-site maintenance, repair, or replacement; Sanitize equipment to remove the following
+    information from associated media prior to removal from organizational facilities for off-site maintenance, repair, or
+    replacement: {{ insert: param, ma-02_odp.02 }}; Check all potentially impacted controls to verify that the controls are
+    still functioning properly following maintenance, repair, or replacement actions; and Include the following information
+    in organizational maintenance records: {{ insert: param, ma-02_odp.03 }}.'
+  group: ma
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ma-3.1
+  title: Inspect Tools
+  objective: Inspect the maintenance tools used by maintenance personnel for improper or unauthorized modifications.
+  group: ma
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ma-3.2
+  title: Inspect Media
+  objective: Check media containing diagnostic and test programs for malicious code before the media are used in the 
+    system.
+  group: ma
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ma-3.3
+  title: Prevent Unauthorized Removal
+  objective: 'Prevent the removal of maintenance equipment containing organizational information by:'
+  group: ma
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ma-3.4
+  title: Restricted Tool Use
+  objective: Restrict the use of maintenance tools to authorized personnel only.
+  group: ma
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ma-3.5
+  title: Execution with Privilege
+  objective: Monitor the use of maintenance tools that execute with increased privilege.
+  group: ma
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ma-3.6
+  title: Software Updates and Patches
+  objective: Inspect maintenance tools to ensure the latest software updates and patches are installed.
+  group: ma
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ma-3
+  title: Maintenance Tools
+  objective: 'Approve, control, and monitor the use of system maintenance tools; and Review previously approved system maintenance
+    tools {{ insert: param, ma-03_odp }}.'
+  group: ma
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ma-4.1
+  title: Logging and Review
+  objective: 'Log {{ insert: param, ma-4.1_prm_1 }} for nonlocal maintenance and diagnostic sessions; and Review the audit
+    records of the maintenance and diagnostic sessions to detect anomalous behavior.'
+  group: ma
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ma-4.2
+  title: Document Nonlocal Maintenance
+  objective: Document Nonlocal Maintenance
+  group: ma
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ma-4.3
+  title: Comparable Security and Sanitization
+  objective: Require that nonlocal maintenance and diagnostic services be performed from a system that implements a 
+    security capability comparable to the capability implemented on the system being serviced; or Remove the component 
+    to be serviced from the system prior to nonlocal maintenance or diagnostic services; sanitize the component (for 
+    organizational information); and after the service is performed, inspect and sanitize the component (for potentially
+    malicious software) before reconnecting the component to the system.
+  group: ma
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: ma-4.4
+  title: Authentication and Separation of Maintenance Sessions
+  objective: 'Protect nonlocal maintenance sessions by:'
+  group: ma
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ma-4.5
+  title: Approvals and Notifications
+  objective: 'Require the approval of each nonlocal maintenance session by {{ insert: param, ma-04.05_odp.01 }} ; and Notify
+    the following personnel or roles of the date and time of planned nonlocal maintenance: {{ insert: param, ma-04.05_odp.02
+    }}.'
+  group: ma
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ma-4.6
+  title: Cryptographic Protection
+  objective: 'Implement the following cryptographic mechanisms to protect the integrity and confidentiality of nonlocal maintenance
+    and diagnostic communications: {{ insert: param, ma-04.06_odp }}.'
+  group: ma
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ma-4.7
+  title: Disconnect Verification
+  objective: Verify session and network connection termination after the completion of nonlocal maintenance and 
+    diagnostic sessions.
+  group: ma
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ma-4
+  title: Nonlocal Maintenance
+  objective: Approve and monitor nonlocal maintenance and diagnostic activities; Allow the use of nonlocal maintenance 
+    and diagnostic tools only as consistent with organizational policy and documented in the security plan for the 
+    system; Employ strong authentication in the establishment of nonlocal maintenance and diagnostic sessions; Maintain 
+    records for nonlocal maintenance and diagnostic activities; and Terminate session and network connections when 
+    nonlocal maintenance is completed.
+  group: ma
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ma-5.1
+  title: Individuals Without Appropriate Access
+  objective: 'Implement procedures for the use of maintenance personnel that lack appropriate security clearances or are not
+    U.S. citizens, that include the following requirements: Develop and implement {{ insert: param, ma-05.01_odp }} in the
+    event a system component cannot be sanitized, removed, or disconnected from the system.'
+  group: ma
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: ma-5.2
+  title: Security Clearances for Classified Systems
+  objective: Verify that personnel performing maintenance and diagnostic activities on a system processing, storing, or 
+    transmitting classified information possess security clearances and formal access approvals for at least the highest
+    classification level and for compartments of information on the system.
+  group: ma
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ma-5.3
+  title: Citizenship Requirements for Classified Systems
+  objective: Verify that personnel performing maintenance and diagnostic activities on a system processing, storing, or 
+    transmitting classified information are U.S. citizens.
+  group: ma
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ma-5.4
+  title: Foreign Nationals
+  objective: 'Ensure that:'
+  group: ma
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ma-5.5
+  title: Non-system Maintenance
+  objective: Ensure that non-escorted personnel performing maintenance activities not directly associated with the 
+    system but in the physical proximity of the system, have required access authorizations.
+  group: ma
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ma-5
+  title: Maintenance Personnel
+  objective: Establish a process for maintenance personnel authorization and maintain a list of authorized maintenance 
+    organizations or personnel; Verify that non-escorted personnel performing maintenance on the system possess the 
+    required access authorizations; and Designate organizational personnel with required access authorizations and 
+    technical competence to supervise the maintenance activities of personnel who do not possess the required access 
+    authorizations.
+  group: ma
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ma-6.1
+  title: Preventive Maintenance
+  objective: 'Perform preventive maintenance on {{ insert: param, ma-06.01_odp.01 }} at {{ insert: param, ma-06.01_odp.02
+    }}.'
+  group: ma
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ma-6.2
+  title: Predictive Maintenance
+  objective: 'Perform predictive maintenance on {{ insert: param, ma-06.02_odp.01 }} at {{ insert: param, ma-06.02_odp.02
+    }}.'
+  group: ma
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ma-6.3
+  title: Automated Support for Predictive Maintenance
+  objective: 'Transfer predictive maintenance data to a maintenance management system using {{ insert: param, ma-06.03_odp
+    }}.'
+  group: ma
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ma-6
+  title: Timely Maintenance
+  objective: 'Obtain maintenance support and/or spare parts for {{ insert: param, ma-06_odp.01 }} within {{ insert: param,
+    ma-06_odp.02 }} of failure.'
+  group: ma
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ma-7
+  title: Field Maintenance
+  objective: 'Restrict or prohibit field maintenance on {{ insert: param, ma-07_odp.01 }} to {{ insert: param, ma-07_odp.02
+    }}.'
+  group: ma
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: mp-1
+  title: Policy and Procedures
+  objective: 'Develop, document, and disseminate to {{ insert: param, mp-1_prm_1 }}: Designate an {{ insert: param, mp-01_odp.04
+    }} to manage the development, documentation, and dissemination of the media protection policy and procedures; and Review
+    and update the current media protection:'
+  group: mp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: mp-2.1
+  title: Automated Restricted Access
+  objective: Automated Restricted Access
+  group: mp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: mp-2.2
+  title: Cryptographic Protection
+  objective: Cryptographic Protection
+  group: mp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: mp-2
+  title: Media Access
+  objective: 'Restrict access to {{ insert: param, mp-2_prm_1 }} to {{ insert: param, mp-2_prm_2 }}.'
+  group: mp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: mp-3
+  title: Media Marking
+  objective: 'Mark system media indicating the distribution limitations, handling caveats, and applicable security markings
+    (if any) of the information; and Exempt {{ insert: param, mp-03_odp.01 }} from marking if the media remain within {{ insert:
+    param, mp-03_odp.02 }}.'
+  group: mp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: mp-4.1
+  title: Cryptographic Protection
+  objective: Cryptographic Protection
+  group: mp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: mp-4.2
+  title: Automated Restricted Access
+  objective: 'Restrict access to media storage areas and log access attempts and access granted using {{ insert: param, mp-4.2_prm_1
+    }}.'
+  group: mp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: mp-4
+  title: Media Storage
+  objective: 'Physically control and securely store {{ insert: param, mp-4_prm_1 }} within {{ insert: param, mp-4_prm_2 }}
+    ; and Protect system media types defined in MP-4a until the media are destroyed or sanitized using approved equipment,
+    techniques, and procedures.'
+  group: mp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: mp-5.1
+  title: Protection Outside of Controlled Areas
+  objective: Protection Outside of Controlled Areas
+  group: mp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: mp-5.2
+  title: Documentation of Activities
+  objective: Documentation of Activities
+  group: mp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: mp-5.3
+  title: Custodians
+  objective: Employ an identified custodian during transport of system media outside of controlled areas.
+  group: mp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: mp-5.4
+  title: Cryptographic Protection
+  objective: Cryptographic Protection
+  group: mp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: mp-5
+  title: Media Transport
+  objective: 'Protect and control {{ insert: param, mp-05_odp.01 }} during transport outside of controlled areas using {{
+    insert: param, mp-5_prm_2 }}; Maintain accountability for system media during transport outside of controlled areas; Document
+    activities associated with the transport of system media; and Restrict the activities associated with the transport of
+    system media to authorized personnel.'
+  group: mp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: mp-6.1
+  title: Review, Approve, Track, Document, and Verify
+  objective: Review, approve, track, document, and verify media sanitization and disposal actions.
+  group: mp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: mp-6.2
+  title: Equipment Testing
+  objective: 'Test sanitization equipment and procedures {{ insert: param, mp-6.2_prm_1 }} to ensure that the intended sanitization
+    is being achieved.'
+  group: mp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: mp-6.3
+  title: Nondestructive Techniques
+  objective: 'Apply nondestructive sanitization techniques to portable storage devices prior to connecting such devices to
+    the system under the following circumstances: {{ insert: param, mp-06.03_odp }}.'
+  group: mp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: mp-6.4
+  title: Controlled Unclassified Information
+  objective: Controlled Unclassified Information
+  group: mp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: mp-6.5
+  title: Classified Information
+  objective: Classified Information
+  group: mp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: mp-6.6
+  title: Media Destruction
+  objective: Media Destruction
+  group: mp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: mp-6.7
+  title: Dual Authorization
+  objective: 'Enforce dual authorization for the sanitization of {{ insert: param, mp-06.07_odp }}.'
+  group: mp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: mp-6.8
+  title: Remote Purging or Wiping of Information
+  objective: 'Provide the capability to purge or wipe information from {{ insert: param, mp-06.08_odp.01 }} {{ insert: param,
+    mp-06.08_odp.02 }}.'
+  group: mp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: mp-6
+  title: Media Sanitization
+  objective: 'Sanitize {{ insert: param, mp-6_prm_1 }} prior to disposal, release out of organizational control, or release
+    for reuse using {{ insert: param, mp-6_prm_2 }} ; and Employ sanitization mechanisms with the strength and integrity commensurate
+    with the security category or classification of the information.'
+  group: mp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: mp-7.1
+  title: Prohibit Use Without Owner
+  objective: Prohibit Use Without Owner
+  group: mp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: mp-7.2
+  title: Prohibit Use of Sanitization-resistant Media
+  objective: Prohibit the use of sanitization-resistant media in organizational systems.
+  group: mp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: mp-7
+  title: Media Use
+  objective: '{{ insert: param, mp-07_odp.02 }} the use of {{ insert: param, mp-07_odp.01 }} on {{ insert: param, mp-07_odp.03
+    }} using {{ insert: param, mp-07_odp.04 }} ; and Prohibit the use of portable storage devices in organizational systems
+    when such devices have no identifiable owner.'
+  group: mp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: mp-8.1
+  title: Documentation of Process
+  objective: Document system media downgrading actions.
+  group: mp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: mp-8.2
+  title: Equipment Testing
+  objective: 'Test downgrading equipment and procedures {{ insert: param, mp-8.2_prm_1 }} to ensure that downgrading actions
+    are being achieved.'
+  group: mp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: mp-8.3
+  title: Controlled Unclassified Information
+  objective: Downgrade system media containing controlled unclassified information prior to public release.
+  group: mp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: mp-8.4
+  title: Classified Information
+  objective: Downgrade system media containing classified information prior to release to individuals without required 
+    access authorizations.
+  group: mp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: mp-8
+  title: Media Downgrading
+  objective: 'Establish {{ insert: param, mp-08_odp.01 }} that includes employing downgrading mechanisms with strength and
+    integrity commensurate with the security category or classification of the information; Verify that the system media downgrading
+    process is commensurate with the security category and/or classification level of the information to be removed and the
+    access authorizations of the potential recipients of the downgraded information; Identify {{ insert: param, mp-08_odp.02
+    }} ; and Downgrade the identified system media using the established process.'
+  group: mp
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-1
+  title: Policy and Procedures
+  objective: 'Develop, document, and disseminate to {{ insert: param, pe-1_prm_1 }}: Designate an {{ insert: param, pe-01_odp.04
+    }} to manage the development, documentation, and dissemination of the physical and environmental protection policy and
+    procedures; and Review and update the current physical and environmental protection:'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-2.1
+  title: Access by Position or Role
+  objective: Authorize physical access to the facility where the system resides based on position or role.
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-2.2
+  title: Two Forms of Identification
+  objective: 'Require two forms of identification from the following forms of identification for visitor access to the facility
+    where the system resides: {{ insert: param, pe-02.02_odp }}.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-2.3
+  title: Restrict Unescorted Access
+  objective: 'Restrict unescorted access to the facility where the system resides to personnel with {{ insert: param, pe-02.03_odp.01
+    }}.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-2
+  title: Physical Access Authorizations
+  objective: 'Develop, approve, and maintain a list of individuals with authorized access to the facility where the system
+    resides; Issue authorization credentials for facility access; Review the access list detailing authorized facility access
+    by individuals {{ insert: param, pe-02_odp }} ; and Remove individuals from the facility access list when access is no
+    longer required.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-3.1
+  title: System Access
+  objective: 'Enforce physical access authorizations to the system in addition to the physical access controls for the facility
+    at {{ insert: param, pe-03.01_odp }}.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: pe-3.2
+  title: Facility and Systems
+  objective: 'Perform security checks {{ insert: param, pe-03.02_odp }} at the physical perimeter of the facility or system
+    for exfiltration of information or removal of system components.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-3.3
+  title: Continuous Guards
+  objective: 'Employ guards to control {{ insert: param, pe-03.03_odp }} to the facility where the system resides 24 hours
+    per day, 7 days per week.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-3.4
+  title: Lockable Casings
+  objective: 'Use lockable physical casings to protect {{ insert: param, pe-03.04_odp }} from unauthorized physical access.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-3.5
+  title: Tamper Protection
+  objective: 'Employ {{ insert: param, pe-03.05_odp.01 }} to {{ insert: param, pe-03.05_odp.02 }} physical tampering or alteration
+    of {{ insert: param, pe-03.05_odp.03 }} within the system.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-3.6
+  title: Facility Penetration Testing
+  objective: Facility Penetration Testing
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-3.7
+  title: Physical Barriers
+  objective: Limit access using physical barriers.
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-3.8
+  title: Access Control Vestibules
+  objective: 'Employ access control vestibules at {{ insert: param, pe-03.08_odp }}.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-3
+  title: Physical Access Control
+  objective: 'Enforce physical access authorizations at {{ insert: param, pe-03_odp.01 }} by: Maintain physical access audit
+    logs for {{ insert: param, pe-03_odp.04 }}; Control access to areas within the facility designated as publicly accessible
+    by implementing the following controls: {{ insert: param, pe-03_odp.05 }}; Escort visitors and control visitor activity
+    {{ insert: param, pe-03_odp.06 }}; Secure keys, combinations, and other physical access devices; Inventory {{ insert:
+    param, pe-03_odp.07 }} every {{ insert: param, pe-03_odp.08 }} ; and Change combinations and keys {{ insert: param, pe-3_prm_9
+    }} and/or when keys are lost, combinations are compromised, or when individuals possessing the keys or combinations are
+    transferred or terminated.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-4
+  title: Access Control for Transmission
+  objective: 'Control physical access to {{ insert: param, pe-04_odp.01 }} within organizational facilities using {{ insert:
+    param, pe-04_odp.02 }}.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: pe-5.1
+  title: Access to Output by Authorized Individuals
+  objective: Access to Output by Authorized Individuals
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: pe-5.2
+  title: Link to Individual Identity
+  objective: Link individual identity to receipt of output from output devices.
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: pe-5.3
+  title: Marking Output Devices
+  objective: Marking Output Devices
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: pe-5
+  title: Access Control for Output Devices
+  objective: 'Control physical access to output from {{ insert: param, pe-05_odp }} to prevent unauthorized individuals from
+    obtaining the output.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: pe-6.1
+  title: Intrusion Alarms and Surveillance Equipment
+  objective: Monitor physical access to the facility where the system resides using physical intrusion alarms and 
+    surveillance equipment.
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: pe-6.2
+  title: Automated Intrusion Recognition and Responses
+  objective: 'Recognize {{ insert: param, pe-06.02_odp.01 }} and initiate {{ insert: param, pe-06.02_odp.02 }} using {{ insert:
+    param, pe-06.02_odp.03 }}.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-6.3
+  title: Video Surveillance
+  objective: 'Employ video surveillance of {{ insert: param, pe-06.03_odp.01 }}; Review video recordings {{ insert: param,
+    pe-06.03_odp.02 }} ; and Retain video recordings for {{ insert: param, pe-06.03_odp.03 }}.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-6.4
+  title: Monitoring Physical Access to Systems
+  objective: 'Monitor physical access to the system in addition to the physical access monitoring of the facility at {{ insert:
+    param, pe-06.04_odp }}.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: pe-6
+  title: Monitoring Physical Access
+  objective: 'Monitor physical access to the facility where the system resides to detect and respond to physical security
+    incidents; Review physical access logs {{ insert: param, pe-06_odp.01 }} and upon occurrence of {{ insert: param, pe-06_odp.02
+    }} ; and Coordinate results of reviews and investigations with the organizational incident response capability.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-7
+  title: Visitor Control
+  objective: Visitor Control
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-8.1
+  title: Automated Records Maintenance and Review
+  objective: 'Maintain and review visitor access records using {{ insert: param, pe-8.1_prm_1 }}.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: pe-8.2
+  title: Physical Access Records
+  objective: Physical Access Records
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-8.3
+  title: Limit Personally Identifiable Information Elements
+  objective: 'Limit personally identifiable information contained in visitor access records to the following elements identified
+    in the privacy risk assessment: {{ insert: param, pe-08.03_odp }}.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-8
+  title: Visitor Access Records
+  objective: 'Maintain visitor access records to the facility where the system resides for {{ insert: param, pe-08_odp.01
+    }}; Review visitor access records {{ insert: param, pe-08_odp.02 }} ; and Report anomalies in visitor access records to
+    {{ insert: param, pe-08_odp.03 }}.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-9.1
+  title: Redundant Cabling
+  objective: 'Employ redundant power cabling paths that are physically separated by {{ insert: param, pe-09.01_odp }}.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: pe-9.2
+  title: Automatic Voltage Controls
+  objective: 'Employ automatic voltage controls for {{ insert: param, pe-09.02_odp }}.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: pe-9
+  title: Power Equipment and Cabling
+  objective: Protect power equipment and power cabling for the system from damage and destruction.
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: pe-10.1
+  title: Accidental and Unauthorized Activation
+  objective: Accidental and Unauthorized Activation
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: pe-10
+  title: Emergency Shutoff
+  objective: 'Provide the capability of shutting off power to {{ insert: param, pe-10_odp.01 }} in emergency situations; Place
+    emergency shutoff switches or devices in {{ insert: param, pe-10_odp.02 }} to facilitate access for authorized personnel;
+    and Protect emergency power shutoff capability from unauthorized activation.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: pe-11.1
+  title: Alternate Power Supply — Minimal Operational Capability
+  objective: 'Provide an alternate power supply for the system that is activated {{ insert: param, pe-11.01_odp }} and that
+    can maintain minimally required operational capability in the event of an extended loss of the primary power source.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: pe-11.2
+  title: Alternate Power Supply — Self-contained
+  objective: 'Provide an alternate power supply for the system that is activated {{ insert: param, pe-11.02_odp.01 }} and
+    that is:'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: pe-11
+  title: Emergency Power
+  objective: 'Provide an uninterruptible power supply to facilitate {{ insert: param, pe-11_odp }} in the event of a primary
+    power source loss.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: pe-12.1
+  title: Essential Mission and Business Functions
+  objective: Provide emergency lighting for all areas within the facility supporting essential mission and business 
+    functions.
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-12
+  title: Emergency Lighting
+  objective: Employ and maintain automatic emergency lighting for the system that activates in the event of a power 
+    outage or disruption and that covers emergency exits and evacuation routes within the facility.
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-13.1
+  title: Detection Systems — Automatic Activation and Notification
+  objective: 'Employ fire detection systems that activate automatically and notify {{ insert: param, pe-13.01_odp.01 }} and
+    {{ insert: param, pe-13.01_odp.02 }} in the event of a fire.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: pe-13.2
+  title: Suppression Systems — Automatic Activation and Notification
+  objective: 'Employ fire suppression systems that activate automatically and notify {{ insert: param, pe-13.02_odp.01 }}
+    and {{ insert: param, pe-13.02_odp.02 }} ; and Employ an automatic fire suppression capability when the facility is not
+    staffed on a continuous basis.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: pe-13.3
+  title: Automatic Fire Suppression
+  objective: Automatic Fire Suppression
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-13.4
+  title: Inspections
+  objective: 'Ensure that the facility undergoes {{ insert: param, pe-13.04_odp.01 }} fire protection inspections by authorized
+    and qualified inspectors and identified deficiencies are resolved within {{ insert: param, pe-13.04_odp.02 }}.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-13
+  title: Fire Protection
+  objective: Employ and maintain fire detection and suppression systems that are supported by an independent energy 
+    source.
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-14.1
+  title: Automatic Controls
+  objective: 'Employ the following automatic environmental controls in the facility to prevent fluctuations potentially harmful
+    to the system: {{ insert: param, pe-14.01_odp }}.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-14.2
+  title: Monitoring with Alarms and Notifications
+  objective: 'Employ environmental control monitoring that provides an alarm or notification of changes potentially harmful
+    to personnel or equipment to {{ insert: param, pe-14.02_odp }}.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-14
+  title: Environmental Controls
+  objective: 'Maintain {{ insert: param, pe-14_odp.01 }} levels within the facility where the system resides at {{ insert:
+    param, pe-14_odp.03 }} ; and Monitor environmental control levels {{ insert: param, pe-14_odp.04 }}.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-15.1
+  title: Automation Support
+  objective: 'Detect the presence of water near the system and alert {{ insert: param, pe-15.01_odp.01 }} using {{ insert:
+    param, pe-15.01_odp.02 }}.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: pe-15
+  title: Water Damage Protection
+  objective: Protect the system from damage resulting from water leakage by providing master shutoff or isolation valves
+    that are accessible, working properly, and known to key personnel.
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-16
+  title: Delivery and Removal
+  objective: 'Authorize and control {{ insert: param, pe-16_prm_1 }} entering and exiting the facility; and Maintain records
+    of the system components.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-17
+  title: Alternate Work Site
+  objective: 'Determine and document the {{ insert: param, pe-17_odp.01 }} allowed for use by employees; Employ the following
+    controls at alternate work sites: {{ insert: param, pe-17_odp.02 }}; Assess the effectiveness of controls at alternate
+    work sites; and Provide a means for employees to communicate with information security and privacy personnel in case of
+    incidents.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: pe-18.1
+  title: Facility Site
+  objective: Facility Site
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: pe-18
+  title: Location of System Components
+  objective: 'Position system components within the facility to minimize potential damage from {{ insert: param, pe-18_odp
+    }} and to minimize the opportunity for unauthorized access.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: pe-19.1
+  title: National Emissions Policies and Procedures
+  objective: Protect system components, associated data communications, and networks in accordance with national 
+    Emissions Security policies and procedures based on the security category or classification of the information.
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-19
+  title: Information Leakage
+  objective: Protect the system from information leakage due to electromagnetic signals emanations.
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-20
+  title: Asset Monitoring and Tracking
+  objective: 'Employ {{ insert: param, pe-20_odp.01 }} to track and monitor the location and movement of {{ insert: param,
+    pe-20_odp.02 }} within {{ insert: param, pe-20_odp.03 }}.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-21
+  title: Electromagnetic Pulse Protection
+  objective: 'Employ {{ insert: param, pe-21_odp.01 }} against electromagnetic pulse damage for {{ insert: param, pe-21_odp.02
+    }}.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-22
+  title: Component Marking
+  objective: 'Mark {{ insert: param, pe-22_odp }} indicating the impact level or classification level of the information permitted
+    to be processed, stored, or transmitted by the hardware component.'
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pe-23
+  title: Facility Location
+  objective: Plan the location or site of the facility where the system resides considering physical and environmental 
+    hazards; and For existing facilities, consider the physical and environmental hazards in the organizational risk 
+    management strategy.
+  group: pe
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pl-1
+  title: Policy and Procedures
+  objective: 'Develop, document, and disseminate to {{ insert: param, pl-1_prm_1 }}: Designate an {{ insert: param, pl-01_odp.04
+    }} to manage the development, documentation, and dissemination of the planning policy and procedures; and Review and update
+    the current planning:'
+  group: pl
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pl-2.1
+  title: Concept of Operations
+  objective: Concept of Operations
+  group: pl
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pl-2.2
+  title: Functional Architecture
+  objective: Functional Architecture
+  group: pl
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pl-2.3
+  title: Plan and Coordinate with Other Organizational Entities
+  objective: Plan and Coordinate with Other Organizational Entities
+  group: pl
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pl-2
+  title: System Security and Privacy Plans
+  objective: 'Develop security and privacy plans for the system that: Distribute copies of the plans and communicate subsequent
+    changes to the plans to {{ insert: param, pl-02_odp.02 }}; Review the plans {{ insert: param, pl-02_odp.03 }}; Update
+    the plans to address changes to the system and environment of operation or problems identified during plan implementation
+    or control assessments; and Protect the plans from unauthorized disclosure and modification.'
+  group: pl
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pl-3
+  title: System Security Plan Update
+  objective: System Security Plan Update
+  group: pl
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pl-4.1
+  title: Social Media and External Site/Application Usage Restrictions
+  objective: 'Include in the rules of behavior, restrictions on:'
+  group: pl
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pl-4
+  title: Rules of Behavior
+  objective: 'Establish and provide to individuals requiring access to the system, the rules that describe their responsibilities
+    and expected behavior for information and system usage, security, and privacy; Receive a documented acknowledgment from
+    such individuals, indicating that they have read, understand, and agree to abide by the rules of behavior, before authorizing
+    access to information and the system; Review and update the rules of behavior {{ insert: param, pl-04_odp.01 }} ; and
+    Require individuals who have acknowledged a previous version of the rules of behavior to read and re-acknowledge {{ insert:
+    param, pl-04_odp.02 }}.'
+  group: pl
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pl-5
+  title: Privacy Impact Assessment
+  objective: Privacy Impact Assessment
+  group: pl
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pl-6
+  title: Security-related Activity Planning
+  objective: Security-related Activity Planning
+  group: pl
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pl-7
+  title: Concept of Operations
+  objective: 'Develop a Concept of Operations (CONOPS) for the system describing how the organization intends to operate the
+    system from the perspective of information security and privacy; and Review and update the CONOPS {{ insert: param, pl-07_odp
+    }}.'
+  group: pl
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pl-8.1
+  title: Defense in Depth
+  objective: 'Design the security and privacy architectures for the system using a defense-in-depth approach that:'
+  group: pl
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: pl-8.2
+  title: Supplier Diversity
+  objective: 'Require that {{ insert: param, pl-08.02_odp.01 }} allocated to {{ insert: param, pl-08.02_odp.02 }} are obtained
+    from different suppliers.'
+  group: pl
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: pl-8
+  title: Security and Privacy Architectures
+  objective: 'Develop security and privacy architectures for the system that: Review and update the architectures {{ insert:
+    param, pl-08_odp }} to reflect changes in the enterprise architecture; and Reflect planned architecture changes in security
+    and privacy plans, Concept of Operations (CONOPS), criticality analysis, organizational procedures, and procurements and
+    acquisitions.'
+  group: pl
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: pl-9
+  title: Central Management
+  objective: 'Centrally manage {{ insert: param, pl-09_odp }}.'
+  group: pl
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pl-10
+  title: Baseline Selection
+  objective: Select a control baseline for the system.
+  group: pl
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pl-11
+  title: Baseline Tailoring
+  objective: Tailor the selected control baseline by applying specified tailoring actions.
+  group: pl
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-1
+  title: Information Security Program Plan
+  objective: 'Develop and disseminate an organization-wide information security program plan that: Review and update the organization-wide
+    information security program plan {{ insert: param, pm-01_odp.01 }} and following {{ insert: param, pm-01_odp.02 }} ;
+    and Protect the information security program plan from unauthorized disclosure and modification.'
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-2
+  title: Information Security Program Leadership Role
+  objective: Appoint a senior agency information security officer with the mission and resources to coordinate, develop,
+    implement, and maintain an organization-wide information security program.
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-3
+  title: Information Security and Privacy Resources
+  objective: Include the resources needed to implement the information security and privacy programs in capital planning
+    and investment requests and document all exceptions to this requirement; Prepare documentation required for 
+    addressing information security and privacy programs in capital planning and investment requests in accordance with 
+    applicable laws, executive orders, directives, policies, regulations, standards; and Make available for expenditure,
+    the planned information security and privacy resources.
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-4
+  title: Plan of Action and Milestones Process
+  objective: 'Implement a process to ensure that plans of action and milestones for the information security, privacy, and
+    supply chain risk management programs and associated organizational systems: Review plans of action and milestones for
+    consistency with the organizational risk management strategy and organization-wide priorities for risk response actions.'
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-5.1
+  title: Inventory of Personally Identifiable Information
+  objective: 'Establish, maintain, and update {{ insert: param, pm-05.01_odp }} an inventory of all systems, applications,
+    and projects that process personally identifiable information.'
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-5
+  title: System Inventory
+  objective: 'Develop and update {{ insert: param, pm-05_odp }} an inventory of organizational systems.'
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-6
+  title: Measures of Performance
+  objective: Develop, monitor, and report on the results of information security and privacy measures of performance.
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-7.1
+  title: Offloading
+  objective: 'Offload {{ insert: param, pm-07.01_odp }} to other systems, system components, or an external provider.'
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-7
+  title: Enterprise Architecture
+  objective: Develop and maintain an enterprise architecture with consideration for information security, privacy, and 
+    the resulting risk to organizational operations and assets, individuals, other organizations, and the Nation.
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-8
+  title: Critical Infrastructure Plan
+  objective: Address information security and privacy issues in the development, documentation, and updating of a 
+    critical infrastructure and key resources protection plan.
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-9
+  title: Risk Management Strategy
+  objective: 'Develops a comprehensive strategy to manage: Implement the risk management strategy consistently across the
+    organization; and Review and update the risk management strategy {{ insert: param, pm-09_odp }} or as required, to address
+    organizational changes.'
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-10
+  title: Authorization Process
+  objective: Manage the security and privacy state of organizational systems and the environments in which those systems
+    operate through authorization processes; Designate individuals to fulfill specific roles and responsibilities within
+    the organizational risk management process; and Integrate the authorization processes into an organization-wide risk
+    management program.
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-11
+  title: Mission and Business Process Definition
+  objective: 'Define organizational mission and business processes with consideration for information security and privacy
+    and the resulting risk to organizational operations, organizational assets, individuals, other organizations, and the
+    Nation; and Determine information protection and personally identifiable information processing needs arising from the
+    defined mission and business processes; and Review and revise the mission and business processes {{ insert: param, pm-11_odp
+    }}.'
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-12
+  title: Insider Threat Program
+  objective: Implement an insider threat program that includes a cross-discipline insider threat incident handling team.
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-13
+  title: Security and Privacy Workforce
+  objective: Establish a security and privacy workforce development and improvement program.
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-14
+  title: Testing, Training, and Monitoring
+  objective: 'Implement a process for ensuring that organizational plans for conducting security and privacy testing, training,
+    and monitoring activities associated with organizational systems: Review testing, training, and monitoring plans for consistency
+    with the organizational risk management strategy and organization-wide priorities for risk response actions.'
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-15
+  title: Security and Privacy Groups and Associations
+  objective: 'Establish and institutionalize contact with selected groups and associations within the security and privacy
+    communities:'
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-16.1
+  title: Automated Means for Sharing Threat Intelligence
+  objective: Employ automated mechanisms to maximize the effectiveness of sharing threat intelligence information.
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-16
+  title: Threat Awareness Program
+  objective: Implement a threat awareness program that includes a cross-organization information-sharing capability for 
+    threat intelligence.
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-17
+  title: Protecting Controlled Unclassified Information on External Systems
+  objective: 'Establish policy and procedures to ensure that requirements for the protection of controlled unclassified information
+    that is processed, stored or transmitted on external systems, are implemented in accordance with applicable laws, executive
+    orders, directives, policies, regulations, and standards; and Review and update the policy and procedures {{ insert: param,
+    pm-17_prm_1 }}.'
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-18
+  title: Privacy Program Plan
+  objective: 'Develop and disseminate an organization-wide privacy program plan that provides an overview of the agency’s
+    privacy program, and: Update the plan {{ insert: param, pm-18_odp }} and to address changes in federal privacy laws and
+    policy and organizational changes and problems identified during plan implementation or privacy control assessments.'
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-19
+  title: Privacy Program Leadership Role
+  objective: Appoint a senior agency official for privacy with the authority, mission, accountability, and resources to 
+    coordinate, develop, and implement, applicable privacy requirements and manage privacy risks through the 
+    organization-wide privacy program.
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-20.1
+  title: Privacy Policies on Websites, Applications, and Digital Services
+  objective: 'Develop and post privacy policies on all external-facing websites, mobile applications, and other digital services,
+    that:'
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-20
+  title: Dissemination of Privacy Program Information
+  objective: 'Maintain a central resource webpage on the organization’s principal public website that serves as a central
+    source of information about the organization’s privacy program and that:'
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-21
+  title: Accounting of Disclosures
+  objective: 'Develop and maintain an accurate accounting of disclosures of personally identifiable information, including:
+    Retain the accounting of disclosures for the length of the time the personally identifiable information is maintained
+    or five years after the disclosure is made, whichever is longer; and Make the accounting of disclosures available to the
+    individual to whom the personally identifiable information relates upon request.'
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-22
+  title: Personally Identifiable Information Quality Management
+  objective: 'Develop and document organization-wide policies and procedures for:'
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-23
+  title: Data Governance Body
+  objective: 'Establish a Data Governance Body consisting of {{ insert: param, pm-23_odp.01 }} with {{ insert: param, pm-23_odp.02
+    }}.'
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-24
+  title: Data Integrity Board
+  objective: 'Establish a Data Integrity Board to:'
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-25
+  title: Minimization of Personally Identifiable Information Used in Testing, Training, and Research
+  objective: 'Develop, document, and implement policies and procedures that address the use of personally identifiable information
+    for internal testing, training, and research; Limit or minimize the amount of personally identifiable information used
+    for internal testing, training, and research purposes; Authorize the use of personally identifiable information when such
+    information is required for internal testing, training, and research; and Review and update policies and procedures {{
+    insert: param, pm-25_prm_1 }}.'
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-26
+  title: Complaint Management
+  objective: 'Implement a process for receiving and responding to complaints, concerns, or questions from individuals about
+    the organizational security and privacy practices that includes:'
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-27
+  title: Privacy Reporting
+  objective: 'Develop {{ insert: param, pm-27_odp.01 }} and disseminate to: Review and update privacy reports {{ insert: param,
+    pm-27_odp.04 }}.'
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-28
+  title: Risk Framing
+  objective: 'Identify and document: Distribute the results of risk framing activities to {{ insert: param, pm-28_odp.01 }}
+    ; and Review and update risk framing considerations {{ insert: param, pm-28_odp.02 }}.'
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-29
+  title: Risk Management Program Leadership Roles
+  objective: Appoint a Senior Accountable Official for Risk Management to align organizational information security and 
+    privacy management processes with strategic, operational, and budgetary planning processes; and Establish a Risk 
+    Executive (function) to view and analyze risk from an organization-wide perspective and ensure management of risk is
+    consistent across the organization.
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-30.1
+  title: Suppliers of Critical or Mission-essential Items
+  objective: Identify, prioritize, and assess suppliers of critical or mission-essential technologies, products, and 
+    services.
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-30
+  title: Supply Chain Risk Management Strategy
+  objective: 'Develop an organization-wide strategy for managing supply chain risks associated with the development, acquisition,
+    maintenance, and disposal of systems, system components, and system services; Implement the supply chain risk management
+    strategy consistently across the organization; and Review and update the supply chain risk management strategy on {{ insert:
+    param, pm-30_odp }} or as required, to address organizational changes.'
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-31
+  title: Continuous Monitoring Strategy
+  objective: 'Develop an organization-wide continuous monitoring strategy and implement continuous monitoring programs that
+    include:'
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pm-32
+  title: Purposing
+  objective: 'Analyze {{ insert: param, pm-32_odp }} supporting mission essential services or functions to ensure that the
+    information resources are being used consistent with their intended purpose.'
+  group: pm
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ps-1
+  title: Policy and Procedures
+  objective: 'Develop, document, and disseminate to {{ insert: param, ps-1_prm_1 }}: Designate an {{ insert: param, ps-01_odp.04
+    }} to manage the development, documentation, and dissemination of the personnel security policy and procedures; and Review
+    and update the current personnel security:'
+  group: ps
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ps-2
+  title: Position Risk Designation
+  objective: 'Assign a risk designation to all organizational positions; Establish screening criteria for individuals filling
+    those positions; and Review and update position risk designations {{ insert: param, ps-02_odp }}.'
+  group: ps
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ps-3.1
+  title: Classified Information
+  objective: Verify that individuals accessing a system processing, storing, or transmitting classified information are 
+    cleared and indoctrinated to the highest classification level of the information to which they have access on the 
+    system.
+  group: ps
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ps-3.2
+  title: Formal Indoctrination
+  objective: Verify that individuals accessing a system processing, storing, or transmitting types of classified 
+    information that require formal indoctrination, are formally indoctrinated for all the relevant types of information
+    to which they have access on the system.
+  group: ps
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ps-3.3
+  title: Information Requiring Special Protective Measures
+  objective: 'Verify that individuals accessing a system processing, storing, or transmitting information requiring special
+    protection:'
+  group: ps
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ps-3.4
+  title: Citizenship Requirements
+  objective: 'Verify that individuals accessing a system processing, storing, or transmitting {{ insert: param, ps-03.04_odp.01
+    }} meet {{ insert: param, ps-03.04_odp.02 }}.'
+  group: ps
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ps-3
+  title: Personnel Screening
+  objective: 'Screen individuals prior to authorizing access to the system; and Rescreen individuals in accordance with {{
+    insert: param, ps-3_prm_1 }}.'
+  group: ps
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ps-4.1
+  title: Post-employment Requirements
+  objective: Notify terminated individuals of applicable, legally binding post-employment requirements for the 
+    protection of organizational information; and Require terminated individuals to sign an acknowledgment of 
+    post-employment requirements as part of the organizational termination process.
+  group: ps
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ps-4.2
+  title: Automated Actions
+  objective: 'Use {{ insert: param, ps-04.02_odp.01 }} to {{ insert: param, ps-04.02_odp.02 }}.'
+  group: ps
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: ps-4
+  title: Personnel Termination
+  objective: 'Upon termination of individual employment:'
+  group: ps
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ps-5
+  title: Personnel Transfer
+  objective: 'Review and confirm ongoing operational need for current logical and physical access authorizations to systems
+    and facilities when individuals are reassigned or transferred to other positions within the organization; Initiate {{
+    insert: param, ps-05_odp.01 }} within {{ insert: param, ps-05_odp.02 }}; Modify access authorization as needed to correspond
+    with any changes in operational need due to reassignment or transfer; and Notify {{ insert: param, ps-05_odp.03 }} within
+    {{ insert: param, ps-05_odp.04 }}.'
+  group: ps
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ps-6.1
+  title: Information Requiring Special Protection
+  objective: Information Requiring Special Protection
+  group: ps
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ps-6.2
+  title: Classified Information Requiring Special Protection
+  objective: 'Verify that access to classified information requiring special protection is granted only to individuals who:'
+  group: ps
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ps-6.3
+  title: Post-employment Requirements
+  objective: Notify individuals of applicable, legally binding post-employment requirements for protection of 
+    organizational information; and Require individuals to sign an acknowledgment of these requirements, if applicable, 
+    as part of granting initial access to covered information.
+  group: ps
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ps-6
+  title: Access Agreements
+  objective: 'Develop and document access agreements for organizational systems; Review and update the access agreements {{
+    insert: param, ps-06_odp.01 }} ; and Verify that individuals requiring access to organizational information and systems:'
+  group: ps
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ps-7
+  title: External Personnel Security
+  objective: 'Establish personnel security requirements, including security roles and responsibilities for external providers;
+    Require external providers to comply with personnel security policies and procedures established by the organization;
+    Document personnel security requirements; Require external providers to notify {{ insert: param, ps-07_odp.01 }} of any
+    personnel transfers or terminations of external personnel who possess organizational credentials and/or badges, or who
+    have system privileges within {{ insert: param, ps-07_odp.02 }} ; and Monitor provider compliance with personnel security
+    requirements.'
+  group: ps
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ps-8
+  title: Personnel Sanctions
+  objective: 'Employ a formal sanctions process for individuals failing to comply with established information security and
+    privacy policies and procedures; and Notify {{ insert: param, ps-08_odp.01 }} within {{ insert: param, ps-08_odp.02 }}
+    when a formal employee sanctions process is initiated, identifying the individual sanctioned and the reason for the sanction.'
+  group: ps
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ps-9
+  title: Position Descriptions
+  objective: Incorporate security and privacy roles and responsibilities into organizational position descriptions.
+  group: ps
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pt-1
+  title: Policy and Procedures
+  objective: 'Develop, document, and disseminate to {{ insert: param, pt-1_prm_1 }}: Designate an {{ insert: param, pt-01_odp.04
+    }} to manage the development, documentation, and dissemination of the personally identifiable information processing and
+    transparency policy and procedures; and Review and update the current personally identifiable information processing and
+    transparency:'
+  group: pt
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pt-2.1
+  title: Data Tagging
+  objective: 'Attach data tags containing {{ insert: param, pt-02.01_odp.01 }} to {{ insert: param, pt-02.01_odp.02 }}.'
+  group: pt
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pt-2.2
+  title: Automation
+  objective: 'Manage enforcement of the authorized processing of personally identifiable information using {{ insert: param,
+    pt-02.02_odp }}.'
+  group: pt
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pt-2
+  title: Authority to Process Personally Identifiable Information
+  objective: 'Determine and document the {{ insert: param, pt-02_odp.01 }} that permits the {{ insert: param, pt-02_odp.02
+    }} of personally identifiable information; and Restrict the {{ insert: param, pt-02_odp.03 }} of personally identifiable
+    information to only that which is authorized.'
+  group: pt
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pt-3.1
+  title: Data Tagging
+  objective: 'Attach data tags containing the following purposes to {{ insert: param, pt-03.01_odp.02 }}: {{ insert: param,
+    pt-03.01_odp.01 }}.'
+  group: pt
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pt-3.2
+  title: Automation
+  objective: 'Track processing purposes of personally identifiable information using {{ insert: param, pt-03.02_odp }}.'
+  group: pt
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pt-3
+  title: Personally Identifiable Information Processing Purposes
+  objective: 'Identify and document the {{ insert: param, pt-03_odp.01 }} for processing personally identifiable information;
+    Describe the purpose(s) in the public privacy notices and policies of the organization; Restrict the {{ insert: param,
+    pt-03_odp.02 }} of personally identifiable information to only that which is compatible with the identified purpose(s);
+    and Monitor changes in processing personally identifiable information and implement {{ insert: param, pt-03_odp.03 }}
+    to ensure that any changes are made in accordance with {{ insert: param, pt-03_odp.04 }}.'
+  group: pt
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pt-4.1
+  title: Tailored Consent
+  objective: 'Provide {{ insert: param, pt-04.01_odp }} to allow individuals to tailor processing permissions to selected
+    elements of personally identifiable information.'
+  group: pt
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pt-4.2
+  title: Just-in-time Consent
+  objective: 'Present {{ insert: param, pt-04.02_odp.01 }} to individuals at {{ insert: param, pt-04.02_odp.02 }} and in conjunction
+    with {{ insert: param, pt-04.02_odp.03 }}.'
+  group: pt
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pt-4.3
+  title: Revocation
+  objective: 'Implement {{ insert: param, pt-04.03_odp }} for individuals to revoke consent to the processing of their personally
+    identifiable information.'
+  group: pt
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pt-4
+  title: Consent
+  objective: 'Implement {{ insert: param, pt-04_odp }} for individuals to consent to the processing of their personally identifiable
+    information prior to its collection that facilitate individuals’ informed decision-making.'
+  group: pt
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pt-5.1
+  title: Just-in-time Notice
+  objective: 'Present notice of personally identifiable information processing to individuals at a time and location where
+    the individual provides personally identifiable information or in conjunction with a data action, or {{ insert: param,
+    pt-05.01_odp }}.'
+  group: pt
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pt-5.2
+  title: Privacy Act Statements
+  objective: Include Privacy Act statements on forms that collect information that will be maintained in a Privacy Act 
+    system of records, or provide Privacy Act statements on separate forms that can be retained by individuals.
+  group: pt
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pt-5
+  title: Privacy Notice
+  objective: 'Provide notice to individuals about the processing of personally identifiable information that:'
+  group: pt
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pt-6.1
+  title: Routine Uses
+  objective: 'Review all routine uses published in the system of records notice at {{ insert: param, pt-06.01_odp }} to ensure
+    continued accuracy, and to ensure that routine uses continue to be compatible with the purpose for which the information
+    was collected.'
+  group: pt
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pt-6.2
+  title: Exemption Rules
+  objective: 'Review all Privacy Act exemptions claimed for the system of records at {{ insert: param, pt-06.02_odp }} to
+    ensure they remain appropriate and necessary in accordance with law, that they have been promulgated as regulations, and
+    that they are accurately described in the system of records notice.'
+  group: pt
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pt-6
+  title: System of Records Notice
+  objective: 'For systems that process information that will be maintained in a Privacy Act system of records:'
+  group: pt
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pt-7.1
+  title: Social Security Numbers
+  objective: 'When a system processes Social Security numbers:'
+  group: pt
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pt-7.2
+  title: First Amendment Information
+  objective: Prohibit the processing of information describing how any individual exercises rights guaranteed by the 
+    First Amendment unless expressly authorized by statute or by the individual or unless pertinent to and within the 
+    scope of an authorized law enforcement activity.
+  group: pt
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pt-7
+  title: Specific Categories of Personally Identifiable Information
+  objective: 'Apply {{ insert: param, pt-07_odp }} for specific categories of personally identifiable information.'
+  group: pt
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: pt-8
+  title: Computer Matching Requirements
+  objective: 'When a system or organization processes information for the purpose of conducting a matching program:'
+  group: pt
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ra-1
+  title: Policy and Procedures
+  objective: 'Develop, document, and disseminate to {{ insert: param, ra-1_prm_1 }}: Designate an {{ insert: param, ra-01_odp.04
+    }} to manage the development, documentation, and dissemination of the risk assessment policy and procedures; and Review
+    and update the current risk assessment:'
+  group: ra
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ra-2.1
+  title: Impact-level Prioritization
+  objective: Conduct an impact-level prioritization of organizational systems to obtain additional granularity on system
+    impact levels.
+  group: ra
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ra-2
+  title: Security Categorization
+  objective: Categorize the system and information it processes, stores, and transmits; Document the security 
+    categorization results, including supporting rationale, in the security plan for the system; and Verify that the 
+    authorizing official or authorizing official designated representative reviews and approves the security 
+    categorization decision.
+  group: ra
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ra-3.1
+  title: Supply Chain Risk Assessment
+  objective: 'Assess supply chain risks associated with {{ insert: param, ra-03.01_odp.01 }} ; and Update the supply chain
+    risk assessment {{ insert: param, ra-03.01_odp.02 }} , when there are significant changes to the relevant supply chain,
+    or when changes to the system, environments of operation, or other conditions may necessitate a change in the supply chain.'
+  group: ra
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ra-3.2
+  title: Use of All-source Intelligence
+  objective: Use all-source intelligence to assist in the analysis of risk.
+  group: ra
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ra-3.3
+  title: Dynamic Threat Awareness
+  objective: 'Determine the current cyber threat environment on an ongoing basis using {{ insert: param, ra-03.03_odp }}.'
+  group: ra
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ra-3.4
+  title: Predictive Cyber Analytics
+  objective: 'Employ the following advanced automation and analytics capabilities to predict and identify risks to {{ insert:
+    param, ra-03.04_odp.02 }}: {{ insert: param, ra-3.4_prm_2 }}.'
+  group: ra
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ra-3
+  title: Risk Assessment
+  objective: 'Conduct a risk assessment, including: Integrate risk assessment results and risk management decisions from the
+    organization and mission or business process perspectives with system-level risk assessments; Document risk assessment
+    results in {{ insert: param, ra-03_odp.01 }}; Review risk assessment results {{ insert: param, ra-03_odp.03 }}; Disseminate
+    risk assessment results to {{ insert: param, ra-03_odp.04 }} ; and Update the risk assessment {{ insert: param, ra-03_odp.05
+    }} or when there are significant changes to the system, its environment of operation, or other conditions that may impact
+    the security or privacy state of the system.'
+  group: ra
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ra-4
+  title: Risk Assessment Update
+  objective: Risk Assessment Update
+  group: ra
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ra-5.1
+  title: Update Tool Capability
+  objective: Update Tool Capability
+  group: ra
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ra-5.2
+  title: Update Vulnerabilities to Be Scanned
+  objective: 'Update the system vulnerabilities to be scanned {{ insert: param, ra-05.02_odp.01 }}.'
+  group: ra
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ra-5.3
+  title: Breadth and Depth of Coverage
+  objective: Define the breadth and depth of vulnerability scanning coverage.
+  group: ra
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ra-5.4
+  title: Discoverable Information
+  objective: 'Determine information about the system that is discoverable and take {{ insert: param, ra-05.04_odp }}.'
+  group: ra
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: ra-5.5
+  title: Privileged Access
+  objective: 'Implement privileged access authorization to {{ insert: param, ra-05.05_odp.01 }} for {{ insert: param, ra-05.05_odp.02
+    }}.'
+  group: ra
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ra-5.6
+  title: Automated Trend Analyses
+  objective: 'Compare the results of multiple vulnerability scans using {{ insert: param, ra-05.06_odp }}.'
+  group: ra
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ra-5.7
+  title: Automated Detection and Notification of Unauthorized Components
+  objective: Automated Detection and Notification of Unauthorized Components
+  group: ra
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ra-5.8
+  title: Review Historic Audit Logs
+  objective: 'Review historic audit logs to determine if a vulnerability identified in a {{ insert: param, ra-05.08_odp.01
+    }} has been previously exploited within an {{ insert: param, ra-05.08_odp.02 }}.'
+  group: ra
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ra-5.9
+  title: Penetration Testing and Analyses
+  objective: Penetration Testing and Analyses
+  group: ra
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ra-5.10
+  title: Correlate Scanning Information
+  objective: Correlate the output from vulnerability scanning tools to determine the presence of multi-vulnerability and
+    multi-hop attack vectors.
+  group: ra
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ra-5.11
+  title: Public Disclosure Program
+  objective: Establish a public reporting channel for receiving reports of vulnerabilities in organizational systems and
+    system components.
+  group: ra
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ra-5
+  title: Vulnerability Monitoring and Scanning
+  objective: 'Monitor and scan for vulnerabilities in the system and hosted applications {{ insert: param, ra-5_prm_1 }} and
+    when new vulnerabilities potentially affecting the system are identified and reported; Employ vulnerability monitoring
+    tools and techniques that facilitate interoperability among tools and automate parts of the vulnerability management process
+    by using standards for: Analyze vulnerability scan reports and results from vulnerability monitoring; Remediate legitimate
+    vulnerabilities {{ insert: param, ra-05_odp.03 }} in accordance with an organizational assessment of risk; Share information
+    obtained from the vulnerability monitoring process and control assessments with {{ insert: param, ra-05_odp.04 }} to help
+    eliminate similar vulnerabilities in other systems; and Employ vulnerability monitoring tools that include the capability
+    to readily update the vulnerabilities to be scanned.'
+  group: ra
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ra-6
+  title: Technical Surveillance Countermeasures Survey
+  objective: 'Employ a technical surveillance countermeasures survey at {{ insert: param, ra-06_odp.01 }} {{ insert: param,
+    ra-06_odp.02 }}.'
+  group: ra
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ra-7
+  title: Risk Response
+  objective: Respond to findings from security and privacy assessments, monitoring, and audits in accordance with 
+    organizational risk tolerance.
+  group: ra
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ra-8
+  title: Privacy Impact Assessments
+  objective: 'Conduct privacy impact assessments for systems, programs, or other activities before:'
+  group: ra
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: ra-9
+  title: Criticality Analysis
+  objective: 'Identify critical system components and functions by performing a criticality analysis for {{ insert: param,
+    ra-09_odp.01 }} at {{ insert: param, ra-09_odp.02 }}.'
+  group: ra
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: ra-10
+  title: Threat Hunting
+  objective: 'Establish and maintain a cyber threat hunting capability to: Employ the threat hunting capability {{ insert:
+    param, ra-10_odp }}.'
+  group: ra
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-1
+  title: Policy and Procedures
+  objective: 'Develop, document, and disseminate to {{ insert: param, sa-1_prm_1 }}: Designate an {{ insert: param, sa-01_odp.04
+    }} to manage the development, documentation, and dissemination of the system and services acquisition policy and procedures;
+    and Review and update the current system and services acquisition:'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-2
+  title: Allocation of Resources
+  objective: Determine the high-level information security and privacy requirements for the system or system service in 
+    mission and business process planning; Determine, document, and allocate the resources required to protect the 
+    system or system service as part of the organizational capital planning and investment control process; and 
+    Establish a discrete line item for information security and privacy in organizational programming and budgeting 
+    documentation.
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-3.1
+  title: Manage Preproduction Environment
+  objective: Protect system preproduction environments commensurate with risk throughout the system development life 
+    cycle for the system, system component, or system service.
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-3.2
+  title: Use of Live or Operational Data
+  objective: Approve, document, and control the use of live data in preproduction environments for the system, system 
+    component, or system service; and Protect preproduction environments for the system, system component, or system 
+    service at the same impact or classification level as any live data in use within the preproduction environments.
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-3.3
+  title: Technology Refresh
+  objective: Plan for and implement a technology refresh schedule for the system throughout the system development life 
+    cycle.
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-3
+  title: System Development Life Cycle
+  objective: 'Acquire, develop, and manage the system using {{ insert: param, sa-03_odp }} that incorporates information security
+    and privacy considerations; Define and document information security and privacy roles and responsibilities throughout
+    the system development life cycle; Identify individuals having information security and privacy roles and responsibilities;
+    and Integrate the organizational information security and privacy risk management process into system development life
+    cycle activities.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-4.1
+  title: Functional Properties of Controls
+  objective: Require the developer of the system, system component, or system service to provide a description of the 
+    functional properties of the controls to be implemented.
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-4.2
+  title: Design and Implementation Information for Controls
+  objective: 'Require the developer of the system, system component, or system service to provide design and implementation
+    information for the controls that includes: {{ insert: param, sa-04.02_odp.01 }} at {{ insert: param, sa-04.02_odp.03
+    }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-4.3
+  title: Development Methods, Techniques, and Practices
+  objective: 'Require the developer of the system, system component, or system service to demonstrate the use of a system
+    development life cycle process that includes:'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-4.4
+  title: Assignment of Components to Systems
+  objective: Assignment of Components to Systems
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-4.5
+  title: System, Component, and Service Configurations
+  objective: 'Require the developer of the system, system component, or system service to:'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: sa-4.6
+  title: Use of Information Assurance Products
+  objective: Employ only government off-the-shelf or commercial off-the-shelf information assurance and information 
+    assurance-enabled information technology products that compose an NSA-approved solution to protect classified 
+    information when the networks used to transmit the information are at a lower classification level than the 
+    information being transmitted; and Ensure that these products have been evaluated and/or validated by NSA or in 
+    accordance with NSA-approved procedures.
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-4.7
+  title: 'NIAP-approved Protection Profiles '
+  objective: Limit the use of commercially provided information assurance and information assurance-enabled information 
+    technology products to those products that have been successfully evaluated against a National Information Assurance
+    partnership (NIAP)-approved Protection Profile for a specific technology type, if such a profile exists; and 
+    Require, if no NIAP-approved Protection Profile exists for a specific technology type but a commercially provided 
+    information technology product relies on cryptographic functionality to enforce its security policy, that the 
+    cryptographic module is FIPS-validated or NSA-approved.
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-4.8
+  title: Continuous Monitoring Plan for Controls
+  objective: Require the developer of the system, system component, or system service to produce a plan for continuous 
+    monitoring of control effectiveness that is consistent with the continuous monitoring program of the organization.
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-4.9
+  title: Functions, Ports, Protocols, and Services in Use
+  objective: Require the developer of the system, system component, or system service to identify the functions, ports, 
+    protocols, and services intended for organizational use.
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-4.10
+  title: Use of Approved PIV Products
+  objective: Employ only information technology products on the FIPS 201-approved products list for Personal Identity 
+    Verification (PIV) capability implemented within organizational systems.
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-4.11
+  title: System of Records
+  objective: 'Include {{ insert: param, sa-04.11_odp }} in the acquisition contract for the operation of a system of records
+    on behalf of an organization to accomplish an organizational mission or function.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-4.12
+  title: Data Ownership
+  objective: 'Include organizational data ownership requirements in the acquisition contract; and Require all data to be removed
+    from the contractor’s system and returned to the organization within {{ insert: param, sa-04.12_odp }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-4
+  title: Acquisition Process
+  objective: 'Include the following requirements, descriptions, and criteria, explicitly or by reference, using {{ insert:
+    param, sa-04_odp.01 }} in the acquisition contract for the system, system component, or system service:'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-5.1
+  title: Functional Properties of Security Controls
+  objective: Functional Properties of Security Controls
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-5.2
+  title: Security-relevant External System Interfaces
+  objective: Security-relevant External System Interfaces
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-5.3
+  title: High-level Design
+  objective: High-level Design
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-5.4
+  title: Low-level Design
+  objective: Low-level Design
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-5.5
+  title: Source Code
+  objective: Source Code
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-5
+  title: System Documentation
+  objective: 'Obtain or develop administrator documentation for the system, system component, or system service that describes:
+    Obtain or develop user documentation for the system, system component, or system service that describes: Document attempts
+    to obtain system, system component, or system service documentation when such documentation is either unavailable or nonexistent
+    and take {{ insert: param, sa-05_odp.01 }} in response; and Distribute documentation to {{ insert: param, sa-05_odp.02
+    }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-6
+  title: Software Usage Restrictions
+  objective: Software Usage Restrictions
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-7
+  title: User-installed Software
+  objective: User-installed Software
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8.1
+  title: Clear Abstractions
+  objective: Implement the security design principle of clear abstractions.
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8.2
+  title: Least Common Mechanism
+  objective: 'Implement the security design principle of least common mechanism in {{ insert: param, sa-08.02_odp }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8.3
+  title: Modularity and Layering
+  objective: 'Implement the security design principles of modularity and layering in {{ insert: param, sa-8.3_prm_1 }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8.4
+  title: Partially Ordered Dependencies
+  objective: 'Implement the security design principle of partially ordered dependencies in {{ insert: param, sa-08.04_odp
+    }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8.5
+  title: Efficiently Mediated Access
+  objective: 'Implement the security design principle of efficiently mediated access in {{ insert: param, sa-08.05_odp }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8.6
+  title: Minimized Sharing
+  objective: 'Implement the security design principle of minimized sharing in {{ insert: param, sa-08.06_odp }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8.7
+  title: Reduced Complexity
+  objective: 'Implement the security design principle of reduced complexity in {{ insert: param, sa-08.07_odp }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8.8
+  title: Secure Evolvability
+  objective: 'Implement the security design principle of secure evolvability in {{ insert: param, sa-08.08_odp }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8.9
+  title: Trusted Components
+  objective: 'Implement the security design principle of trusted components in {{ insert: param, sa-08.09_odp }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8.10
+  title: Hierarchical Trust
+  objective: 'Implement the security design principle of hierarchical trust in {{ insert: param, sa-08.10_odp }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8.11
+  title: Inverse Modification Threshold
+  objective: 'Implement the security design principle of inverse modification threshold in {{ insert: param, sa-08.11_odp
+    }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8.12
+  title: Hierarchical Protection
+  objective: 'Implement the security design principle of hierarchical protection in {{ insert: param, sa-08.12_odp }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8.13
+  title: Minimized Security Elements
+  objective: 'Implement the security design principle of minimized security elements in {{ insert: param, sa-08.13_odp }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8.14
+  title: Least Privilege
+  objective: 'Implement the security design principle of least privilege in {{ insert: param, sa-08.14_odp }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8.15
+  title: Predicate Permission
+  objective: 'Implement the security design principle of predicate permission in {{ insert: param, sa-08.15_odp }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8.16
+  title: Self-reliant Trustworthiness
+  objective: 'Implement the security design principle of self-reliant trustworthiness in {{ insert: param, sa-08.16_odp }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8.17
+  title: Secure Distributed Composition
+  objective: 'Implement the security design principle of secure distributed composition in {{ insert: param, sa-08.17_odp
+    }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8.18
+  title: Trusted Communications Channels
+  objective: 'Implement the security design principle of trusted communications channels in {{ insert: param, sa-08.18_odp
+    }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8.19
+  title: Continuous Protection
+  objective: 'Implement the security design principle of continuous protection in {{ insert: param, sa-08.19_odp }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8.20
+  title: Secure Metadata Management
+  objective: 'Implement the security design principle of secure metadata management in {{ insert: param, sa-08.20_odp }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8.21
+  title: Self-analysis
+  objective: 'Implement the security design principle of self-analysis in {{ insert: param, sa-08.21_odp }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8.22
+  title: Accountability and Traceability
+  objective: 'Implement the security design principle of accountability and traceability in {{ insert: param, sa-8.22_prm_1
+    }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8.23
+  title: Secure Defaults
+  objective: 'Implement the security design principle of secure defaults in {{ insert: param, sa-08.23_odp }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8.24
+  title: Secure Failure and Recovery
+  objective: 'Implement the security design principle of secure failure and recovery in {{ insert: param, sa-8.24_prm_1 }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8.25
+  title: Economic Security
+  objective: 'Implement the security design principle of economic security in {{ insert: param, sa-08.25_odp }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8.26
+  title: Performance Security
+  objective: 'Implement the security design principle of performance security in {{ insert: param, sa-08.26_odp }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8.27
+  title: Human Factored Security
+  objective: 'Implement the security design principle of human factored security in {{ insert: param, sa-08.27_odp }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8.28
+  title: Acceptable Security
+  objective: 'Implement the security design principle of acceptable security in {{ insert: param, sa-08.28_odp }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8.29
+  title: Repeatable and Documented Procedures
+  objective: 'Implement the security design principle of repeatable and documented procedures in {{ insert: param, sa-08.29_odp
+    }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8.30
+  title: Procedural Rigor
+  objective: 'Implement the security design principle of procedural rigor in {{ insert: param, sa-08.30_odp }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8.31
+  title: Secure System Modification
+  objective: 'Implement the security design principle of secure system modification in {{ insert: param, sa-08.31_odp }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8.32
+  title: Sufficient Documentation
+  objective: 'Implement the security design principle of sufficient documentation in {{ insert: param, sa-08.32_odp }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8.33
+  title: Minimization
+  objective: 'Implement the privacy principle of minimization using {{ insert: param, sa-08.33_odp }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-8
+  title: Security and Privacy Engineering Principles
+  objective: 'Apply the following systems security and privacy engineering principles in the specification, design, development,
+    implementation, and modification of the system and system components: {{ insert: param, sa-8_prm_1 }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-9.1
+  title: Risk Assessments and Organizational Approvals
+  objective: 'Conduct an organizational assessment of risk prior to the acquisition or outsourcing of information security
+    services; and Verify that the acquisition or outsourcing of dedicated information security services is approved by {{
+    insert: param, sa-09.01_odp }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-9.2
+  title: Identification of Functions, Ports, Protocols, and Services
+  objective: 'Require providers of the following external system services to identify the functions, ports, protocols, and
+    other services required for the use of such services: {{ insert: param, sa-09.02_odp }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-9.3
+  title: Establish and Maintain Trust Relationship with Providers
+  objective: 'Establish, document, and maintain trust relationships with external service providers based on the following
+    requirements, properties, factors, or conditions: {{ insert: param, sa-9.3_prm_1 }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-9.4
+  title: Consistent Interests of Consumers and Providers
+  objective: 'Take the following actions to verify that the interests of {{ insert: param, sa-09.04_odp.01 }} are consistent
+    with and reflect organizational interests: {{ insert: param, sa-09.04_odp.02 }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-9.5
+  title: Processing, Storage, and Service Location
+  objective: 'Restrict the location of {{ insert: param, sa-09.05_odp.01 }} to {{ insert: param, sa-09.05_odp.02 }} based
+    on {{ insert: param, sa-09.05_odp.03 }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-9.6
+  title: Organization-controlled Cryptographic Keys
+  objective: Maintain exclusive control of cryptographic keys for encrypted material stored or transmitted through an 
+    external system.
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-9.7
+  title: Organization-controlled Integrity Checking
+  objective: Provide the capability to check the integrity of information while it resides in the external system.
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-9.8
+  title: Processing and Storage Location — U.S. Jurisdiction
+  objective: Restrict the geographic location of information processing and data storage to facilities located within in
+    the legal jurisdictional boundary of the United States.
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-9
+  title: External System Services
+  objective: 'Require that providers of external system services comply with organizational security and privacy requirements
+    and employ the following controls: {{ insert: param, sa-09_odp.01 }}; Define and document organizational oversight and
+    user roles and responsibilities with regard to external system services; and Employ the following processes, methods,
+    and techniques to monitor control compliance by external service providers on an ongoing basis: {{ insert: param, sa-09_odp.02
+    }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-10.1
+  title: Software and Firmware Integrity Verification
+  objective: Require the developer of the system, system component, or system service to enable integrity verification 
+    of software and firmware components.
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-10.2
+  title: Alternative Configuration Management Processes
+  objective: Provide an alternate configuration management process using organizational personnel in the absence of a 
+    dedicated developer configuration management team.
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-10.3
+  title: Hardware Integrity Verification
+  objective: Require the developer of the system, system component, or system service to enable integrity verification 
+    of hardware components.
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-10.4
+  title: Trusted Generation
+  objective: Require the developer of the system, system component, or system service to employ tools for comparing 
+    newly generated versions of security-relevant hardware descriptions, source code, and object code with previous 
+    versions.
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-10.5
+  title: Mapping Integrity for Version Control
+  objective: Require the developer of the system, system component, or system service to maintain the integrity of the 
+    mapping between the master build data describing the current version of security-relevant hardware, software, and 
+    firmware and the on-site master copy of the data for the current version.
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-10.6
+  title: Trusted Distribution
+  objective: Require the developer of the system, system component, or system service to execute procedures for ensuring
+    that security-relevant hardware, software, and firmware updates distributed to the organization are exactly as 
+    specified by the master copies.
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-10.7
+  title: Security and Privacy Representatives
+  objective: 'Require {{ insert: param, sa-10.7_prm_1 }} to be included in the {{ insert: param, sa-10.7_prm_2 }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-10
+  title: Developer Configuration Management
+  objective: 'Require the developer of the system, system component, or system service to:'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-11.1
+  title: Static Code Analysis
+  objective: Require the developer of the system, system component, or system service to employ static code analysis 
+    tools to identify common flaws and document the results of the analysis.
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-11.2
+  title: Threat Modeling and Vulnerability Analyses
+  objective: 'Require the developer of the system, system component, or system service to perform threat modeling and vulnerability
+    analyses during development and the subsequent testing and evaluation of the system, component, or service that:'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-11.3
+  title: Independent Verification of Assessment Plans and Evidence
+  objective: 'Require an independent agent satisfying {{ insert: param, sa-11.03_odp }} to verify the correct implementation
+    of the developer security and privacy assessment plans and the evidence produced during testing and evaluation; and Verify
+    that the independent agent is provided with sufficient information to complete the verification process or granted the
+    authority to obtain such information.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-11.4
+  title: Manual Code Reviews
+  objective: 'Require the developer of the system, system component, or system service to perform a manual code review of
+    {{ insert: param, sa-11.04_odp.01 }} using the following processes, procedures, and/or techniques: {{ insert: param, sa-11.04_odp.02
+    }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-11.5
+  title: Penetration Testing
+  objective: 'Require the developer of the system, system component, or system service to perform penetration testing:'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-11.6
+  title: Attack Surface Reviews
+  objective: Require the developer of the system, system component, or system service to perform attack surface reviews.
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-11.7
+  title: Verify Scope of Testing and Evaluation
+  objective: 'Require the developer of the system, system component, or system service to verify that the scope of testing
+    and evaluation provides complete coverage of the required controls at the following level of rigor: {{ insert: param,
+    sa-11.7_prm_1 }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-11.8
+  title: Dynamic Code Analysis
+  objective: Require the developer of the system, system component, or system service to employ dynamic code analysis 
+    tools to identify common flaws and document the results of the analysis.
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-11.9
+  title: Interactive Application Security Testing
+  objective: Require the developer of the system, system component, or system service to employ interactive application 
+    security testing tools to identify flaws and document the results.
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-11
+  title: Developer Testing and Evaluation
+  objective: 'Require the developer of the system, system component, or system service, at all post-design stages of the system
+    development life cycle, to:'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-12.1
+  title: Acquisition Strategies / Tools / Methods
+  objective: Acquisition Strategies / Tools / Methods
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-12.2
+  title: Supplier Reviews
+  objective: Supplier Reviews
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-12.3
+  title: Trusted Shipping and Warehousing
+  objective: Trusted Shipping and Warehousing
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-12.4
+  title: Diversity of Suppliers
+  objective: Diversity of Suppliers
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-12.5
+  title: Limitation of Harm
+  objective: Limitation of Harm
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-12.6
+  title: Minimizing Procurement Time
+  objective: Minimizing Procurement Time
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-12.7
+  title: Assessments Prior to Selection / Acceptance / Update
+  objective: Assessments Prior to Selection / Acceptance / Update
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-12.8
+  title: Use of All-source Intelligence
+  objective: Use of All-source Intelligence
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-12.9
+  title: Operations Security
+  objective: Operations Security
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-12.10
+  title: Validate as Genuine and Not Altered
+  objective: Validate as Genuine and Not Altered
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-12.11
+  title: Penetration Testing / Analysis of Elements, Processes, and Actors
+  objective: Penetration Testing / Analysis of Elements, Processes, and Actors
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-12.12
+  title: Inter-organizational Agreements
+  objective: Inter-organizational Agreements
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-12.13
+  title: Critical Information System Components
+  objective: Critical Information System Components
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-12.14
+  title: Identity and Traceability
+  objective: Identity and Traceability
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-12.15
+  title: Processes to Address Weaknesses or Deficiencies
+  objective: Processes to Address Weaknesses or Deficiencies
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-12
+  title: Supply Chain Protection
+  objective: Supply Chain Protection
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-13
+  title: Trustworthiness
+  objective: Trustworthiness
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-14.1
+  title: Critical Components with No Viable Alternative Sourcing
+  objective: Critical Components with No Viable Alternative Sourcing
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-14
+  title: Criticality Analysis
+  objective: Criticality Analysis
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-15.1
+  title: Quality Metrics
+  objective: 'Require the developer of the system, system component, or system service to:'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-15.2
+  title: Security and Privacy Tracking Tools
+  objective: Require the developer of the system, system component, or system service to select and employ security and 
+    privacy tracking tools for use during the development process.
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-15.3
+  title: Criticality Analysis
+  objective: 'Require the developer of the system, system component, or system service to perform a criticality analysis:'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-15.4
+  title: Threat Modeling and Vulnerability Analysis
+  objective: Threat Modeling and Vulnerability Analysis
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-15.5
+  title: Attack Surface Reduction
+  objective: 'Require the developer of the system, system component, or system service to reduce attack surfaces to {{ insert:
+    param, sa-15.05_odp }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-15.6
+  title: Continuous Improvement
+  objective: Require the developer of the system, system component, or system service to implement an explicit process 
+    to continuously improve the development process.
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-15.7
+  title: Automated Vulnerability Analysis
+  objective: 'Require the developer of the system, system component, or system service {{ insert: param, sa-15.07_odp.01 }}
+    to:'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-15.8
+  title: Reuse of Threat and Vulnerability Information
+  objective: Require the developer of the system, system component, or system service to use threat modeling and 
+    vulnerability analyses from similar systems, components, or services to inform the current development process.
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-15.9
+  title: Use of Live Data
+  objective: Use of Live Data
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-15.10
+  title: Incident Response Plan
+  objective: Require the developer of the system, system component, or system service to provide, implement, and test an
+    incident response plan.
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-15.11
+  title: Archive System or Component
+  objective: Require the developer of the system or system component to archive the system or component to be released 
+    or delivered together with the corresponding evidence supporting the final security and privacy review.
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-15.12
+  title: Minimize Personally Identifiable Information
+  objective: Require the developer of the system or system component to minimize the use of personally identifiable 
+    information in development and test environments.
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-15.13
+  title: Logging Syntax
+  objective: Require the developer of the system or system component to minimize the use of personally identifiable 
+    information in development and test environments.
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-15
+  title: Development Process, Standards, and Tools
+  objective: 'Require the developer of the system, system component, or system service to follow a documented development
+    process that: Review the development process, standards, tools, tool options, and tool configurations {{ insert: param,
+    sa-15_odp.01 }} to determine if the process, standards, tools, tool options and tool configurations selected and employed
+    can satisfy the following security and privacy requirements: {{ insert: param, sa-15_prm_2 }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sa-16
+  title: Developer-provided Training
+  objective: 'Require the developer of the system, system component, or system service to provide the following training on
+    the correct use and operation of the implemented security and privacy functions, controls, and/or mechanisms: {{ insert:
+    param, sa-16_odp }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: sa-17.1
+  title: Formal Policy Model
+  objective: 'Require the developer of the system, system component, or system service to:'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: sa-17.2
+  title: Security-relevant Components
+  objective: 'Require the developer of the system, system component, or system service to:'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: sa-17.3
+  title: Formal Correspondence
+  objective: 'Require the developer of the system, system component, or system service to:'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: sa-17.4
+  title: Informal Correspondence
+  objective: 'Require the developer of the system, system component, or system service to:'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: sa-17.5
+  title: Conceptually Simple Design
+  objective: 'Require the developer of the system, system component, or system service to:'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: sa-17.6
+  title: Structure for Testing
+  objective: Require the developer of the system, system component, or system service to structure security-relevant 
+    hardware, software, and firmware to facilitate testing.
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: sa-17.7
+  title: Structure for Least Privilege
+  objective: Require the developer of the system, system component, or system service to structure security-relevant 
+    hardware, software, and firmware to facilitate controlling access with least privilege.
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: sa-17.8
+  title: Orchestration
+  objective: 'Design {{ insert: param, sa-17.08_odp.01 }} with coordinated behavior to implement the following capabilities:
+    {{ insert: param, sa-17.08_odp.02 }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: sa-17.9
+  title: Design Diversity
+  objective: 'Use different designs for {{ insert: param, sa-17.09_odp }} to satisfy a common set of requirements or to provide
+    equivalent functionality.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: sa-17
+  title: Developer Security and Privacy Architecture and Design
+  objective: 'Require the developer of the system, system component, or system service to produce a design specification and
+    security and privacy architecture that:'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: sa-18.1
+  title: Multiple Phases of System Development Life Cycle
+  objective: Multiple Phases of System Development Life Cycle
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-18.2
+  title: Inspection of Systems or Components
+  objective: Inspection of Systems or Components
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-18
+  title: Tamper Resistance and Detection
+  objective: Tamper Resistance and Detection
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-19.1
+  title: Anti-counterfeit Training
+  objective: Anti-counterfeit Training
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-19.2
+  title: Configuration Control for Component Service and Repair
+  objective: Configuration Control for Component Service and Repair
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-19.3
+  title: Component Disposal
+  objective: Component Disposal
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-19.4
+  title: Anti-counterfeit Scanning
+  objective: Anti-counterfeit Scanning
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-19
+  title: Component Authenticity
+  objective: Component Authenticity
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-20
+  title: Customized Development of Critical Components
+  objective: 'Reimplement or custom develop the following critical system components: {{ insert: param, sa-20_odp }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-21.1
+  title: Validation of Screening
+  objective: Validation of Screening
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: sa-21
+  title: Developer Screening
+  objective: 'Require that the developer of {{ insert: param, sa-21_odp.01 }}:'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: sa-22.1
+  title: Alternative Sources for Continued Support
+  objective: Alternative Sources for Continued Support
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-22
+  title: Unsupported System Components
+  objective: 'Replace system components when support for the components is no longer available from the developer, vendor,
+    or manufacturer; or Provide the following options for alternative sources for continued support for unsupported components
+    {{ insert: param, sa-22_odp.01 }}.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-23
+  title: Specialization
+  objective: 'Employ {{ insert: param, sa-23_odp.01 }} on {{ insert: param, sa-23_odp.02 }} supporting mission essential services
+    or functions to increase the trustworthiness in those systems or components.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sa-24
+  title: Design For Cyber Resiliency
+  objective: 'Design organizational systems, system components, or system services to achieve cyber resiliency by: Implement
+    the selected cyber resiliency goals, objectives, techniques, implementation approaches, and design principles as part
+    of an organizational risk management process or systems security engineering process.'
+  group: sa
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-1
+  title: Policy and Procedures
+  objective: 'Develop, document, and disseminate to {{ insert: param, sc-1_prm_1 }}: Designate an {{ insert: param, sc-01_odp.04
+    }} to manage the development, documentation, and dissemination of the system and communications protection policy and
+    procedures; and Review and update the current system and communications protection:'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-2.1
+  title: Interfaces for Non-privileged Users
+  objective: Prevent the presentation of system management functionality at interfaces to non-privileged users.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sc-2.2
+  title: Disassociability
+  objective: Store state information from applications and software separately.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sc-2
+  title: Separation of System and User Functionality
+  objective: Separate user functionality, including user interface services, from system management functionality.
+  group: sc
+  assessment-requirements:
+  - id: sysctl_kernel_dmesg_restrict
+    state: Active
+    text: Rule 'sysctl_kernel_dmesg_restrict' MUST be verified
+    applicability:
+    - fedora-moderate
+  state: Active
+- id: sc-3.1
+  title: Hardware Separation
+  objective: Employ hardware separation mechanisms to implement security function isolation.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: sc-3.2
+  title: Access and Flow Control Functions
+  objective: Isolate security functions enforcing access and information flow control from nonsecurity functions and 
+    from other security functions.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: sc-3.3
+  title: Minimize Nonsecurity Functionality
+  objective: Minimize the number of nonsecurity functions included within the isolation boundary containing security 
+    functions.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: sc-3.4
+  title: Module Coupling and Cohesiveness
+  objective: Implement security functions as largely independent modules that maximize internal cohesiveness within 
+    modules and minimize coupling between modules.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: sc-3.5
+  title: Layered Structures
+  objective: Implement security functions as a layered structure minimizing interactions between layers of the design 
+    and avoiding any dependence by lower layers on the functionality or correctness of higher layers.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: sc-3
+  title: Security Function Isolation
+  objective: Isolate security functions from nonsecurity functions.
+  group: sc
+  assessment-requirements:
+  - id: selinux_not_disabled
+    state: Active
+    text: Rule 'selinux_not_disabled' MUST be verified
+    applicability: &id023
+    - fedora-high
+  - id: selinux_state
+    state: Active
+    text: Rule 'selinux_state' MUST be verified
+    applicability: *id023
+  - id: var_selinux_state
+    state: Active
+    text: Variable 'var_selinux_state' is set to 'enforcing'
+    applicability: *id023
+  state: Active
+- id: sc-4.1
+  title: Security Levels
+  objective: Security Levels
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sc-4.2
+  title: Multilevel or Periods Processing
+  objective: 'Prevent unauthorized information transfer via shared resources in accordance with {{ insert: param, sc-04.02_odp
+    }} when system processing explicitly switches between different information classification levels or security categories.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sc-4
+  title: Information in Shared System Resources
+  objective: Prevent unauthorized and unintended information transfer via shared system resources.
+  group: sc
+  assessment-requirements:
+  - id: dir_perms_world_writable_sticky_bits
+    state: Active
+    text: Rule 'dir_perms_world_writable_sticky_bits' MUST be verified
+    applicability: &id024
+    - fedora-moderate
+  - id: file_permissions_unauthorized_world_writable
+    state: Active
+    text: Rule 'file_permissions_unauthorized_world_writable' MUST be verified
+    applicability: *id024
+  state: Active
+- id: sc-5.1
+  title: Restrict Ability to Attack Other Systems
+  objective: 'Restrict the ability of individuals to launch the following denial-of-service attacks against other systems:
+    {{ insert: param, sc-05.01_odp }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-5.2
+  title: Capacity, Bandwidth, and Redundancy
+  objective: Manage capacity, bandwidth, or other redundancy to limit the effects of information flooding 
+    denial-of-service attacks.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-5.3
+  title: Detection and Monitoring
+  objective: 'Employ the following monitoring tools to detect indicators of denial-of-service attacks against, or launched
+    from, the system: {{ insert: param, sc-05.03_odp.01 }} ; and Monitor the following system resources to determine if sufficient
+    resources exist to prevent effective denial-of-service attacks: {{ insert: param, sc-05.03_odp.02 }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-5
+  title: Denial-of-service Protection
+  objective: '{{ insert: param, sc-05_odp.02 }} the effects of the following types of denial-of-service events: {{ insert:
+    param, sc-05_odp.01 }} ; and Employ the following controls to achieve the denial-of-service objective: {{ insert: param,
+    sc-05_odp.03 }}.'
+  group: sc
+  assessment-requirements:
+  - id: sysctl_net_ipv4_tcp_syncookies
+    state: Active
+    text: Rule 'sysctl_net_ipv4_tcp_syncookies' MUST be verified
+    applicability:
+    - fedora-low
+  state: Active
+- id: sc-6
+  title: Resource Availability
+  objective: 'Protect the availability of resources by allocating {{ insert: param, sc-06_odp.01 }} by {{ insert: param, sc-06_odp.02
+    }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-7.1
+  title: Physically Separated Subnetworks
+  objective: Physically Separated Subnetworks
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-7.2
+  title: Public Access
+  objective: Public Access
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-7.3
+  title: Access Points
+  objective: Limit the number of external network connections to the system.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sc-7.4
+  title: External Telecommunications Services
+  objective: 'Implement a managed interface for each external telecommunication service; Establish a traffic flow policy for
+    each managed interface; Protect the confidentiality and integrity of the information being transmitted across each interface;
+    Document each exception to the traffic flow policy with a supporting mission or business need and duration of that need;
+    Review exceptions to the traffic flow policy {{ insert: param, sc-07.04_odp }} and remove exceptions that are no longer
+    supported by an explicit mission or business need; Prevent unauthorized exchange of control plane traffic with external
+    networks; Publish information to enable remote networks to detect unauthorized control plane traffic from internal networks;
+    and Filter unauthorized control plane traffic from external networks.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sc-7.5
+  title: Deny by Default — Allow by Exception
+  objective: 'Deny network communications traffic by default and allow network communications traffic by exception {{ insert:
+    param, sc-07.05_odp.01 }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sc-7.6
+  title: Response to Recognized Failures
+  objective: Response to Recognized Failures
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-7.7
+  title: Split Tunneling for Remote Devices
+  objective: 'Prevent split tunneling for remote devices connecting to organizational systems unless the split tunnel is securely
+    provisioned using {{ insert: param, sc-07.07_odp }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sc-7.8
+  title: Route Traffic to Authenticated Proxy Servers
+  objective: 'Route {{ insert: param, sc-07.08_odp.01 }} to {{ insert: param, sc-07.08_odp.02 }} through authenticated proxy
+    servers at managed interfaces.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sc-7.9
+  title: Restrict Threatening Outgoing Communications Traffic
+  objective: Detect and deny outgoing communications traffic posing a threat to external systems; and Audit the identity
+    of internal users associated with denied communications.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-7.10
+  title: Prevent Exfiltration
+  objective: 'Prevent the exfiltration of information; and Conduct exfiltration tests {{ insert: param, sc-07.10_odp }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-7.11
+  title: Restrict Incoming Communications Traffic
+  objective: 'Only allow incoming communications from {{ insert: param, sc-07.11_odp.01 }} to be routed to {{ insert: param,
+    sc-07.11_odp.02 }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-7.12
+  title: Host-based Protection
+  objective: 'Implement {{ insert: param, sc-07.12_odp.01 }} at {{ insert: param, sc-07.12_odp.02 }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-7.13
+  title: Isolation of Security Tools, Mechanisms, and Support Components
+  objective: 'Isolate {{ insert: param, sc-07.13_odp }} from other internal system components by implementing physically separate
+    subnetworks with managed interfaces to other components of the system.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-7.14
+  title: Protect Against Unauthorized Physical Connections
+  objective: 'Protect against unauthorized physical connections at {{ insert: param, sc-07.14_odp }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-7.15
+  title: Networked Privileged Accesses
+  objective: Route networked, privileged accesses through a dedicated, managed interface for purposes of access control 
+    and auditing.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-7.16
+  title: Prevent Discovery of System Components
+  objective: Prevent the discovery of specific system components that represent a managed interface.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-7.17
+  title: Automated Enforcement of Protocol Formats
+  objective: Enforce adherence to protocol formats.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-7.18
+  title: Fail Secure
+  objective: Prevent systems from entering unsecure states in the event of an operational failure of a boundary 
+    protection device.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: sc-7.19
+  title: Block Communication from Non-organizationally Configured Hosts
+  objective: 'Block inbound and outbound communications traffic between {{ insert: param, sc-07.19_odp }} that are independently
+    configured by end users and external service providers.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-7.20
+  title: Dynamic Isolation and Segregation
+  objective: 'Provide the capability to dynamically isolate {{ insert: param, sc-07.20_odp }} from other system components.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-7.21
+  title: Isolation of System Components
+  objective: 'Employ boundary protection mechanisms to isolate {{ insert: param, sc-07.21_odp.01 }} supporting {{ insert:
+    param, sc-07.21_odp.02 }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: sc-7.22
+  title: Separate Subnets for Connecting to Different Security Domains
+  objective: Implement separate network addresses to connect to systems in different security domains.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-7.23
+  title: Disable Sender Feedback on Protocol Validation Failure
+  objective: Disable feedback to senders on protocol format validation failure.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-7.24
+  title: Personally Identifiable Information
+  objective: 'For systems that process personally identifiable information:'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-7.25
+  title: Unclassified National Security System Connections
+  objective: 'Prohibit the direct connection of {{ insert: param, sc-07.25_odp.01 }} to an external network without the use
+    of {{ insert: param, sc-07.25_odp.02 }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-7.26
+  title: Classified National Security System Connections
+  objective: 'Prohibit the direct connection of a classified national security system to an external network without the use
+    of {{ insert: param, sc-07.26_odp }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-7.27
+  title: Unclassified Non-national Security System Connections
+  objective: 'Prohibit the direct connection of {{ insert: param, sc-07.27_odp.01 }} to an external network without the use
+    of {{ insert: param, sc-07.27_odp.02 }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-7.28
+  title: Connections to Public Networks
+  objective: 'Prohibit the direct connection of {{ insert: param, sc-07.28_odp }} to a public network.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-7.29
+  title: Separate Subnets to Isolate Functions
+  objective: 'Implement {{ insert: param, sc-07.29_odp.01 }} separate subnetworks to isolate the following critical system
+    components and functions: {{ insert: param, sc-07.29_odp.02 }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-7
+  title: Boundary Protection
+  objective: 'Monitor and control communications at the external managed interfaces to the system and at key internal managed
+    interfaces within the system; Implement subnetworks for publicly accessible system components that are {{ insert: param,
+    sc-07_odp }} separated from internal organizational networks; and Connect to external networks or systems only through
+    managed interfaces consisting of boundary protection devices arranged in accordance with an organizational security and
+    privacy architecture.'
+  group: sc
+  assessment-requirements:
+  - id: service_firewalld_enabled
+    state: Active
+    text: Rule 'service_firewalld_enabled' MUST be verified
+    applicability:
+    - fedora-low
+  state: Active
+- id: sc-8.1
+  title: Cryptographic Protection
+  objective: 'Implement cryptographic mechanisms to {{ insert: param, sc-08.01_odp }} during transmission.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sc-8.2
+  title: Pre- and Post-transmission Handling
+  objective: 'Maintain the {{ insert: param, sc-08.02_odp }} of information during preparation for transmission and during
+    reception.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sc-8.3
+  title: Cryptographic Protection for Message Externals
+  objective: 'Implement cryptographic mechanisms to protect message externals unless otherwise protected by {{ insert: param,
+    sc-08.03_odp }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sc-8.4
+  title: Conceal or Randomize Communications
+  objective: 'Implement cryptographic mechanisms to conceal or randomize communication patterns unless otherwise protected
+    by {{ insert: param, sc-08.04_odp }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sc-8.5
+  title: Protected Distribution System
+  objective: 'Implement {{ insert: param, sc-08.05_odp.01 }} to {{ insert: param, sc-08.05_odp.02 }} during transmission.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sc-8
+  title: Transmission Confidentiality and Integrity
+  objective: 'Protect the {{ insert: param, sc-08_odp }} of transmitted information.'
+  group: sc
+  assessment-requirements:
+  - id: configure_custom_crypto_policy_cis
+    state: Active
+    text: Rule 'configure_custom_crypto_policy_cis' MUST be verified
+    applicability:
+    - fedora-moderate
+  state: Active
+- id: sc-9
+  title: Transmission Confidentiality
+  objective: Transmission Confidentiality
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-10
+  title: Network Disconnect
+  objective: 'Terminate the network connection associated with a communications session at the end of the session or after
+    {{ insert: param, sc-10_odp }} of inactivity.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sc-11.1
+  title: Irrefutable Communications Path
+  objective: 'Provide a trusted communications path that is irrefutably distinguishable from other communications paths; and
+    Initiate the trusted communications path for communications between the {{ insert: param, sc-11.01_odp }} of the system
+    and the user.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-11
+  title: Trusted Path
+  objective: 'Provide a {{ insert: param, sc-11_odp.01 }} isolated trusted communications path for communications between
+    the user and the trusted components of the system; and Permit users to invoke the trusted communications path for communications
+    between the user and the following security functions of the system, including at a minimum, authentication and re-authentication:
+    {{ insert: param, sc-11_odp.02 }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-12.1
+  title: Availability
+  objective: Maintain availability of information in the event of the loss of cryptographic keys by users.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: sc-12.2
+  title: Symmetric Keys
+  objective: 'Produce, control, and distribute symmetric cryptographic keys using {{ insert: param, sc-12.02_odp }} key management
+    technology and processes.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-12.3
+  title: Asymmetric Keys
+  objective: 'Produce, control, and distribute asymmetric cryptographic keys using {{ insert: param, sc-12.03_odp }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-12.4
+  title: PKI Certificates
+  objective: PKI Certificates
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-12.5
+  title: PKI Certificates / Hardware Tokens
+  objective: PKI Certificates / Hardware Tokens
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-12.6
+  title: Physical Control of Keys
+  objective: Maintain physical control of cryptographic keys when stored information is encrypted by external service 
+    providers.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-12
+  title: Cryptographic Key Establishment and Management
+  objective: 'Establish and manage cryptographic keys when cryptography is employed within the system in accordance with the
+    following key management requirements: {{ insert: param, sc-12_odp }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-13.1
+  title: FIPS-validated Cryptography
+  objective: FIPS-validated Cryptography
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-13.2
+  title: NSA-approved Cryptography
+  objective: NSA-approved Cryptography
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-13.3
+  title: Individuals Without Formal Access Approvals
+  objective: Individuals Without Formal Access Approvals
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-13.4
+  title: Digital Signatures
+  objective: Digital Signatures
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-13
+  title: Cryptographic Protection
+  objective: 'Determine the {{ insert: param, sc-13_odp.01 }} ; and Implement the following types of cryptography required
+    for each specified cryptographic use: {{ insert: param, sc-13_odp.02 }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-14
+  title: Public Access Protections
+  objective: Public Access Protections
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-15.1
+  title: Physical or Logical Disconnect
+  objective: 'Provide {{ insert: param, sc-15.01_odp }} disconnect of collaborative computing devices in a manner that supports
+    ease of use.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-15.2
+  title: Blocking Inbound and Outbound Communications Traffic
+  objective: Blocking Inbound and Outbound Communications Traffic
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-15.3
+  title: Disabling and Removal in Secure Work Areas
+  objective: 'Disable or remove collaborative computing devices and applications from {{ insert: param, sc-15.03_odp.01 }}
+    in {{ insert: param, sc-15.03_odp.02 }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-15.4
+  title: Explicitly Indicate Current Participants
+  objective: 'Provide an explicit indication of current participants in {{ insert: param, sc-15.04_odp }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-15
+  title: Collaborative Computing Devices and Applications
+  objective: 'Prohibit remote activation of collaborative computing devices and applications with the following exceptions:
+    {{ insert: param, sc-15_odp }} ; and Provide an explicit indication of use to users physically present at the devices.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-16.1
+  title: Integrity Verification
+  objective: Verify the integrity of transmitted security and privacy attributes.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-16.2
+  title: Anti-spoofing Mechanisms
+  objective: Implement anti-spoofing mechanisms to prevent adversaries from falsifying the security attributes 
+    indicating the successful application of the security process.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-16.3
+  title: Cryptographic Binding
+  objective: 'Implement {{ insert: param, sc-16.03_odp }} to bind security and privacy attributes to transmitted information.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-16
+  title: Transmission of Security and Privacy Attributes
+  objective: 'Associate {{ insert: param, sc-16_prm_1 }} with information exchanged between systems and between system components.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-17
+  title: Public Key Infrastructure Certificates
+  objective: 'Issue public key certificates under an {{ insert: param, sc-17_odp }} or obtain public key certificates from
+    an approved service provider; and Include only approved trust anchors in trust stores or certificate stores managed by
+    the organization.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sc-18.1
+  title: Identify Unacceptable Code and Take Corrective Actions
+  objective: 'Identify {{ insert: param, sc-18.01_odp.01 }} and take {{ insert: param, sc-18.01_odp.02 }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sc-18.2
+  title: Acquisition, Development, and Use
+  objective: 'Verify that the acquisition, development, and use of mobile code to be deployed in the system meets {{ insert:
+    param, sc-18.02_odp }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sc-18.3
+  title: Prevent Downloading and Execution
+  objective: 'Prevent the download and execution of {{ insert: param, sc-18.03_odp }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sc-18.4
+  title: Prevent Automatic Execution
+  objective: 'Prevent the automatic execution of mobile code in {{ insert: param, sc-18.04_odp.01 }} and enforce {{ insert:
+    param, sc-18.04_odp.02 }} prior to executing the code.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sc-18.5
+  title: Allow Execution Only in Confined Environments
+  objective: Allow execution of permitted mobile code only in confined virtual machine environments.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sc-18
+  title: Mobile Code
+  objective: Define acceptable and unacceptable mobile code and mobile code technologies; and Authorize, monitor, and 
+    control the use of mobile code within the system.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sc-19
+  title: Voice Over Internet Protocol
+  objective: Technology-specific; addressed as any other technology or protocol.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-20.1
+  title: Child Subspaces
+  objective: Child Subspaces
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-20.2
+  title: Data Origin and Integrity
+  objective: Provide data origin and integrity protection artifacts for internal name/address resolution queries.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-20
+  title: Secure Name/Address Resolution Service (Authoritative Source)
+  objective: Provide additional data origin authentication and integrity verification artifacts along with the 
+    authoritative name resolution data the system returns in response to external name/address resolution queries; and 
+    Provide the means to indicate the security status of child zones and (if the child supports secure resolution 
+    services) to enable verification of a chain of trust among parent and child domains, when operating as part of a 
+    distributed, hierarchical namespace.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-21.1
+  title: Data Origin and Integrity
+  objective: Data Origin and Integrity
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-21
+  title: Secure Name/Address Resolution Service (Recursive or Caching Resolver)
+  objective: Request and perform data origin authentication and data integrity verification on the name/address 
+    resolution responses the system receives from authoritative sources.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-22
+  title: Architecture and Provisioning for Name/Address Resolution Service
+  objective: Ensure the systems that collectively provide name/address resolution service for an organization are 
+    fault-tolerant and implement internal and external role separation.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-23.1
+  title: Invalidate Session Identifiers at Logout
+  objective: Invalidate session identifiers upon user logout or other session termination.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sc-23.2
+  title: User-initiated Logouts and Message Displays
+  objective: User-initiated Logouts and Message Displays
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sc-23.3
+  title: Unique System-generated Session Identifiers
+  objective: 'Generate a unique session identifier for each session with {{ insert: param, sc-23.03_odp }} and recognize only
+    session identifiers that are system-generated.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sc-23.4
+  title: Unique Session Identifiers with Randomization
+  objective: Unique Session Identifiers with Randomization
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sc-23.5
+  title: Allowed Certificate Authorities
+  objective: 'Only allow the use of {{ insert: param, sc-23.05_odp }} for verification of the establishment of protected sessions.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sc-23
+  title: Session Authenticity
+  objective: Protect the authenticity of communications sessions.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sc-24
+  title: Fail in Known State
+  objective: 'Fail to a {{ insert: param, sc-24_odp.02 }} for the following failures on the indicated components while preserving
+    {{ insert: param, sc-24_odp.03 }} in failure: {{ insert: param, sc-24_odp.01 }}.'
+  group: sc
+  assessment-requirements:
+  - id: service_systemd-journald_enabled
+    state: Active
+    text: Rule 'service_systemd-journald_enabled' MUST be verified
+    applicability:
+    - fedora-high
+  state: Active
+- id: sc-25
+  title: Thin Nodes
+  objective: 'Employ minimal functionality and information storage on the following system components: {{ insert: param, sc-25_odp
+    }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-26.1
+  title: Detection of Malicious Code
+  objective: Detection of Malicious Code
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-26
+  title: Decoys
+  objective: Include components within organizational systems specifically designed to be the target of malicious 
+    attacks for detecting, deflecting, and analyzing such attacks.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-27
+  title: Platform-independent Applications
+  objective: 'Include within organizational systems the following platform independent applications: {{ insert: param, sc-27_odp
+    }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-28.1
+  title: Cryptographic Protection
+  objective: 'Implement cryptographic mechanisms to prevent unauthorized disclosure and modification of the following information
+    at rest on {{ insert: param, sc-28.01_odp.02 }}: {{ insert: param, sc-28.01_odp.01 }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sc-28.2
+  title: Offline Storage
+  objective: 'Remove the following information from online storage and store offline in a secure location: {{ insert: param,
+    sc-28.02_odp }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sc-28.3
+  title: Cryptographic Keys
+  objective: 'Provide protected storage for cryptographic keys {{ insert: param, sc-28.03_odp.01 }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sc-28
+  title: Protection of Information at Rest
+  objective: 'Protect the {{ insert: param, sc-28_odp.01 }} of the following information at rest: {{ insert: param, sc-28_odp.02
+    }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sc-29.1
+  title: Virtualization Techniques
+  objective: 'Employ virtualization techniques to support the deployment of a diversity of operating systems and applications
+    that are changed {{ insert: param, sc-29.01_odp }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-29
+  title: Heterogeneity
+  objective: 'Employ a diverse set of information technologies for the following system components in the implementation of
+    the system: {{ insert: param, sc-29_odp }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-30.1
+  title: Virtualization Techniques
+  objective: Virtualization Techniques
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-30.2
+  title: Randomness
+  objective: 'Employ {{ insert: param, sc-30.02_odp }} to introduce randomness into organizational operations and assets.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-30.3
+  title: Change Processing and Storage Locations
+  objective: 'Change the location of {{ insert: param, sc-30.03_odp.01 }} {{ insert: param, sc-30.03_odp.02 }}].'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-30.4
+  title: Misleading Information
+  objective: 'Employ realistic, but misleading information in {{ insert: param, sc-30.04_odp }} about its security state or
+    posture.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-30.5
+  title: Concealment of System Components
+  objective: 'Employ the following techniques to hide or conceal {{ insert: param, sc-30.05_odp.02 }}: {{ insert: param, sc-30.05_odp.01
+    }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-30
+  title: Concealment and Misdirection
+  objective: 'Employ the following concealment and misdirection techniques for {{ insert: param, sc-30_odp.02 }} at {{ insert:
+    param, sc-30_odp.03 }} to confuse and mislead adversaries: {{ insert: param, sc-30_odp.01 }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-31.1
+  title: Test Covert Channels for Exploitability
+  objective: Test a subset of the identified covert channels to determine the channels that are exploitable.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-31.2
+  title: Maximum Bandwidth
+  objective: 'Reduce the maximum bandwidth for identified covert {{ insert: param, sc-31.02_odp.01 }} channels to {{ insert:
+    param, sc-31.02_odp.02 }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-31.3
+  title: Measure Bandwidth in Operational Environments
+  objective: 'Measure the bandwidth of {{ insert: param, sc-31.03_odp }} in the operational environment of the system.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-31
+  title: Covert Channel Analysis
+  objective: 'Perform a covert channel analysis to identify those aspects of communications within the system that are potential
+    avenues for covert {{ insert: param, sc-31_odp }} channels; and Estimate the maximum bandwidth of those channels.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-32.1
+  title: Separate Physical Domains for Privileged Functions
+  objective: Partition privileged functions into separate physical domains.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-32
+  title: System Partitioning
+  objective: 'Partition the system into {{ insert: param, sc-32_odp.01 }} residing in separate {{ insert: param, sc-32_odp.02
+    }} domains or environments based on {{ insert: param, sc-32_odp.03 }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-33
+  title: Transmission Preparation Integrity
+  objective: Transmission Preparation Integrity
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-34.1
+  title: No Writable Storage
+  objective: 'Employ {{ insert: param, sc-34.01_odp }} with no writeable storage that is persistent across component restart
+    or power on/off.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-34.2
+  title: Integrity Protection on Read-only Media
+  objective: Protect the integrity of information prior to storage on read-only media and control the media after such 
+    information has been recorded onto the media.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-34.3
+  title: Hardware-based Protection
+  objective: Hardware-based Protection
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-34
+  title: Non-modifiable Executable Programs
+  objective: 'For {{ insert: param, sc-34_odp.01 }} , load and execute:'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-35
+  title: External Malicious Code Identification
+  objective: Include system components that proactively seek to identify network-based malicious code or malicious 
+    websites.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-36.1
+  title: Polling Techniques
+  objective: 'Employ polling techniques to identify potential faults, errors, or compromises to the following processing and
+    storage components: {{ insert: param, sc-36.01_odp.01 }} ; and Take the following actions in response to identified faults,
+    errors, or compromises: {{ insert: param, sc-36.01_odp.02 }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-36.2
+  title: Synchronization
+  objective: 'Synchronize the following duplicate systems or system components: {{ insert: param, sc-36.02_odp }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-36
+  title: Distributed Processing and Storage
+  objective: 'Distribute the following processing and storage components across multiple {{ insert: param, sc-36_prm_1 }}:
+    {{ insert: param, sc-36_prm_2 }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-37.1
+  title: Ensure Delivery and Transmission
+  objective: 'Employ {{ insert: param, sc-37.01_odp.01 }} to ensure that only {{ insert: param, sc-37.01_odp.02 }} receive
+    the following information, system components, or devices: {{ insert: param, sc-37.01_odp.03 }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-37
+  title: Out-of-band Channels
+  objective: 'Employ the following out-of-band channels for the physical delivery or electronic transmission of {{ insert:
+    param, sc-37_odp.02 }} to {{ insert: param, sc-37_odp.03 }}: {{ insert: param, sc-37_odp.01 }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-38
+  title: Operations Security
+  objective: 'Employ the following operations security controls to protect key organizational information throughout the system
+    development life cycle: {{ insert: param, sc-38_odp }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-39.1
+  title: Hardware Separation
+  objective: Implement hardware separation mechanisms to facilitate process isolation.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-39.2
+  title: Separate Execution Domain Per Thread
+  objective: 'Maintain a separate execution domain for each thread in {{ insert: param, sc-39.02_odp }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-39
+  title: Process Isolation
+  objective: Maintain a separate execution domain for each executing system process.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-40.1
+  title: Electromagnetic Interference
+  objective: 'Implement cryptographic mechanisms that achieve {{ insert: param, sc-40.01_odp }} against the effects of intentional
+    electromagnetic interference.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-40.2
+  title: Reduce Detection Potential
+  objective: 'Implement cryptographic mechanisms to reduce the detection potential of wireless links to {{ insert: param,
+    sc-40.02_odp }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-40.3
+  title: Imitative or Manipulative Communications Deception
+  objective: Implement cryptographic mechanisms to identify and reject wireless transmissions that are deliberate 
+    attempts to achieve imitative or manipulative communications deception based on signal parameters.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-40.4
+  title: Signal Parameter Identification
+  objective: 'Implement cryptographic mechanisms to prevent the identification of {{ insert: param, sc-40.04_odp }} by using
+    the transmitter signal parameters.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-40
+  title: Wireless Link Protection
+  objective: 'Protect external and internal {{ insert: param, sc-40_prm_1 }} from the following signal parameter attacks:
+    {{ insert: param, sc-40_prm_2 }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-41
+  title: Port and I/O Device Access
+  objective: '{{ insert: param, sc-41_odp.02 }} disable or remove {{ insert: param, sc-41_odp.01 }} on the following systems
+    or system components: {{ insert: param, sc-41_odp.03 }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-42.1
+  title: Reporting to Authorized Individuals or Roles
+  objective: 'Verify that the system is configured so that data or information collected by the {{ insert: param, sc-42.01_odp
+    }} is only reported to authorized individuals or roles.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-42.2
+  title: Authorized Use
+  objective: 'Employ the following measures so that data or information collected by {{ insert: param, sc-42.01_odp }} is
+    only used for authorized purposes: {{ insert: param, sc-42.02_odp }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-42.3
+  title: Prohibit Use of Devices
+  objective: Prohibit Use of Devices
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-42.4
+  title: Notice of Collection
+  objective: 'Employ the following measures to facilitate an individual’s awareness that personally identifiable information
+    is being collected by {{ insert: param, sc-42.04_odp.02 }}: {{ insert: param, sc-42.04_odp.01 }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-42.5
+  title: Collection Minimization
+  objective: 'Employ {{ insert: param, sc-42.05_odp }} that are configured to minimize the collection of information about
+    individuals that is not needed.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-42
+  title: Sensor Capability and Data
+  objective: 'Prohibit {{ insert: param, sc-42_odp.01 }} ; and Provide an explicit indication of sensor use to {{ insert:
+    param, sc-42_odp.05 }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-43
+  title: Usage Restrictions
+  objective: 'Establish usage restrictions and implementation guidelines for the following system components: {{ insert: param,
+    sc-43_odp }} ; and Authorize, monitor, and control the use of such components within the system.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-44
+  title: Detonation Chambers
+  objective: 'Employ a detonation chamber capability within {{ insert: param, sc-44_odp }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-45.1
+  title: Synchronization with Authoritative Time Source
+  objective: 'Compare the internal system clocks {{ insert: param, sc-45.01_odp.01 }} with {{ insert: param, sc-45.01_odp.02
+    }} ; and Synchronize the internal system clocks to the authoritative time source when the time difference is greater than
+    {{ insert: param, sc-45.01_odp.03 }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-45.2
+  title: Secondary Authoritative Time Source
+  objective: Identify a secondary authoritative time source that is in a different geographic region than the primary 
+    authoritative time source; and Synchronize the internal system clocks to the secondary authoritative time source if 
+    the primary authoritative time source is unavailable.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-45
+  title: System Time Synchronization
+  objective: Synchronize system clocks within and between systems and system components.
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-46
+  title: Cross Domain Policy Enforcement
+  objective: 'Implement a policy enforcement mechanism {{ insert: param, sc-46_odp }} between the physical and/or network
+    interfaces for the connecting security domains.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-47
+  title: Alternate Communications Paths
+  objective: 'Establish {{ insert: param, sc-47_odp }} for system operations organizational command and control.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-48.1
+  title: Dynamic Relocation of Sensors or Monitoring Capabilities
+  objective: 'Dynamically relocate {{ insert: param, sc-48.01_odp.01 }} to {{ insert: param, sc-48.01_odp.02 }} under the
+    following conditions or circumstances: {{ insert: param, sc-48.01_odp.03 }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-48
+  title: Sensor Relocation
+  objective: 'Relocate {{ insert: param, sc-48_odp.01 }} to {{ insert: param, sc-48_odp.02 }} under the following conditions
+    or circumstances: {{ insert: param, sc-48_odp.03 }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-49
+  title: Hardware-enforced Separation and Policy Enforcement
+  objective: 'Implement hardware-enforced separation and policy enforcement mechanisms between {{ insert: param, sc-49_odp
+    }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-50
+  title: Software-enforced Separation and Policy Enforcement
+  objective: 'Implement software-enforced separation and policy enforcement mechanisms between {{ insert: param, sc-50_odp
+    }}.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sc-51
+  title: Hardware-based Protection
+  objective: 'Employ hardware-based, write-protect for {{ insert: param, sc-51_odp.01 }} ; and Implement specific procedures
+    for {{ insert: param, sc-51_odp.02 }} to manually disable hardware write-protect for firmware modifications and re-enable
+    the write-protect prior to returning to operational mode.'
+  group: sc
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-1
+  title: Policy and Procedures
+  objective: 'Develop, document, and disseminate to {{ insert: param, si-1_prm_1 }}: Designate an {{ insert: param, si-01_odp.04
+    }} to manage the development, documentation, and dissemination of the system and information integrity policy and procedures;
+    and Review and update the current system and information integrity:'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-2.1
+  title: Central Management
+  objective: Central Management
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-2.2
+  title: Automated Flaw Remediation Status
+  objective: 'Determine if system components have applicable security-relevant software and firmware updates installed using
+    {{ insert: param, si-02.02_odp.01 }} {{ insert: param, si-02.02_odp.02 }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: si-2.3
+  title: Time to Remediate Flaws and Benchmarks for Corrective Actions
+  objective: 'Measure the time between flaw identification and flaw remediation; and Establish the following benchmarks for
+    taking corrective actions: {{ insert: param, si-02.03_odp }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-2.4
+  title: Automated Patch Management Tools
+  objective: 'Employ automated patch management tools to facilitate flaw remediation to the following system components: {{
+    insert: param, si-02.04_odp }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-2.5
+  title: Automatic Software and Firmware Updates
+  objective: 'Install {{ insert: param, si-02.05_odp.01 }} automatically to {{ insert: param, si-02.05_odp.02 }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-2.6
+  title: Removal of Previous Versions of Software and Firmware
+  objective: 'Remove previous versions of {{ insert: param, si-02.06_odp }} after updated versions have been installed.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-2.7
+  title: Root Cause Analysis
+  objective: Conduct root cause analysis to identify underlying causes of issues or failures. Develop actions to address
+    the root cause of the issue or failure. Implement the actions and monitor the implementation for effectiveness.
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-2
+  title: Flaw Remediation
+  objective: 'Identify, report, and correct system flaws; Test software and firmware updates related to flaw remediation for
+    effectiveness and potential side effects before installation; Install security-relevant software and firmware updates
+    within {{ insert: param, si-02_odp }} of the release of the updates; and Incorporate flaw remediation into the organizational
+    configuration management process.'
+  group: si
+  assessment-requirements:
+  - id: ensure_gpgcheck_globally_activated
+    state: Active
+    text: Rule 'ensure_gpgcheck_globally_activated' MUST be verified
+    applicability: &id025
+    - fedora-low
+  - id: ensure_fedora_gpgkey_installed
+    state: Active
+    text: Rule 'ensure_fedora_gpgkey_installed' MUST be verified
+    applicability: *id025
+  state: Active
+- id: si-3.1
+  title: Central Management
+  objective: Central Management
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-3.2
+  title: Automatic Updates
+  objective: Automatic Updates
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-3.3
+  title: Non-privileged Users
+  objective: Non-privileged Users
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-3.4
+  title: Updates Only by Privileged Users
+  objective: Update malicious code protection mechanisms only when directed by a privileged user.
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-3.5
+  title: Portable Storage Devices
+  objective: Portable Storage Devices
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-3.6
+  title: Testing and Verification
+  objective: 'Test malicious code protection mechanisms {{ insert: param, si-03.06_odp }} by introducing known benign code
+    into the system; and Verify that the detection of the code and the associated incident reporting occur.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-3.7
+  title: Nonsignature-based Detection
+  objective: Nonsignature-based Detection
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-3.8
+  title: Detect Unauthorized Commands
+  objective: 'Detect the following unauthorized operating system commands through the kernel application programming interface
+    on {{ insert: param, si-03.08_odp.02 }}: {{ insert: param, si-03.08_odp.01 }} ; and {{ insert: param, si-03.08_odp.03
+    }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-3.9
+  title: Authenticate Remote Commands
+  objective: Authenticate Remote Commands
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-3.10
+  title: Malicious Code Analysis
+  objective: 'Employ the following tools and techniques to analyze the characteristics and behavior of malicious code: {{
+    insert: param, si-03.10_odp }} ; and Incorporate the results from malicious code analysis into organizational incident
+    response and flaw remediation processes.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-3
+  title: Malicious Code Protection
+  objective: 'Implement {{ insert: param, si-03_odp.01 }} malicious code protection mechanisms at system entry and exit points
+    to detect and eradicate malicious code; Automatically update malicious code protection mechanisms as new releases are
+    available in accordance with organizational configuration management policy and procedures; Configure malicious code protection
+    mechanisms to: Address the receipt of false positives during malicious code detection and eradication and the resulting
+    potential impact on the availability of the system.'
+  group: si
+  assessment-requirements:
+  - id: kernel_module_usb-storage_disabled
+    state: Active
+    text: Rule 'kernel_module_usb-storage_disabled' MUST be verified
+    applicability: &id026
+    - fedora-low
+  - id: service_autofs_disabled
+    state: Active
+    text: Rule 'service_autofs_disabled' MUST be verified
+    applicability: *id026
+  state: Active
+- id: si-4.1
+  title: System-wide Intrusion Detection System
+  objective: Connect and configure individual intrusion detection tools into a system-wide intrusion detection system.
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-4.2
+  title: Automated Tools and Mechanisms for Real-time Analysis
+  objective: Employ automated tools and mechanisms to support near real-time analysis of events.
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: si-4.3
+  title: Automated Tool and Mechanism Integration
+  objective: Employ automated tools and mechanisms to integrate intrusion detection tools and mechanisms into access 
+    control and flow control mechanisms.
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-4.4
+  title: Inbound and Outbound Communications Traffic
+  objective: 'Determine criteria for unusual or unauthorized activities or conditions for inbound and outbound communications
+    traffic; Monitor inbound and outbound communications traffic {{ insert: param, si-4.4_prm_1 }} for {{ insert: param, si-4.4_prm_2
+    }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: si-4.5
+  title: System-generated Alerts
+  objective: 'Alert {{ insert: param, si-04.05_odp.01 }} when the following system-generated indications of compromise or
+    potential compromise occur: {{ insert: param, si-04.05_odp.02 }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: si-4.6
+  title: Restrict Non-privileged Users
+  objective: Restrict Non-privileged Users
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-4.7
+  title: Automated Response to Suspicious Events
+  objective: 'Notify {{ insert: param, si-04.07_odp.01 }} of detected suspicious events; and Take the following actions upon
+    detection: {{ insert: param, si-04.07_odp.02 }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-4.8
+  title: Protection of Monitoring Information
+  objective: Protection of Monitoring Information
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-4.9
+  title: Testing of Monitoring Tools and Mechanisms
+  objective: 'Test intrusion-monitoring tools and mechanisms {{ insert: param, si-04.09_odp }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-4.10
+  title: Visibility of Encrypted Communications
+  objective: 'Make provisions so that {{ insert: param, si-04.10_odp.01 }} is visible to {{ insert: param, si-04.10_odp.02
+    }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: si-4.11
+  title: Analyze Communications Traffic Anomalies
+  objective: 'Analyze outbound communications traffic at the external interfaces to the system and selected {{ insert: param,
+    si-04.11_odp }} to discover anomalies.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-4.12
+  title: Automated Organization-generated Alerts
+  objective: 'Alert {{ insert: param, si-04.12_odp.01 }} using {{ insert: param, si-04.12_odp.02 }} when the following indications
+    of inappropriate or unusual activities with security or privacy implications occur: {{ insert: param, si-04.12_odp.03
+    }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: si-4.13
+  title: Analyze Traffic and Event Patterns
+  objective: Analyze communications traffic and event patterns for the system; Develop profiles representing common 
+    traffic and event patterns; and Use the traffic and event profiles in tuning system-monitoring devices.
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-4.14
+  title: Wireless Intrusion Detection
+  objective: Employ a wireless intrusion detection system to identify rogue wireless devices and to detect attack 
+    attempts and potential compromises or breaches to the system.
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: si-4.15
+  title: Wireless to Wireline Communications
+  objective: Employ an intrusion detection system to monitor wireless communications traffic as the traffic passes from 
+    wireless to wireline networks.
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-4.16
+  title: Correlate Monitoring Information
+  objective: Correlate information from monitoring tools and mechanisms employed throughout the system.
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-4.17
+  title: Integrated Situational Awareness
+  objective: Correlate information from monitoring physical, cyber, and supply chain activities to achieve integrated, 
+    organization-wide situational awareness.
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-4.18
+  title: Analyze Traffic and Covert Exfiltration
+  objective: 'Analyze outbound communications traffic at external interfaces to the system and at the following interior points
+    to detect covert exfiltration of information: {{ insert: param, si-04.18_odp }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-4.19
+  title: Risk for Individuals
+  objective: 'Implement {{ insert: param, si-04.19_odp.01 }} of individuals who have been identified by {{ insert: param,
+    si-04.19_odp.02 }} as posing an increased level of risk.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-4.20
+  title: Privileged Users
+  objective: 'Implement the following additional monitoring of privileged users: {{ insert: param, si-04.20_odp }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: si-4.21
+  title: Probationary Periods
+  objective: 'Implement the following additional monitoring of individuals during {{ insert: param, si-04.21_odp.02 }}: {{
+    insert: param, si-04.21_odp.01 }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-4.22
+  title: Unauthorized Network Services
+  objective: 'Detect network services that have not been authorized or approved by {{ insert: param, si-04.22_odp.01 }} ;
+    and {{ insert: param, si-04.22_odp.02 }} when detected.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: si-4.23
+  title: Host-based Devices
+  objective: 'Implement the following host-based monitoring mechanisms at {{ insert: param, si-04.23_odp.02 }}: {{ insert:
+    param, si-04.23_odp.01 }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-4.24
+  title: Indicators of Compromise
+  objective: 'Discover, collect, and distribute to {{ insert: param, si-04.24_odp.02 }} , indicators of compromise provided
+    by {{ insert: param, si-04.24_odp.01 }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-4.25
+  title: Optimize Network Traffic Analysis
+  objective: Provide visibility into network traffic at external and key internal system interfaces to optimize the 
+    effectiveness of monitoring devices.
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-4
+  title: System Monitoring
+  objective: 'Monitor the system to detect: Identify unauthorized use of the system through the following techniques and methods:
+    {{ insert: param, si-04_odp.02 }}; Invoke internal monitoring capabilities or deploy monitoring devices: Analyze detected
+    events and anomalies; Adjust the level of system monitoring activity when there is a change in risk to organizational
+    operations and assets, individuals, other organizations, or the Nation; Obtain legal opinion regarding system monitoring
+    activities; and Provide {{ insert: param, si-04_odp.03 }} to {{ insert: param, si-04_odp.04 }} {{ insert: param, si-04_odp.05
+    }}.'
+  group: si
+  assessment-requirements:
+  - id: kernel_module_dccp_disabled
+    state: Active
+    text: Rule 'kernel_module_dccp_disabled' MUST be verified
+    applicability: &id027
+    - fedora-low
+  - id: kernel_module_rds_disabled
+    state: Active
+    text: Rule 'kernel_module_rds_disabled' MUST be verified
+    applicability: *id027
+  - id: kernel_module_sctp_disabled
+    state: Active
+    text: Rule 'kernel_module_sctp_disabled' MUST be verified
+    applicability: *id027
+  - id: kernel_module_tipc_disabled
+    state: Active
+    text: Rule 'kernel_module_tipc_disabled' MUST be verified
+    applicability: *id027
+  - id: service_avahi-daemon_disabled
+    state: Active
+    text: Rule 'service_avahi-daemon_disabled' MUST be verified
+    applicability: *id027
+  state: Active
+- id: si-5.1
+  title: Automated Alerts and Advisories
+  objective: 'Broadcast security alert and advisory information throughout the organization using {{ insert: param, si-05.01_odp
+    }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: si-5
+  title: Security Alerts, Advisories, and Directives
+  objective: 'Receive system security alerts, advisories, and directives from {{ insert: param, si-05_odp.01 }} on an ongoing
+    basis; Generate internal security alerts, advisories, and directives as deemed necessary; Disseminate security alerts,
+    advisories, and directives to: {{ insert: param, si-05_odp.02 }} ; and Implement security directives in accordance with
+    established time frames, or notify the issuing organization of the degree of noncompliance.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-6.1
+  title: Notification of Failed Security Tests
+  objective: Notification of Failed Security Tests
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: si-6.2
+  title: Automation Support for Distributed Testing
+  objective: Implement automated mechanisms to support the management of distributed security and privacy function 
+    testing.
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: si-6.3
+  title: Report Verification Results
+  objective: 'Report the results of security and privacy function verification to {{ insert: param, si-06.03_odp }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: si-6
+  title: Security and Privacy Function Verification
+  objective: 'Verify the correct operation of {{ insert: param, si-6_prm_1 }}; Perform the verification of the functions specified
+    in SI-6a {{ insert: param, si-06_odp.03 }}; Alert {{ insert: param, si-06_odp.06 }} to failed security and privacy verification
+    tests; and {{ insert: param, si-06_odp.07 }} when anomalies are discovered.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: si-7.1
+  title: Integrity Checks
+  objective: 'Perform an integrity check of {{ insert: param, si-7.1_prm_1 }} {{ insert: param, si-7.1_prm_2 }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: si-7.2
+  title: Automated Notifications of Integrity Violations
+  objective: 'Employ automated tools that provide notification to {{ insert: param, si-07.02_odp }} upon discovering discrepancies
+    during integrity verification.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: si-7.3
+  title: Centrally Managed Integrity Tools
+  objective: Employ centrally managed integrity verification tools.
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: si-7.4
+  title: Tamper-evident Packaging
+  objective: Tamper-evident Packaging
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: si-7.5
+  title: Automated Response to Integrity Violations
+  objective: 'Automatically {{ insert: param, si-07.05_odp.01 }} when integrity violations are discovered.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: si-7.6
+  title: Cryptographic Protection
+  objective: Implement cryptographic mechanisms to detect unauthorized changes to software, firmware, and information.
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: si-7.7
+  title: Integration of Detection and Response
+  objective: 'Incorporate the detection of the following unauthorized changes into the organizational incident response capability:
+    {{ insert: param, si-07.07_odp }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: si-7.8
+  title: Auditing Capability for Significant Events
+  objective: 'Upon detection of a potential integrity violation, provide the capability to audit the event and initiate the
+    following actions: {{ insert: param, si-07.08_odp.01 }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: si-7.9
+  title: Verify Boot Process
+  objective: 'Verify the integrity of the boot process of the following system components: {{ insert: param, si-07.09_odp
+    }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: si-7.10
+  title: Protection of Boot Firmware
+  objective: 'Implement the following mechanisms to protect the integrity of boot firmware in {{ insert: param, si-07.10_odp.02
+    }}: {{ insert: param, si-07.10_odp.01 }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: si-7.11
+  title: Confined Environments with Limited Privileges
+  objective: Confined Environments with Limited Privileges
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: si-7.12
+  title: Integrity Verification
+  objective: 'Require that the integrity of the following user-installed software be verified prior to execution: {{ insert:
+    param, si-07.12_odp }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: si-7.13
+  title: Code Execution in Protected Environments
+  objective: Code Execution in Protected Environments
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: si-7.14
+  title: Binary or Machine Executable Code
+  objective: Binary or Machine Executable Code
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: si-7.15
+  title: Code Authentication
+  objective: 'Implement cryptographic mechanisms to authenticate the following software or firmware components prior to installation:
+    {{ insert: param, si-07.15_odp }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: si-7.16
+  title: Time Limit on Process Execution Without Supervision
+  objective: 'Prohibit processes from executing without supervision for more than {{ insert: param, si-07.16_odp }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: si-7.17
+  title: Runtime Application Self-protection
+  objective: 'Implement {{ insert: param, si-07.17_odp }} for application self-protection at runtime.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: si-7
+  title: Software, Firmware, and Information Integrity
+  objective: 'Employ integrity verification tools to detect unauthorized changes to the following software, firmware, and
+    information: {{ insert: param, si-7_prm_1 }} ; and Take the following actions when unauthorized changes to the software,
+    firmware, and information are detected: {{ insert: param, si-7_prm_2 }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: si-8.1
+  title: Central Management
+  objective: Central Management
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: si-8.2
+  title: Automatic Updates
+  objective: 'Automatically update spam protection mechanisms {{ insert: param, si-08.02_odp }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: si-8.3
+  title: Continuous Learning Capability
+  objective: Implement spam protection mechanisms with a learning capability to more effectively identify legitimate 
+    communications traffic.
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: si-8
+  title: Spam Protection
+  objective: Employ spam protection mechanisms at system entry and exit points to detect and act on unsolicited 
+    messages; and Update spam protection mechanisms when new releases are available in accordance with organizational 
+    configuration management policy and procedures.
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: si-9
+  title: Information Input Restrictions
+  objective: Information Input Restrictions
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-10.1
+  title: Manual Override Capability
+  objective: 'Provide a manual override capability for input validation of the following information inputs: {{ insert: param,
+    si-10_odp }}; Restrict the use of the manual override capability to only {{ insert: param, si-10.01_odp }} ; and Audit
+    the use of the manual override capability.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: si-10.2
+  title: Review and Resolve Errors
+  objective: 'Review and resolve input validation errors within {{ insert: param, si-10.2_prm_1 }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: si-10.3
+  title: Predictable Behavior
+  objective: Verify that the system behaves in a predictable and documented manner when invalid inputs are received.
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: si-10.4
+  title: Timing Interactions
+  objective: Account for timing interactions among system components in determining appropriate responses for invalid 
+    inputs.
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: si-10.5
+  title: Restrict Inputs to Trusted Sources and Approved Formats
+  objective: 'Restrict the use of information inputs to {{ insert: param, si-10.05_odp.01 }} and/or {{ insert: param, si-10.05_odp.02
+    }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: si-10.6
+  title: Injection Prevention
+  objective: Prevent untrusted data injections.
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: si-10
+  title: Information Input Validation
+  objective: 'Check the validity of the following information inputs: {{ insert: param, si-10_odp }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: si-11
+  title: Error Handling
+  objective: 'Generate error messages that provide information necessary for corrective actions without revealing information
+    that could be exploited; and Reveal error messages only to {{ insert: param, si-11_odp }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: si-12.1
+  title: Limit Personally Identifiable Information Elements
+  objective: 'Limit personally identifiable information being processed in the information life cycle to the following elements
+    of personally identifiable information: {{ insert: param, si-12.01_odp }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-12.2
+  title: Minimize Personally Identifiable Information in Testing, Training, and Research
+  objective: 'Use the following techniques to minimize the use of personally identifiable information for research, testing,
+    or training: {{ insert: param, si-12.2_prm_1 }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-12.3
+  title: Information Disposal
+  objective: 'Use the following techniques to dispose of, destroy, or erase information following the retention period: {{
+    insert: param, si-12.3_prm_1 }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-12
+  title: Information Management and Retention
+  objective: Manage and retain information within the system and information output from the system in accordance with 
+    applicable laws, executive orders, directives, regulations, policies, standards, guidelines and operational 
+    requirements.
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-13.1
+  title: Transferring Component Responsibilities
+  objective: 'Take system components out of service by transferring component responsibilities to substitute components no
+    later than {{ insert: param, si-13.01_odp }} of mean time to failure.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-13.2
+  title: Time Limit on Process Execution Without Supervision
+  objective: Time Limit on Process Execution Without Supervision
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-13.3
+  title: Manual Transfer Between Components
+  objective: 'Manually initiate transfers between active and standby system components when the use of the active component
+    reaches {{ insert: param, si-13.03_odp }} of the mean time to failure.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-13.4
+  title: Standby Component Installation and Notification
+  objective: 'If system component failures are detected:'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-13.5
+  title: Failover Capability
+  objective: 'Provide {{ insert: param, si-13.05_odp.01 }} {{ insert: param, si-13.05_odp.02 }} for the system.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-13
+  title: Predictable Failure Prevention
+  objective: 'Determine mean time to failure (MTTF) for the following system components in specific environments of operation:
+    {{ insert: param, si-13_odp.01 }} ; and Provide substitute system components and a means to exchange active and standby
+    components in accordance with the following criteria: {{ insert: param, si-13_odp.02 }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-14.1
+  title: Refresh from Trusted Sources
+  objective: 'Obtain software and data employed during system component and service refreshes from the following trusted sources:
+    {{ insert: param, si-14.01_odp }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-14.2
+  title: Non-persistent Information
+  objective: '{{ insert: param, si-14.02_odp.01 }} ; and Delete information when no longer needed.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-14.3
+  title: Non-persistent Connectivity
+  objective: 'Establish connections to the system on demand and terminate connections after {{ insert: param, si-14.03_odp
+    }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-14
+  title: Non-persistence
+  objective: 'Implement non-persistent {{ insert: param, si-14_odp.01 }} that are initiated in a known state and terminated
+    {{ insert: param, si-14_odp.02 }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-15
+  title: Information Output Filtering
+  objective: 'Validate information output from the following software programs and/or applications to ensure that the information
+    is consistent with the expected content: {{ insert: param, si-15_odp }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-16
+  title: Memory Protection
+  objective: 'Implement the following controls to protect the system memory from unauthorized code execution: {{ insert: param,
+    si-16_odp }}.'
+  group: si
+  assessment-requirements:
+  - id: sysctl_kernel_randomize_va_space
+    state: Active
+    text: Rule 'sysctl_kernel_randomize_va_space' MUST be verified
+    applicability:
+    - fedora-moderate
+  state: Active
+- id: si-17
+  title: Fail-safe Procedures
+  objective: 'Implement the indicated fail-safe procedures when the indicated failures occur: {{ insert: param, si-17_prm_1
+    }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-18.1
+  title: Automation Support
+  objective: 'Correct or delete personally identifiable information that is inaccurate or outdated, incorrectly determined
+    regarding impact, or incorrectly de-identified using {{ insert: param, si-18.01_odp }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-18.2
+  title: Data Tags
+  objective: Employ data tags to automate the correction or deletion of personally identifiable information across the 
+    information life cycle within organizational systems.
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-18.3
+  title: Collection
+  objective: Collect personally identifiable information directly from the individual.
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-18.4
+  title: Individual Requests
+  objective: Correct or delete personally identifiable information upon request by individuals or their designated 
+    representatives.
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-18.5
+  title: Notice of Correction or Deletion
+  objective: 'Notify {{ insert: param, si-18.05_odp }} and individuals that the personally identifiable information has been
+    corrected or deleted.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-18
+  title: Personally Identifiable Information Quality Operations
+  objective: 'Check the accuracy, relevance, timeliness, and completeness of personally identifiable information across the
+    information life cycle {{ insert: param, si-18_prm_1 }} ; and Correct or delete inaccurate or outdated personally identifiable
+    information.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-19.1
+  title: Collection
+  objective: De-identify the dataset upon collection by not collecting personally identifiable information.
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-19.2
+  title: Archiving
+  objective: Prohibit archiving of personally identifiable information elements if those elements in a dataset will not 
+    be needed after the dataset is archived.
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-19.3
+  title: Release
+  objective: Remove personally identifiable information elements from a dataset prior to its release if those elements 
+    in the dataset do not need to be part of the data release.
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-19.4
+  title: Removal, Masking, Encryption, Hashing, or Replacement of Direct Identifiers
+  objective: Remove, mask, encrypt, hash, or replace direct identifiers in a dataset.
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-19.5
+  title: Statistical Disclosure Control
+  objective: Manipulate numerical data, contingency tables, and statistical findings so that no individual or 
+    organization is identifiable in the results of the analysis.
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-19.6
+  title: Differential Privacy
+  objective: Prevent disclosure of personally identifiable information by adding non-deterministic noise to the results 
+    of mathematical operations before the results are reported.
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-19.7
+  title: Validated Algorithms and Software
+  objective: Perform de-identification using validated algorithms and software that is validated to implement the 
+    algorithms.
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-19.8
+  title: Motivated Intruder
+  objective: Perform a motivated intruder test on the de-identified dataset to determine if the identified data remains 
+    or if the de-identified data can be re-identified.
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-19
+  title: De-identification
+  objective: 'Remove the following elements of personally identifiable information from datasets: {{ insert: param, si-19_odp.01
+    }} ; and Evaluate {{ insert: param, si-19_odp.02 }} for effectiveness of de-identification.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-20
+  title: Tainting
+  objective: 'Embed data or capabilities in the following systems or system components to determine if organizational data
+    has been exfiltrated or improperly removed from the organization: {{ insert: param, si-20_odp }}.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-21
+  title: Information Refresh
+  objective: 'Refresh {{ insert: param, si-21_odp.01 }} at {{ insert: param, si-21_odp.02 }} or generate the information on
+    demand and delete the information when no longer needed.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-22
+  title: Information Diversity
+  objective: 'Identify the following alternative sources of information for {{ insert: param, si-22_odp.02 }}: {{ insert:
+    param, si-22_odp.01 }} ; and Use an alternative information source for the execution of essential functions or services
+    on {{ insert: param, si-22_odp.03 }} when the primary source of information is corrupted or unavailable.'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: si-23
+  title: Information Fragmentation
+  objective: 'Based on {{ insert: param, si-23_odp.01 }}:'
+  group: si
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sr-1
+  title: Policy and Procedures
+  objective: 'Develop, document, and disseminate to {{ insert: param, sr-1_prm_1 }}: Designate an {{ insert: param, sr-01_odp.04
+    }} to manage the development, documentation, and dissemination of the supply chain risk management policy and procedures;
+    and Review and update the current supply chain risk management:'
+  group: sr
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sr-2.1
+  title: Establish SCRM Team
+  objective: 'Establish a supply chain risk management team consisting of {{ insert: param, sr-02.01_odp.01 }} to lead and
+    support the following SCRM activities: {{ insert: param, sr-02.01_odp.02 }}.'
+  group: sr
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sr-2
+  title: Supply Chain Risk Management Plan
+  objective: 'Develop a plan for managing supply chain risks associated with the research and development, design, manufacturing,
+    acquisition, delivery, integration, operations and maintenance, and disposal of the following systems, system components
+    or system services: {{ insert: param, sr-02_odp.01 }}; Review and update the supply chain risk management plan {{ insert:
+    param, sr-02_odp.02 }} or as required, to address threat, organizational or environmental changes; and Protect the supply
+    chain risk management plan from unauthorized disclosure and modification.'
+  group: sr
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sr-3.1
+  title: Diverse Supply Base
+  objective: 'Employ a diverse set of sources for the following system components and services: {{ insert: param, sr-3.1_prm_1
+    }}.'
+  group: sr
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sr-3.2
+  title: Limitation of Harm
+  objective: 'Employ the following controls to limit harm from potential adversaries identifying and targeting the organizational
+    supply chain: {{ insert: param, sr-03.02_odp }}.'
+  group: sr
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sr-3.3
+  title: Sub-tier Flow Down
+  objective: Ensure that the controls included in the contracts of prime contractors are also included in the contracts 
+    of subcontractors.
+  group: sr
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sr-3
+  title: Supply Chain Controls and Processes
+  objective: 'Establish a process or processes to identify and address weaknesses or deficiencies in the supply chain elements
+    and processes of {{ insert: param, sr-03_odp.01 }} in coordination with {{ insert: param, sr-03_odp.02 }}; Employ the
+    following controls to protect against supply chain risks to the system, system component, or system service and to limit
+    the harm or consequences from supply chain-related events: {{ insert: param, sr-03_odp.03 }} ; and Document the selected
+    and implemented supply chain processes and controls in {{ insert: param, sr-03_odp.04 }}.'
+  group: sr
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sr-4.1
+  title: Identity
+  objective: 'Establish and maintain unique identification of the following supply chain elements, processes, and personnel
+    associated with the identified system and critical system components: {{ insert: param, sr-04.01_odp }}.'
+  group: sr
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sr-4.2
+  title: Track and Trace
+  objective: 'Establish and maintain unique identification of the following systems and critical system components for tracking
+    through the supply chain: {{ insert: param, sr-04.02_odp }}.'
+  group: sr
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sr-4.3
+  title: Validate as Genuine and Not Altered
+  objective: 'Employ the following controls to validate that the system or system component received is genuine and has not
+    been altered: {{ insert: param, sr-4.3_prm_1 }}.'
+  group: sr
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sr-4.4
+  title: Supply Chain Integrity — Pedigree
+  objective: 'Employ {{ insert: param, sr-04.04_odp.01 }} and conduct {{ insert: param, sr-04.04_odp.02 }} to ensure the integrity
+    of the system and system components by validating the internal composition and provenance of critical or mission-essential
+    technologies, products, and services.'
+  group: sr
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sr-4
+  title: Provenance
+  objective: 'Document, monitor, and maintain valid provenance of the following systems, system components, and associated
+    data: {{ insert: param, sr-04_odp }}.'
+  group: sr
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sr-5.1
+  title: Adequate Supply
+  objective: 'Employ the following controls to ensure an adequate supply of {{ insert: param, sr-05.01_odp.02 }}: {{ insert:
+    param, sr-05.01_odp.01 }}.'
+  group: sr
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sr-5.2
+  title: Assessments Prior to Selection, Acceptance, Modification, or Update
+  objective: Assess the system, system component, or system service prior to selection, acceptance, modification, or 
+    update.
+  group: sr
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sr-5
+  title: Acquisition Strategies, Tools, and Methods
+  objective: 'Employ the following acquisition strategies, contract tools, and procurement methods to protect against, identify,
+    and mitigate supply chain risks: {{ insert: param, sr-05_odp }}.'
+  group: sr
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sr-6.1
+  title: Testing and Analysis
+  objective: 'Employ {{ insert: param, sr-06.01_odp.01 }} of the following supply chain elements, processes, and actors associated
+    with the system, system component, or system service: {{ insert: param, sr-06.01_odp.02 }}.'
+  group: sr
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sr-6
+  title: Supplier Assessments and Reviews
+  objective: 'Assess and review the supply chain-related risks associated with suppliers or contractors and the system, system
+    component, or system service they provide {{ insert: param, sr-06_odp }}.'
+  group: sr
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-moderate
+  state: Draft
+- id: sr-7
+  title: Supply Chain Operations Security
+  objective: 'Employ the following Operations Security (OPSEC) controls to protect supply chain-related information for the
+    system, system component, or system service: {{ insert: param, sr-07_odp }}.'
+  group: sr
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sr-8
+  title: Notification Agreements
+  objective: 'Establish agreements and procedures with entities involved in the supply chain for the system, system component,
+    or system service for the {{ insert: param, sr-08_odp.01 }}.'
+  group: sr
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sr-9.1
+  title: Multiple Stages of System Development Life Cycle
+  objective: Employ anti-tamper technologies, tools, and techniques throughout the system development life cycle.
+  group: sr
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: sr-9
+  title: Tamper Resistance and Detection
+  objective: Implement a tamper protection program for the system, system component, or system service.
+  group: sr
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-high
+  state: Draft
+- id: sr-10
+  title: Inspection of Systems or Components
+  objective: 'Inspect the following systems or system components {{ insert: param, sr-10_odp.02 }} to detect tampering: {{
+    insert: param, sr-10_odp.01 }}.'
+  group: sr
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sr-11.1
+  title: Anti-counterfeit Training
+  objective: 'Train {{ insert: param, sr-11.01_odp }} to detect counterfeit system components (including hardware, software,
+    and firmware).'
+  group: sr
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sr-11.2
+  title: Configuration Control for Component Service and Repair
+  objective: 'Maintain configuration control over the following system components awaiting service or repair and serviced
+    or repaired components awaiting return to service: {{ insert: param, sr-11.02_odp }}.'
+  group: sr
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sr-11.3
+  title: Anti-counterfeit Scanning
+  objective: 'Scan for counterfeit system components {{ insert: param, sr-11.03_odp }}.'
+  group: sr
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sr-11
+  title: Component Authenticity
+  objective: 'Develop and implement anti-counterfeit policy and procedures that include the means to detect and prevent counterfeit
+    components from entering the system; and Report counterfeit system components to {{ insert: param, sr-11_odp.01 }}.'
+  group: sr
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft
+- id: sr-12
+  title: Component Disposal
+  objective: 'Dispose of {{ insert: param, sr-12_odp.01 }} using the following techniques and methods: {{ insert: param, sr-12_odp.02
+    }}.'
+  group: sr
+  assessment-requirements:
+  - id: no-automated-check
+    state: Active
+    text: 'This control has no automated checks. ComplianceAsCode status: pending. Manual assessment required.'
+    applicability:
+    - fedora-low
+  state: Draft

--- a/governance/policies/nist-800-53-rev5-fedora-policy.yaml
+++ b/governance/policies/nist-800-53-rev5-fedora-policy.yaml
@@ -1,0 +1,3441 @@
+title: NIST SP 800-53 Rev 5 for Fedora
+metadata:
+  id: nist-800-53-rev5-fedora-policy
+  type: Policy
+  gemara-version: 1.2.0
+  description: Automated evaluation policy for NIST SP 800-53 Rev 5 on Fedora, using ComplianceAsCode rules. 
+    requirement-id values are short CaC rule names (the OpenSCAP provider adds the xccdf_org.ssgproject.content_rule_ 
+    prefix).
+  author:
+    id: complianceascode
+    name: ComplianceAsCode Project
+    type: Software
+    uri: https://github.com/ComplianceAsCode/content
+  date: '2026-08-21T12:47:09Z'
+  mapping-references:
+  - id: nist-800-53-rev5-fedora
+    title: NIST SP 800-53 Rev 5 Control Catalog for FEDORA
+    version: Revision 5
+    url: file://../catalogs/nist-800-53-rev5-fedora-catalog.yaml
+  - id: nist-800-53-rev5-guidance
+    title: NIST SP 800-53 Rev 5 Guidance Catalog
+    version: Revision 5
+    url: file://../guidance/nist-800-53-rev5-guidance.yaml
+contacts:
+  responsible:
+  - name: System Administrator
+  accountable:
+  - name: Security Team
+scope:
+  in:
+    technologies:
+    - Fedora
+imports:
+  catalogs:
+  - reference-id: nist-800-53-rev5-fedora
+  guidance:
+  - reference-id: nist-800-53-rev5-guidance
+adherence:
+  evaluation-methods:
+  - id: openscap-automated
+    type: Behavioral
+    mode: Automated
+    description: OpenSCAP automated compliance evaluation
+    executor:
+      id: openscap
+      name: OpenSCAP
+      type: Software
+  assessment-plans:
+  - id: account_disable_post_pw_expiration
+    requirement-id: account_disable_post_pw_expiration
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_account_disable_post_pw_expiration
+      label: Account Disable Post Pw Expiration
+      description: ComplianceAsCode sets var_account_disable_post_pw_expiration to '45' for this control.
+      accepted-values:
+      - '45'
+  - id: account_password_pam_faillock_password_auth
+    requirement-id: account_password_pam_faillock_password_auth
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: account_password_pam_faillock_system_auth
+    requirement-id: account_password_pam_faillock_system_auth
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: account_unique_id
+    requirement-id: account_unique_id
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: account_unique_name
+    requirement-id: account_unique_name
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: accounts_maximum_age_login_defs
+    requirement-id: accounts_maximum_age_login_defs
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_accounts_maximum_age_login_defs
+      label: Accounts Maximum Age Login Defs
+      description: ComplianceAsCode sets var_accounts_maximum_age_login_defs to '365' for this control.
+      accepted-values:
+      - '365'
+  - id: accounts_minimum_age_login_defs
+    requirement-id: accounts_minimum_age_login_defs
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_accounts_minimum_age_login_defs
+      label: Accounts Minimum Age Login Defs
+      description: ComplianceAsCode sets var_accounts_minimum_age_login_defs to '1' for this control.
+      accepted-values:
+      - '1'
+  - id: accounts_no_uid_except_zero
+    requirement-id: accounts_no_uid_except_zero
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: accounts_password_all_shadowed
+    requirement-id: accounts_password_all_shadowed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: accounts_password_last_change_is_in_past
+    requirement-id: accounts_password_last_change_is_in_past
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: accounts_password_pam_dictcheck
+    requirement-id: accounts_password_pam_dictcheck
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: accounts_password_pam_difok
+    requirement-id: accounts_password_pam_difok
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_password_pam_difok
+      label: Password Pam Difok
+      description: ComplianceAsCode sets var_password_pam_difok to '2' for this control.
+      accepted-values:
+      - '2'
+  - id: accounts_password_pam_enforce_root
+    requirement-id: accounts_password_pam_enforce_root
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: accounts_password_pam_maxrepeat
+    requirement-id: accounts_password_pam_maxrepeat
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_password_pam_maxrepeat
+      label: Password Pam Maxrepeat
+      description: ComplianceAsCode sets var_password_pam_maxrepeat to '3' for this control.
+      accepted-values:
+      - '3'
+  - id: accounts_password_pam_maxsequence
+    requirement-id: accounts_password_pam_maxsequence
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: accounts_password_pam_minclass
+    requirement-id: accounts_password_pam_minclass
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_password_pam_minclass
+      label: Password Pam Minclass
+      description: ComplianceAsCode sets var_password_pam_minclass to '4' for this control.
+      accepted-values:
+      - '4'
+  - id: accounts_password_pam_minlen
+    requirement-id: accounts_password_pam_minlen
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_password_pam_minlen
+      label: Password Pam Minlen
+      description: ComplianceAsCode sets var_password_pam_minlen to '14' for this control.
+      accepted-values:
+      - '14'
+  - id: accounts_password_pam_modules_in_authselect_profile
+    requirement-id: accounts_password_pam_modules_in_authselect_profile
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: accounts_password_pam_pwhistory_enforce_for_root
+    requirement-id: accounts_password_pam_pwhistory_enforce_for_root
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: accounts_password_pam_pwhistory_remember_password_auth
+    requirement-id: accounts_password_pam_pwhistory_remember_password_auth
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_password_pam_remember
+      label: Password Pam Remember
+      description: ComplianceAsCode sets var_password_pam_remember to '24' for this control.
+      accepted-values:
+      - '24'
+    - id: var_password_pam_remember_control_flag
+      label: Password Pam Remember Control Flag
+      description: ComplianceAsCode sets var_password_pam_remember_control_flag to 'requisite_or_required' for this 
+        control.
+      accepted-values:
+      - requisite_or_required
+  - id: accounts_password_pam_pwhistory_remember_system_auth
+    requirement-id: accounts_password_pam_pwhistory_remember_system_auth
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_password_pam_remember
+      label: Password Pam Remember
+      description: ComplianceAsCode sets var_password_pam_remember to '24' for this control.
+      accepted-values:
+      - '24'
+    - id: var_password_pam_remember_control_flag
+      label: Password Pam Remember Control Flag
+      description: ComplianceAsCode sets var_password_pam_remember_control_flag to 'requisite_or_required' for this 
+        control.
+      accepted-values:
+      - requisite_or_required
+  - id: accounts_password_pam_pwhistory_use_authtok
+    requirement-id: accounts_password_pam_pwhistory_use_authtok
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: accounts_password_pam_pwquality_password_auth
+    requirement-id: accounts_password_pam_pwquality_password_auth
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: accounts_password_pam_pwquality_system_auth
+    requirement-id: accounts_password_pam_pwquality_system_auth
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: accounts_password_pam_unix_authtok
+    requirement-id: accounts_password_pam_unix_authtok
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: accounts_password_pam_unix_enabled
+    requirement-id: accounts_password_pam_unix_enabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: accounts_password_pam_unix_no_remember
+    requirement-id: accounts_password_pam_unix_no_remember
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: accounts_password_set_max_life_existing
+    requirement-id: accounts_password_set_max_life_existing
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_accounts_maximum_age_login_defs
+      label: Accounts Maximum Age Login Defs
+      description: ComplianceAsCode sets var_accounts_maximum_age_login_defs to '365' for this control.
+      accepted-values:
+      - '365'
+  - id: accounts_password_set_min_life_existing
+    requirement-id: accounts_password_set_min_life_existing
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_accounts_minimum_age_login_defs
+      label: Accounts Minimum Age Login Defs
+      description: ComplianceAsCode sets var_accounts_minimum_age_login_defs to '1' for this control.
+      accepted-values:
+      - '1'
+  - id: accounts_password_set_warn_age_existing
+    requirement-id: accounts_password_set_warn_age_existing
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_accounts_password_warn_age_login_defs
+      label: Accounts Password Warn Age Login Defs
+      description: ComplianceAsCode sets var_accounts_password_warn_age_login_defs to '7' for this control.
+      accepted-values:
+      - '7'
+  - id: accounts_password_warn_age_login_defs
+    requirement-id: accounts_password_warn_age_login_defs
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_accounts_password_warn_age_login_defs
+      label: Accounts Password Warn Age Login Defs
+      description: ComplianceAsCode sets var_accounts_password_warn_age_login_defs to '7' for this control.
+      accepted-values:
+      - '7'
+  - id: accounts_passwords_pam_faillock_deny
+    requirement-id: accounts_passwords_pam_faillock_deny
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_accounts_passwords_pam_faillock_deny
+      label: Accounts Passwords Pam Faillock Deny
+      description: ComplianceAsCode sets var_accounts_passwords_pam_faillock_deny to '5' for this control.
+      accepted-values:
+      - '5'
+  - id: accounts_passwords_pam_faillock_even_deny_root_or_root_unlock_time
+    requirement-id: accounts_passwords_pam_faillock_even_deny_root_or_root_unlock_time
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_accounts_passwords_pam_faillock_root_unlock_time
+      label: Accounts Passwords Pam Faillock Root Unlock Time
+      description: ComplianceAsCode sets var_accounts_passwords_pam_faillock_root_unlock_time to '60' for this control.
+      accepted-values:
+      - '60'
+  - id: accounts_passwords_pam_faillock_unlock_time_with_zero
+    requirement-id: accounts_passwords_pam_faillock_unlock_time_with_zero
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_accounts_passwords_pam_faillock_deny
+      label: Accounts Passwords Pam Faillock Deny
+      description: ComplianceAsCode sets var_accounts_passwords_pam_faillock_deny to '5' for this control.
+      accepted-values:
+      - '5'
+    - id: var_accounts_passwords_pam_faillock_unlock_time
+      label: Accounts Passwords Pam Faillock Unlock Time
+      description: ComplianceAsCode sets var_accounts_passwords_pam_faillock_unlock_time to '900' for this control.
+      accepted-values:
+      - '900'
+  - id: accounts_root_gid_zero
+    requirement-id: accounts_root_gid_zero
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: accounts_root_path_dirs_no_write
+    requirement-id: accounts_root_path_dirs_no_write
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: accounts_set_post_pw_existing
+    requirement-id: accounts_set_post_pw_existing
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_account_disable_post_pw_expiration
+      label: Account Disable Post Pw Expiration
+      description: ComplianceAsCode sets var_account_disable_post_pw_expiration to '45' for this control.
+      accepted-values:
+      - '45'
+  - id: accounts_tmout
+    requirement-id: accounts_tmout
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_accounts_tmout
+      label: Accounts Tmout
+      description: ComplianceAsCode sets var_accounts_tmout to '15_min' for this control.
+      accepted-values:
+      - 15_min
+  - id: accounts_umask_etc_bashrc
+    requirement-id: accounts_umask_etc_bashrc
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_accounts_user_umask
+      label: Accounts User Umask
+      description: ComplianceAsCode sets var_accounts_user_umask to '027' for this control.
+      accepted-values:
+      - '027'
+  - id: accounts_umask_etc_login_defs
+    requirement-id: accounts_umask_etc_login_defs
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_accounts_user_umask
+      label: Accounts User Umask
+      description: ComplianceAsCode sets var_accounts_user_umask to '027' for this control.
+      accepted-values:
+      - '027'
+  - id: accounts_umask_etc_profile
+    requirement-id: accounts_umask_etc_profile
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_accounts_user_umask
+      label: Accounts User Umask
+      description: ComplianceAsCode sets var_accounts_user_umask to '027' for this control.
+      accepted-values:
+      - '027'
+  - id: accounts_umask_root
+    requirement-id: accounts_umask_root
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: accounts_user_dot_group_ownership
+    requirement-id: accounts_user_dot_group_ownership
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: accounts_user_dot_user_ownership
+    requirement-id: accounts_user_dot_user_ownership
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: accounts_user_interactive_home_directory_exists
+    requirement-id: accounts_user_interactive_home_directory_exists
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: aide_build_database
+    requirement-id: aide_build_database
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: aide_check_audit_tools
+    requirement-id: aide_check_audit_tools
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: aide_periodic_cron_checking
+    requirement-id: aide_periodic_cron_checking
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_continue_loading
+    requirement-id: audit_rules_continue_loading
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_dac_modification_chmod
+    requirement-id: audit_rules_dac_modification_chmod
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_dac_modification_chown
+    requirement-id: audit_rules_dac_modification_chown
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_dac_modification_fchmod
+    requirement-id: audit_rules_dac_modification_fchmod
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_dac_modification_fchmodat
+    requirement-id: audit_rules_dac_modification_fchmodat
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_dac_modification_fchmodat2
+    requirement-id: audit_rules_dac_modification_fchmodat2
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_dac_modification_fchown
+    requirement-id: audit_rules_dac_modification_fchown
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_dac_modification_fchownat
+    requirement-id: audit_rules_dac_modification_fchownat
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_dac_modification_fremovexattr
+    requirement-id: audit_rules_dac_modification_fremovexattr
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_dac_modification_fsetxattr
+    requirement-id: audit_rules_dac_modification_fsetxattr
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_dac_modification_lchown
+    requirement-id: audit_rules_dac_modification_lchown
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_dac_modification_lremovexattr
+    requirement-id: audit_rules_dac_modification_lremovexattr
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_dac_modification_lsetxattr
+    requirement-id: audit_rules_dac_modification_lsetxattr
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_dac_modification_removexattr
+    requirement-id: audit_rules_dac_modification_removexattr
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_dac_modification_setxattr
+    requirement-id: audit_rules_dac_modification_setxattr
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_execution_chacl
+    requirement-id: audit_rules_execution_chacl
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_execution_chcon
+    requirement-id: audit_rules_execution_chcon
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_execution_setfacl
+    requirement-id: audit_rules_execution_setfacl
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_file_deletion_events_rename
+    requirement-id: audit_rules_file_deletion_events_rename
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_file_deletion_events_renameat
+    requirement-id: audit_rules_file_deletion_events_renameat
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_file_deletion_events_renameat2
+    requirement-id: audit_rules_file_deletion_events_renameat2
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_file_deletion_events_unlink
+    requirement-id: audit_rules_file_deletion_events_unlink
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_file_deletion_events_unlinkat
+    requirement-id: audit_rules_file_deletion_events_unlinkat
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_immutable
+    requirement-id: audit_rules_immutable
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_kernel_module_loading_delete
+    requirement-id: audit_rules_kernel_module_loading_delete
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_kernel_module_loading_finit
+    requirement-id: audit_rules_kernel_module_loading_finit
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_kernel_module_loading_init
+    requirement-id: audit_rules_kernel_module_loading_init
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_kernel_module_loading_query
+    requirement-id: audit_rules_kernel_module_loading_query
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_login_events_faillock
+    requirement-id: audit_rules_login_events_faillock
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_login_events_lastlog
+    requirement-id: audit_rules_login_events_lastlog
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_mac_modification_etc_selinux
+    requirement-id: audit_rules_mac_modification_etc_selinux
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_mac_modification_usr_share
+    requirement-id: audit_rules_mac_modification_usr_share
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_media_export
+    requirement-id: audit_rules_media_export
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_networkconfig_modification_etc_hosts
+    requirement-id: audit_rules_networkconfig_modification_etc_hosts
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_networkconfig_modification_etc_issue
+    requirement-id: audit_rules_networkconfig_modification_etc_issue
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_networkconfig_modification_etc_issue_net
+    requirement-id: audit_rules_networkconfig_modification_etc_issue_net
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_networkconfig_modification_etc_networkmanager_system_connections
+    requirement-id: audit_rules_networkconfig_modification_etc_networkmanager_system_connections
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_networkconfig_modification_etc_sysconfig_network
+    requirement-id: audit_rules_networkconfig_modification_etc_sysconfig_network
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_networkconfig_modification_hostname_file
+    requirement-id: audit_rules_networkconfig_modification_hostname_file
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_networkconfig_modification_networkmanager
+    requirement-id: audit_rules_networkconfig_modification_networkmanager
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_networkconfig_modification_setdomainname
+    requirement-id: audit_rules_networkconfig_modification_setdomainname
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_networkconfig_modification_sethostname
+    requirement-id: audit_rules_networkconfig_modification_sethostname
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_privileged_commands
+    requirement-id: audit_rules_privileged_commands
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_privileged_commands_kmod
+    requirement-id: audit_rules_privileged_commands_kmod
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_privileged_commands_usermod
+    requirement-id: audit_rules_privileged_commands_usermod
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_session_events_btmp
+    requirement-id: audit_rules_session_events_btmp
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_session_events_utmp
+    requirement-id: audit_rules_session_events_utmp
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_session_events_wtmp
+    requirement-id: audit_rules_session_events_wtmp
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_suid_auid_privilege_function
+    requirement-id: audit_rules_suid_auid_privilege_function
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_sysadmin_actions
+    requirement-id: audit_rules_sysadmin_actions
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_time_adjtimex
+    requirement-id: audit_rules_time_adjtimex
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_time_clock_settime
+    requirement-id: audit_rules_time_clock_settime
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_time_settimeofday
+    requirement-id: audit_rules_time_settimeofday
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_time_watch_localtime
+    requirement-id: audit_rules_time_watch_localtime
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_unsuccessful_file_modification_creat
+    requirement-id: audit_rules_unsuccessful_file_modification_creat
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_unsuccessful_file_modification_ftruncate
+    requirement-id: audit_rules_unsuccessful_file_modification_ftruncate
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_unsuccessful_file_modification_open
+    requirement-id: audit_rules_unsuccessful_file_modification_open
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_unsuccessful_file_modification_openat
+    requirement-id: audit_rules_unsuccessful_file_modification_openat
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_unsuccessful_file_modification_truncate
+    requirement-id: audit_rules_unsuccessful_file_modification_truncate
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_usergroup_modification_group
+    requirement-id: audit_rules_usergroup_modification_group
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_usergroup_modification_gshadow
+    requirement-id: audit_rules_usergroup_modification_gshadow
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_usergroup_modification_nsswitch_conf
+    requirement-id: audit_rules_usergroup_modification_nsswitch_conf
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_usergroup_modification_opasswd
+    requirement-id: audit_rules_usergroup_modification_opasswd
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_usergroup_modification_pam_conf
+    requirement-id: audit_rules_usergroup_modification_pam_conf
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_usergroup_modification_pamd
+    requirement-id: audit_rules_usergroup_modification_pamd
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_usergroup_modification_passwd
+    requirement-id: audit_rules_usergroup_modification_passwd
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_rules_usergroup_modification_shadow
+    requirement-id: audit_rules_usergroup_modification_shadow
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: audit_sudo_log_events
+    requirement-id: audit_sudo_log_events
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: auditd_data_disk_error_action
+    requirement-id: auditd_data_disk_error_action
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_auditd_disk_error_action
+      label: Auditd Disk Error Action
+      description: ComplianceAsCode sets var_auditd_disk_error_action to 'cis_fedora' for this control.
+      accepted-values:
+      - cis_fedora
+  - id: auditd_data_disk_full_action
+    requirement-id: auditd_data_disk_full_action
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_auditd_disk_full_action
+      label: Auditd Disk Full Action
+      description: ComplianceAsCode sets var_auditd_disk_full_action to 'cis_fedora' for this control.
+      accepted-values:
+      - cis_fedora
+  - id: auditd_data_retention_action_mail_acct
+    requirement-id: auditd_data_retention_action_mail_acct
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_auditd_action_mail_acct
+      label: Auditd Action Mail Acct
+      description: ComplianceAsCode sets var_auditd_action_mail_acct to 'root' for this control.
+      accepted-values:
+      - root
+  - id: auditd_data_retention_admin_space_left_action
+    requirement-id: auditd_data_retention_admin_space_left_action
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: auditd_data_retention_max_log_file
+    requirement-id: auditd_data_retention_max_log_file
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_auditd_max_log_file
+      label: Auditd Max Log File
+      description: ComplianceAsCode sets var_auditd_max_log_file to '8' for this control.
+      accepted-values:
+      - '8'
+  - id: auditd_data_retention_max_log_file_action
+    requirement-id: auditd_data_retention_max_log_file_action
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_auditd_max_log_file
+      label: Auditd Max Log File
+      description: ComplianceAsCode sets var_auditd_max_log_file to '8' for this control.
+      accepted-values:
+      - '8'
+    - id: var_auditd_max_log_file_action
+      label: Auditd Max Log File Action
+      description: ComplianceAsCode sets var_auditd_max_log_file_action to 'keep_logs' for this control.
+      accepted-values:
+      - keep_logs
+  - id: auditd_data_retention_space_left_action
+    requirement-id: auditd_data_retention_space_left_action
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_auditd_space_left_action
+      label: Auditd Space Left Action
+      description: ComplianceAsCode sets var_auditd_space_left_action to 'cis_fedora' for this control.
+      accepted-values:
+      - cis_fedora
+  - id: banner_etc_issue_cis
+    requirement-id: banner_etc_issue_cis
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: cis_banner_text
+      label: Cis Banner Text
+      description: ComplianceAsCode sets cis_banner_text to 'cis' for this control.
+      accepted-values:
+      - cis
+  - id: banner_etc_issue_net_cis
+    requirement-id: banner_etc_issue_net_cis
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: cis_banner_text
+      label: Cis Banner Text
+      description: ComplianceAsCode sets cis_banner_text to 'cis' for this control.
+      accepted-values:
+      - cis
+  - id: banner_etc_motd_cis
+    requirement-id: banner_etc_motd_cis
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: cis_banner_text
+      label: Cis Banner Text
+      description: ComplianceAsCode sets cis_banner_text to 'cis' for this control.
+      accepted-values:
+      - cis
+  - id: chronyd_run_as_chrony_user
+    requirement-id: chronyd_run_as_chrony_user
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: chronyd_specify_remote_server
+    requirement-id: chronyd_specify_remote_server
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: configure_custom_crypto_policy_cis
+    requirement-id: configure_custom_crypto_policy_cis
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: coredump_disable_backtraces
+    requirement-id: coredump_disable_backtraces
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: coredump_disable_storage
+    requirement-id: coredump_disable_storage
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: dconf_db_up_to_date
+    requirement-id: dconf_db_up_to_date
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: dconf_gnome_banner_enabled
+    requirement-id: dconf_gnome_banner_enabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: dconf_gnome_disable_automount
+    requirement-id: dconf_gnome_disable_automount
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: dconf_gnome_disable_automount_open
+    requirement-id: dconf_gnome_disable_automount_open
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: dconf_gnome_disable_autorun
+    requirement-id: dconf_gnome_disable_autorun
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: dconf_gnome_disable_user_list
+    requirement-id: dconf_gnome_disable_user_list
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: dconf_gnome_login_banner_text
+    requirement-id: dconf_gnome_login_banner_text
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: dconf_gnome_screensaver_idle_delay
+    requirement-id: dconf_gnome_screensaver_idle_delay
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: dconf_gnome_screensaver_lock_delay
+    requirement-id: dconf_gnome_screensaver_lock_delay
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_screensaver_lock_delay
+      label: Screensaver Lock Delay
+      description: ComplianceAsCode sets var_screensaver_lock_delay to '5_seconds' for this control.
+      accepted-values:
+      - 5_seconds
+  - id: dconf_gnome_screensaver_user_locks
+    requirement-id: dconf_gnome_screensaver_user_locks
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: dconf_gnome_session_idle_user_locks
+    requirement-id: dconf_gnome_session_idle_user_locks
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: dir_perms_world_writable_sticky_bits
+    requirement-id: dir_perms_world_writable_sticky_bits
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: directory_groupowner_sshd_config_d
+    requirement-id: directory_groupowner_sshd_config_d
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: directory_owner_sshd_config_d
+    requirement-id: directory_owner_sshd_config_d
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: directory_permissions_sshd_config_d
+    requirement-id: directory_permissions_sshd_config_d
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: directory_permissions_var_log_audit
+    requirement-id: directory_permissions_var_log_audit
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: disable_host_auth
+    requirement-id: disable_host_auth
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: disable_users_coredumps
+    requirement-id: disable_users_coredumps
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: disable_weak_deps
+    requirement-id: disable_weak_deps
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: ensure_fedora_gpgkey_installed
+    requirement-id: ensure_fedora_gpgkey_installed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: ensure_gpgcheck_globally_activated
+    requirement-id: ensure_gpgcheck_globally_activated
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: ensure_journald_and_rsyslog_not_active_together
+    requirement-id: ensure_journald_and_rsyslog_not_active_together
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: ensure_pam_wheel_group_empty
+    requirement-id: ensure_pam_wheel_group_empty
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_pam_wheel_group_for_su
+      label: Pam Wheel Group For Su
+      description: ComplianceAsCode sets var_pam_wheel_group_for_su to 'cis' for this control.
+      accepted-values:
+      - cis
+  - id: ensure_root_password_configured
+    requirement-id: ensure_root_password_configured
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_at_allow_exists
+    requirement-id: file_at_allow_exists
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_at_deny_not_exist
+    requirement-id: file_at_deny_not_exist
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_cron_allow_exists
+    requirement-id: file_cron_allow_exists
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_cron_deny_not_exist
+    requirement-id: file_cron_deny_not_exist
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_group_ownership_var_log_audit
+    requirement-id: file_group_ownership_var_log_audit
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_groupowner_at_allow
+    requirement-id: file_groupowner_at_allow
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_groupowner_backup_etc_group
+    requirement-id: file_groupowner_backup_etc_group
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_groupowner_backup_etc_gshadow
+    requirement-id: file_groupowner_backup_etc_gshadow
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_groupowner_backup_etc_passwd
+    requirement-id: file_groupowner_backup_etc_passwd
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_groupowner_backup_etc_shadow
+    requirement-id: file_groupowner_backup_etc_shadow
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_groupowner_boot_grub2
+    requirement-id: file_groupowner_boot_grub2
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_groupowner_cron_allow
+    requirement-id: file_groupowner_cron_allow
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_groupowner_cron_d
+    requirement-id: file_groupowner_cron_d
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_groupowner_cron_daily
+    requirement-id: file_groupowner_cron_daily
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_groupowner_cron_hourly
+    requirement-id: file_groupowner_cron_hourly
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_groupowner_cron_monthly
+    requirement-id: file_groupowner_cron_monthly
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_groupowner_cron_weekly
+    requirement-id: file_groupowner_cron_weekly
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_groupowner_cron_yearly
+    requirement-id: file_groupowner_cron_yearly
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_groupowner_crontab
+    requirement-id: file_groupowner_crontab
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_groupowner_etc_group
+    requirement-id: file_groupowner_etc_group
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_groupowner_etc_gshadow
+    requirement-id: file_groupowner_etc_gshadow
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_groupowner_etc_issue
+    requirement-id: file_groupowner_etc_issue
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_groupowner_etc_issue_net
+    requirement-id: file_groupowner_etc_issue_net
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_groupowner_etc_motd
+    requirement-id: file_groupowner_etc_motd
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_groupowner_etc_passwd
+    requirement-id: file_groupowner_etc_passwd
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_groupowner_etc_security_opasswd
+    requirement-id: file_groupowner_etc_security_opasswd
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_groupowner_etc_security_opasswd_old
+    requirement-id: file_groupowner_etc_security_opasswd_old
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_groupowner_etc_shadow
+    requirement-id: file_groupowner_etc_shadow
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_groupowner_etc_shells
+    requirement-id: file_groupowner_etc_shells
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_groupowner_sshd_config
+    requirement-id: file_groupowner_sshd_config
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_groupowner_sshd_drop_in_config
+    requirement-id: file_groupowner_sshd_drop_in_config
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_groupownership_audit_binaries
+    requirement-id: file_groupownership_audit_binaries
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_groupownership_audit_configuration
+    requirement-id: file_groupownership_audit_configuration
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_groupownership_sshd_private_key
+    requirement-id: file_groupownership_sshd_private_key
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_groupownership_sshd_pub_key
+    requirement-id: file_groupownership_sshd_pub_key
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_owner_at_allow
+    requirement-id: file_owner_at_allow
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_owner_backup_etc_group
+    requirement-id: file_owner_backup_etc_group
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_owner_backup_etc_gshadow
+    requirement-id: file_owner_backup_etc_gshadow
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_owner_backup_etc_passwd
+    requirement-id: file_owner_backup_etc_passwd
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_owner_backup_etc_shadow
+    requirement-id: file_owner_backup_etc_shadow
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_owner_boot_grub2
+    requirement-id: file_owner_boot_grub2
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_owner_cron_allow
+    requirement-id: file_owner_cron_allow
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_owner_cron_d
+    requirement-id: file_owner_cron_d
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_owner_cron_daily
+    requirement-id: file_owner_cron_daily
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_owner_cron_hourly
+    requirement-id: file_owner_cron_hourly
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_owner_cron_monthly
+    requirement-id: file_owner_cron_monthly
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_owner_cron_weekly
+    requirement-id: file_owner_cron_weekly
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_owner_cron_yearly
+    requirement-id: file_owner_cron_yearly
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_owner_crontab
+    requirement-id: file_owner_crontab
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_owner_etc_group
+    requirement-id: file_owner_etc_group
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_owner_etc_gshadow
+    requirement-id: file_owner_etc_gshadow
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_owner_etc_issue
+    requirement-id: file_owner_etc_issue
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_owner_etc_issue_net
+    requirement-id: file_owner_etc_issue_net
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_owner_etc_motd
+    requirement-id: file_owner_etc_motd
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_owner_etc_passwd
+    requirement-id: file_owner_etc_passwd
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_owner_etc_security_opasswd
+    requirement-id: file_owner_etc_security_opasswd
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_owner_etc_security_opasswd_old
+    requirement-id: file_owner_etc_security_opasswd_old
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_owner_etc_shadow
+    requirement-id: file_owner_etc_shadow
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_owner_etc_shells
+    requirement-id: file_owner_etc_shells
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_owner_sshd_config
+    requirement-id: file_owner_sshd_config
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_owner_sshd_drop_in_config
+    requirement-id: file_owner_sshd_drop_in_config
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_ownership_audit_binaries
+    requirement-id: file_ownership_audit_binaries
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_ownership_audit_configuration
+    requirement-id: file_ownership_audit_configuration
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_ownership_home_directories
+    requirement-id: file_ownership_home_directories
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_ownership_sshd_private_key
+    requirement-id: file_ownership_sshd_private_key
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_ownership_sshd_pub_key
+    requirement-id: file_ownership_sshd_pub_key
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_ownership_var_log_audit_stig
+    requirement-id: file_ownership_var_log_audit_stig
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permission_user_bash_history
+    requirement-id: file_permission_user_bash_history
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permission_user_init_files
+    requirement-id: file_permission_user_init_files
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permissions_at_allow
+    requirement-id: file_permissions_at_allow
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permissions_audit_binaries
+    requirement-id: file_permissions_audit_binaries
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permissions_audit_configuration
+    requirement-id: file_permissions_audit_configuration
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permissions_backup_etc_group
+    requirement-id: file_permissions_backup_etc_group
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permissions_backup_etc_gshadow
+    requirement-id: file_permissions_backup_etc_gshadow
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permissions_backup_etc_passwd
+    requirement-id: file_permissions_backup_etc_passwd
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permissions_backup_etc_shadow
+    requirement-id: file_permissions_backup_etc_shadow
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permissions_boot_grub2
+    requirement-id: file_permissions_boot_grub2
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permissions_cron_allow
+    requirement-id: file_permissions_cron_allow
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permissions_cron_d
+    requirement-id: file_permissions_cron_d
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permissions_cron_daily
+    requirement-id: file_permissions_cron_daily
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permissions_cron_hourly
+    requirement-id: file_permissions_cron_hourly
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permissions_cron_monthly
+    requirement-id: file_permissions_cron_monthly
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permissions_cron_weekly
+    requirement-id: file_permissions_cron_weekly
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permissions_cron_yearly
+    requirement-id: file_permissions_cron_yearly
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permissions_crontab
+    requirement-id: file_permissions_crontab
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permissions_etc_group
+    requirement-id: file_permissions_etc_group
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permissions_etc_gshadow
+    requirement-id: file_permissions_etc_gshadow
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permissions_etc_issue
+    requirement-id: file_permissions_etc_issue
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permissions_etc_issue_net
+    requirement-id: file_permissions_etc_issue_net
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permissions_etc_motd
+    requirement-id: file_permissions_etc_motd
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permissions_etc_passwd
+    requirement-id: file_permissions_etc_passwd
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permissions_etc_security_opasswd
+    requirement-id: file_permissions_etc_security_opasswd
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permissions_etc_security_opasswd_old
+    requirement-id: file_permissions_etc_security_opasswd_old
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permissions_etc_shadow
+    requirement-id: file_permissions_etc_shadow
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permissions_etc_shells
+    requirement-id: file_permissions_etc_shells
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permissions_home_directories
+    requirement-id: file_permissions_home_directories
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permissions_sshd_config
+    requirement-id: file_permissions_sshd_config
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permissions_sshd_drop_in_config
+    requirement-id: file_permissions_sshd_drop_in_config
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permissions_sshd_private_key
+    requirement-id: file_permissions_sshd_private_key
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permissions_sshd_pub_key
+    requirement-id: file_permissions_sshd_pub_key
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permissions_unauthorized_world_writable
+    requirement-id: file_permissions_unauthorized_world_writable
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: file_permissions_var_log_audit
+    requirement-id: file_permissions_var_log_audit
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: firewalld-backend
+    requirement-id: firewalld-backend
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: firewalld_loopback_traffic_trusted
+    requirement-id: firewalld_loopback_traffic_trusted
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: gid_passwd_group_same
+    requirement-id: gid_passwd_group_same
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: group_unique_id
+    requirement-id: group_unique_id
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: group_unique_name
+    requirement-id: group_unique_name
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: groups_no_zero_gid_except_root
+    requirement-id: groups_no_zero_gid_except_root
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: grub2_audit_argument
+    requirement-id: grub2_audit_argument
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: grub2_audit_backlog_limit_argument
+    requirement-id: grub2_audit_backlog_limit_argument
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_audit_backlog_limit
+      label: Audit Backlog Limit
+      description: ComplianceAsCode sets var_audit_backlog_limit to '8192' for this control.
+      accepted-values:
+      - '8192'
+  - id: grub2_enable_selinux
+    requirement-id: grub2_enable_selinux
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: grub2_password
+    requirement-id: grub2_password
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: has_nonlocal_mta
+    requirement-id: has_nonlocal_mta
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: journald_compress
+    requirement-id: journald_compress
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: journald_disable_forward_to_syslog
+    requirement-id: journald_disable_forward_to_syslog
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: journald_storage
+    requirement-id: journald_storage
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: kernel_module_atm_disabled
+    requirement-id: kernel_module_atm_disabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: kernel_module_can_disabled
+    requirement-id: kernel_module_can_disabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: kernel_module_cramfs_disabled
+    requirement-id: kernel_module_cramfs_disabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: kernel_module_dccp_disabled
+    requirement-id: kernel_module_dccp_disabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: kernel_module_firewire-core_disabled
+    requirement-id: kernel_module_firewire-core_disabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: kernel_module_freevxfs_disabled
+    requirement-id: kernel_module_freevxfs_disabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: kernel_module_hfs_disabled
+    requirement-id: kernel_module_hfs_disabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: kernel_module_hfsplus_disabled
+    requirement-id: kernel_module_hfsplus_disabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: kernel_module_jffs2_disabled
+    requirement-id: kernel_module_jffs2_disabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: kernel_module_overlayfs_disabled
+    requirement-id: kernel_module_overlayfs_disabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: kernel_module_rds_disabled
+    requirement-id: kernel_module_rds_disabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: kernel_module_sctp_disabled
+    requirement-id: kernel_module_sctp_disabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: kernel_module_squashfs_disabled
+    requirement-id: kernel_module_squashfs_disabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: kernel_module_tipc_disabled
+    requirement-id: kernel_module_tipc_disabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: kernel_module_udf_disabled
+    requirement-id: kernel_module_udf_disabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: kernel_module_usb-storage_disabled
+    requirement-id: kernel_module_usb-storage_disabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: mount_option_dev_shm_nodev
+    requirement-id: mount_option_dev_shm_nodev
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: mount_option_dev_shm_noexec
+    requirement-id: mount_option_dev_shm_noexec
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: mount_option_dev_shm_nosuid
+    requirement-id: mount_option_dev_shm_nosuid
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: mount_option_home_nodev
+    requirement-id: mount_option_home_nodev
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: mount_option_home_nosuid
+    requirement-id: mount_option_home_nosuid
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: mount_option_tmp_nodev
+    requirement-id: mount_option_tmp_nodev
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: mount_option_tmp_noexec
+    requirement-id: mount_option_tmp_noexec
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: mount_option_tmp_nosuid
+    requirement-id: mount_option_tmp_nosuid
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: mount_option_var_log_audit_nodev
+    requirement-id: mount_option_var_log_audit_nodev
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: mount_option_var_log_audit_noexec
+    requirement-id: mount_option_var_log_audit_noexec
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: mount_option_var_log_audit_nosuid
+    requirement-id: mount_option_var_log_audit_nosuid
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: mount_option_var_log_nodev
+    requirement-id: mount_option_var_log_nodev
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: mount_option_var_log_noexec
+    requirement-id: mount_option_var_log_noexec
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: mount_option_var_log_nosuid
+    requirement-id: mount_option_var_log_nosuid
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: mount_option_var_nodev
+    requirement-id: mount_option_var_nodev
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: mount_option_var_nosuid
+    requirement-id: mount_option_var_nosuid
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: mount_option_var_tmp_nodev
+    requirement-id: mount_option_var_tmp_nodev
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: mount_option_var_tmp_noexec
+    requirement-id: mount_option_var_tmp_noexec
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: mount_option_var_tmp_nosuid
+    requirement-id: mount_option_var_tmp_nosuid
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: no_empty_passwords
+    requirement-id: no_empty_passwords
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: no_empty_passwords_etc_shadow
+    requirement-id: no_empty_passwords_etc_shadow
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: no_files_or_dirs_ungroupowned
+    requirement-id: no_files_or_dirs_ungroupowned
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: no_files_or_dirs_unowned_by_user
+    requirement-id: no_files_or_dirs_unowned_by_user
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: no_forward_files
+    requirement-id: no_forward_files
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: no_invalid_shell_accounts_unlocked
+    requirement-id: no_invalid_shell_accounts_unlocked
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: no_netrc_files
+    requirement-id: no_netrc_files
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: no_nologin_in_shells
+    requirement-id: no_nologin_in_shells
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: no_password_auth_for_systemaccounts
+    requirement-id: no_password_auth_for_systemaccounts
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: no_rhost_files
+    requirement-id: no_rhost_files
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: no_shelllogin_for_systemaccounts
+    requirement-id: no_shelllogin_for_systemaccounts
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: package_aide_installed
+    requirement-id: package_aide_installed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: package_audit-libs_installed
+    requirement-id: package_audit-libs_installed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: package_audit_installed
+    requirement-id: package_audit_installed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: package_bind_removed
+    requirement-id: package_bind_removed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: package_cron_installed
+    requirement-id: package_cron_installed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: package_cyrus-imapd_removed
+    requirement-id: package_cyrus-imapd_removed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: package_dovecot_removed
+    requirement-id: package_dovecot_removed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: package_firewalld_installed
+    requirement-id: package_firewalld_installed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: package_ftp_removed
+    requirement-id: package_ftp_removed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: package_gdm_removed
+    requirement-id: package_gdm_removed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: package_httpd_removed
+    requirement-id: package_httpd_removed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: package_kea_removed
+    requirement-id: package_kea_removed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: package_libselinux_installed
+    requirement-id: package_libselinux_installed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: package_mcstrans_removed
+    requirement-id: package_mcstrans_removed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: package_net-snmp_removed
+    requirement-id: package_net-snmp_removed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: package_nginx_removed
+    requirement-id: package_nginx_removed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: package_openldap-clients_removed
+    requirement-id: package_openldap-clients_removed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: package_pam_pwquality_installed
+    requirement-id: package_pam_pwquality_installed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: package_postfix_installed
+    requirement-id: package_postfix_installed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: package_rsync_removed
+    requirement-id: package_rsync_removed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: package_samba_removed
+    requirement-id: package_samba_removed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: package_sequoia-sq_installed
+    requirement-id: package_sequoia-sq_installed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: package_setroubleshoot_removed
+    requirement-id: package_setroubleshoot_removed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: package_squid_removed
+    requirement-id: package_squid_removed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: package_sudo_installed
+    requirement-id: package_sudo_installed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: package_systemd-journal-remote_installed
+    requirement-id: package_systemd-journal-remote_installed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: package_telnet-server_removed
+    requirement-id: package_telnet-server_removed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: package_telnet_removed
+    requirement-id: package_telnet_removed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: package_tftp-server_removed
+    requirement-id: package_tftp-server_removed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: package_tftp_removed
+    requirement-id: package_tftp_removed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: package_vsftpd_removed
+    requirement-id: package_vsftpd_removed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: package_xorg-x11-server-Xwayland_removed
+    requirement-id: package_xorg-x11-server-Xwayland_removed
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: partition_for_dev_shm
+    requirement-id: partition_for_dev_shm
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: partition_for_home
+    requirement-id: partition_for_home
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: partition_for_tmp
+    requirement-id: partition_for_tmp
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: partition_for_var
+    requirement-id: partition_for_var
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: partition_for_var_log
+    requirement-id: partition_for_var_log
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: partition_for_var_log_audit
+    requirement-id: partition_for_var_log_audit
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: partition_for_var_tmp
+    requirement-id: partition_for_var_tmp
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: postfix_network_listening_disabled
+    requirement-id: postfix_network_listening_disabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_postfix_inet_interfaces
+      label: Postfix Inet Interfaces
+      description: ComplianceAsCode sets var_postfix_inet_interfaces to 'loopback-only' for this control.
+      accepted-values:
+      - loopback-only
+  - id: root_path_no_dot
+    requirement-id: root_path_no_dot
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: rsyslog_filecreatemode
+    requirement-id: rsyslog_filecreatemode
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: rsyslog_files_groupownership
+    requirement-id: rsyslog_files_groupownership
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: rsyslog_files_ownership
+    requirement-id: rsyslog_files_ownership
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: rsyslog_files_permissions
+    requirement-id: rsyslog_files_permissions
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: selinux_not_disabled
+    requirement-id: selinux_not_disabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: selinux_policytype
+    requirement-id: selinux_policytype
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_selinux_policy_name
+      label: Selinux Policy Name
+      description: ComplianceAsCode sets var_selinux_policy_name to 'targeted' for this control.
+      accepted-values:
+      - targeted
+  - id: selinux_state
+    requirement-id: selinux_state
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_selinux_state
+      label: Selinux State
+      description: ComplianceAsCode sets var_selinux_state to 'enforcing' for this control.
+      accepted-values:
+      - enforcing
+  - id: service_auditd_enabled
+    requirement-id: service_auditd_enabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: service_autofs_disabled
+    requirement-id: service_autofs_disabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: service_avahi-daemon_disabled
+    requirement-id: service_avahi-daemon_disabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: service_bluetooth_disabled
+    requirement-id: service_bluetooth_disabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: service_cockpit_disabled
+    requirement-id: service_cockpit_disabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: service_crond_enabled
+    requirement-id: service_crond_enabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: service_cups_disabled
+    requirement-id: service_cups_disabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: service_dnsmasq_disabled
+    requirement-id: service_dnsmasq_disabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: service_firewalld_enabled
+    requirement-id: service_firewalld_enabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: service_nfs_disabled
+    requirement-id: service_nfs_disabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: service_rpcbind_disabled
+    requirement-id: service_rpcbind_disabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: service_systemd-journal-upload_enabled
+    requirement-id: service_systemd-journal-upload_enabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: service_systemd-journald_enabled
+    requirement-id: service_systemd-journald_enabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: set_password_hashing_algorithm_logindefs
+    requirement-id: set_password_hashing_algorithm_logindefs
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_password_hashing_algorithm
+      label: Password Hashing Algorithm
+      description: ComplianceAsCode sets var_password_hashing_algorithm to 'cis_fedora' for this control.
+      accepted-values:
+      - cis_fedora
+  - id: set_password_hashing_algorithm_passwordauth
+    requirement-id: set_password_hashing_algorithm_passwordauth
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_password_hashing_algorithm
+      label: Password Hashing Algorithm
+      description: ComplianceAsCode sets var_password_hashing_algorithm to 'cis_fedora' for this control.
+      accepted-values:
+      - cis_fedora
+    - id: var_password_hashing_algorithm_pam
+      label: Password Hashing Algorithm Pam
+      description: ComplianceAsCode sets var_password_hashing_algorithm_pam to 'cis_fedora' for this control.
+      accepted-values:
+      - cis_fedora
+  - id: set_password_hashing_algorithm_systemauth
+    requirement-id: set_password_hashing_algorithm_systemauth
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_password_hashing_algorithm
+      label: Password Hashing Algorithm
+      description: ComplianceAsCode sets var_password_hashing_algorithm to 'cis_fedora' for this control.
+      accepted-values:
+      - cis_fedora
+    - id: var_password_hashing_algorithm_pam
+      label: Password Hashing Algorithm Pam
+      description: ComplianceAsCode sets var_password_hashing_algorithm_pam to 'cis_fedora' for this control.
+      accepted-values:
+      - cis_fedora
+  - id: socket_systemd-journal-remote_disabled
+    requirement-id: socket_systemd-journal-remote_disabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sshd_disable_empty_passwords
+    requirement-id: sshd_disable_empty_passwords
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sshd_disable_forwarding
+    requirement-id: sshd_disable_forwarding
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sshd_disable_gssapi_auth
+    requirement-id: sshd_disable_gssapi_auth
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sshd_disable_rhosts
+    requirement-id: sshd_disable_rhosts
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sshd_disable_root_login
+    requirement-id: sshd_disable_root_login
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sshd_do_not_permit_user_env
+    requirement-id: sshd_do_not_permit_user_env
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sshd_enable_pam
+    requirement-id: sshd_enable_pam
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sshd_enable_warning_banner_net
+    requirement-id: sshd_enable_warning_banner_net
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sshd_limit_user_access
+    requirement-id: sshd_limit_user_access
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sshd_set_idle_timeout
+    requirement-id: sshd_set_idle_timeout
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: sshd_idle_timeout_value
+      label: Sshd Idle Timeout
+      description: ComplianceAsCode sets sshd_idle_timeout_value to '5_minutes' for this control.
+      accepted-values:
+      - 5_minutes
+  - id: sshd_set_keepalive
+    requirement-id: sshd_set_keepalive
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_sshd_set_keepalive
+      label: Sshd Set Keepalive
+      description: ComplianceAsCode sets var_sshd_set_keepalive to '1' for this control.
+      accepted-values:
+      - '1'
+  - id: sshd_set_login_grace_time
+    requirement-id: sshd_set_login_grace_time
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_sshd_set_login_grace_time
+      label: Sshd Set Login Grace Time
+      description: ComplianceAsCode sets var_sshd_set_login_grace_time to '60' for this control.
+      accepted-values:
+      - '60'
+  - id: sshd_set_loglevel_verbose
+    requirement-id: sshd_set_loglevel_verbose
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sshd_set_max_auth_tries
+    requirement-id: sshd_set_max_auth_tries
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: sshd_max_auth_tries_value
+      label: Sshd Max Auth Tries
+      description: ComplianceAsCode sets sshd_max_auth_tries_value to '4' for this control.
+      accepted-values:
+      - '4'
+  - id: sshd_set_max_sessions
+    requirement-id: sshd_set_max_sessions
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_sshd_max_sessions
+      label: Sshd Max Sessions
+      description: ComplianceAsCode sets var_sshd_max_sessions to '10' for this control.
+      accepted-values:
+      - '10'
+  - id: sshd_set_maxstartups
+    requirement-id: sshd_set_maxstartups
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_sshd_set_maxstartups
+      label: Sshd Set Maxstartups
+      description: ComplianceAsCode sets var_sshd_set_maxstartups to '10:30:60' for this control.
+      accepted-values:
+      - 10:30:60
+  - id: sudo_add_use_pty
+    requirement-id: sudo_add_use_pty
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sudo_custom_logfile
+    requirement-id: sudo_custom_logfile
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sudo_remove_no_authenticate
+    requirement-id: sudo_remove_no_authenticate
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sudo_remove_nopasswd
+    requirement-id: sudo_remove_nopasswd
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sudo_require_reauthentication
+    requirement-id: sudo_require_reauthentication
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_sudo_timestamp_timeout
+      label: Sudo Timestamp Timeout
+      description: ComplianceAsCode sets var_sudo_timestamp_timeout to '15_minutes' for this control.
+      accepted-values:
+      - 15_minutes
+  - id: sysctl_fs_protected_hardlinks
+    requirement-id: sysctl_fs_protected_hardlinks
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sysctl_fs_protected_symlinks
+    requirement-id: sysctl_fs_protected_symlinks
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sysctl_fs_suid_dumpable
+    requirement-id: sysctl_fs_suid_dumpable
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sysctl_kernel_dmesg_restrict
+    requirement-id: sysctl_kernel_dmesg_restrict
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sysctl_kernel_kptr_restrict
+    requirement-id: sysctl_kernel_kptr_restrict
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sysctl_kernel_randomize_va_space
+    requirement-id: sysctl_kernel_randomize_va_space
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sysctl_kernel_yama_ptrace_scope
+    requirement-id: sysctl_kernel_yama_ptrace_scope
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sysctl_net_ipv4_conf_all_accept_redirects
+    requirement-id: sysctl_net_ipv4_conf_all_accept_redirects
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sysctl_net_ipv4_conf_all_accept_source_route
+    requirement-id: sysctl_net_ipv4_conf_all_accept_source_route
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sysctl_net_ipv4_conf_all_forwarding
+    requirement-id: sysctl_net_ipv4_conf_all_forwarding
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sysctl_net_ipv4_conf_all_log_martians
+    requirement-id: sysctl_net_ipv4_conf_all_log_martians
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sysctl_net_ipv4_conf_all_rp_filter
+    requirement-id: sysctl_net_ipv4_conf_all_rp_filter
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: sysctl_net_ipv4_conf_all_rp_filter_value
+      label: Sysctl Net Ipv4 Conf All Rp Filter
+      description: ComplianceAsCode sets sysctl_net_ipv4_conf_all_rp_filter_value to 'enabled' for this control.
+      accepted-values:
+      - enabled
+  - id: sysctl_net_ipv4_conf_all_secure_redirects
+    requirement-id: sysctl_net_ipv4_conf_all_secure_redirects
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sysctl_net_ipv4_conf_all_send_redirects
+    requirement-id: sysctl_net_ipv4_conf_all_send_redirects
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sysctl_net_ipv4_conf_default_accept_redirects
+    requirement-id: sysctl_net_ipv4_conf_default_accept_redirects
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sysctl_net_ipv4_conf_default_accept_source_route
+    requirement-id: sysctl_net_ipv4_conf_default_accept_source_route
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sysctl_net_ipv4_conf_default_forwarding
+    requirement-id: sysctl_net_ipv4_conf_default_forwarding
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sysctl_net_ipv4_conf_default_log_martians
+    requirement-id: sysctl_net_ipv4_conf_default_log_martians
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sysctl_net_ipv4_conf_default_rp_filter
+    requirement-id: sysctl_net_ipv4_conf_default_rp_filter
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sysctl_net_ipv4_conf_default_secure_redirects
+    requirement-id: sysctl_net_ipv4_conf_default_secure_redirects
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sysctl_net_ipv4_conf_default_send_redirects
+    requirement-id: sysctl_net_ipv4_conf_default_send_redirects
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sysctl_net_ipv4_icmp_echo_ignore_broadcasts
+    requirement-id: sysctl_net_ipv4_icmp_echo_ignore_broadcasts
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sysctl_net_ipv4_icmp_ignore_bogus_error_responses
+    requirement-id: sysctl_net_ipv4_icmp_ignore_bogus_error_responses
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sysctl_net_ipv4_ip_forward
+    requirement-id: sysctl_net_ipv4_ip_forward
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sysctl_net_ipv4_tcp_syncookies
+    requirement-id: sysctl_net_ipv4_tcp_syncookies
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sysctl_net_ipv6_conf_all_accept_ra
+    requirement-id: sysctl_net_ipv6_conf_all_accept_ra
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sysctl_net_ipv6_conf_all_accept_redirects
+    requirement-id: sysctl_net_ipv6_conf_all_accept_redirects
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sysctl_net_ipv6_conf_all_accept_source_route
+    requirement-id: sysctl_net_ipv6_conf_all_accept_source_route
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sysctl_net_ipv6_conf_all_forwarding
+    requirement-id: sysctl_net_ipv6_conf_all_forwarding
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sysctl_net_ipv6_conf_default_accept_ra
+    requirement-id: sysctl_net_ipv6_conf_default_accept_ra
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sysctl_net_ipv6_conf_default_accept_redirects
+    requirement-id: sysctl_net_ipv6_conf_default_accept_redirects
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sysctl_net_ipv6_conf_default_accept_source_route
+    requirement-id: sysctl_net_ipv6_conf_default_accept_source_route
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: sysctl_net_ipv6_conf_default_forwarding
+    requirement-id: sysctl_net_ipv6_conf_default_forwarding
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: use_pam_wheel_group_for_su
+    requirement-id: use_pam_wheel_group_for_su
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+    parameters:
+    - id: var_pam_wheel_group_for_su
+      label: Pam Wheel Group For Su
+      description: ComplianceAsCode sets var_pam_wheel_group_for_su to 'cis' for this control.
+      accepted-values:
+      - cis
+  - id: wireless_disable_interfaces
+    requirement-id: wireless_disable_interfaces
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated
+  - id: xwayland_disabled
+    requirement-id: xwayland_disabled
+    frequency: on-demand
+    evaluation-methods:
+    - id: openscap-automated
+      type: Behavioral
+      mode: Automated


### PR DESCRIPTION
Adds Gemara-compliant artifacts for NIST SP 800-53 Revision 5 compliance evaluation on Fedora systems.

Source: ComplianceAsCode/content
Branch: add-nist-800-53-fedora-control
Testing: Validated with Complytime scan on Fedora 39

Artifacts:
- Bundle manifest (3 layers)
- Control catalog (1,196 controls, 439 rules, 539 mappings)
- Policy (439 assessment plans with OpenSCAP evaluation)

Scan results: 17 requirements tested (9 passed, 8 failed)
Controls verified: AC, AU, IA, SC, SI families

This PR complements the RHEL artifacts and enables Complytime compliance scanning for Fedora distributions.