### PR TITLE
fix: resolve workflow lint issues from zizmor, actionlint, and shellcheck

### DIFF
--- a/.github/workflows/cue-validate.yml
+++ b/.github/workflows/cue-validate.yml
@@ -71,16 +71,20 @@ jobs:
             if ! output=$(cue vet -c -d "${SCHEMA_DEF}" "github.com/gemaraproj/gemara@${GEMARA_VERSION}" "$f" 2>&1); then
               echo "::error file=$f::CUE validation failed for ${TYPE_VALUE}"
               if [ "$failed" -eq 0 ]; then
-                echo "### Failed: ${SCHEMA_NAME} (\`${SCHEMA_DEF}\`)" >> "${GITHUB_STEP_SUMMARY}"
-                echo "" >> "${GITHUB_STEP_SUMMARY}"
+                {
+                  echo "### Failed: ${SCHEMA_NAME} (\`${SCHEMA_DEF}\`)"
+                  echo ""
+                } >> "${GITHUB_STEP_SUMMARY}"
               fi
-              echo "<details><summary><code>$f</code></summary>" >> "${GITHUB_STEP_SUMMARY}"
-              echo "" >> "${GITHUB_STEP_SUMMARY}"
-              echo '```' >> "${GITHUB_STEP_SUMMARY}"
-              echo "$output" >> "${GITHUB_STEP_SUMMARY}"
-              echo '```' >> "${GITHUB_STEP_SUMMARY}"
-              echo "</details>" >> "${GITHUB_STEP_SUMMARY}"
-              echo "" >> "${GITHUB_STEP_SUMMARY}"
+              {
+                echo "<details><summary><code>$f</code></summary>"
+                echo ""
+                echo '```'
+                echo "$output"
+                echo '```'
+                echo "</details>"
+                echo ""
+              } >> "${GITHUB_STEP_SUMMARY}"
               failed=1
             else
               echo "✓ $f"

--- a/.github/workflows/publish-policy-oci.yml
+++ b/.github/workflows/publish-policy-oci.yml
@@ -45,17 +45,19 @@ concurrency:
 
 permissions:
   contents: read
-  id-token: write
-  packages: write
 
 jobs:
   discover:
     name: Discover bundles
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       matrix: ${{ steps.bundles.outputs.matrix }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Build bundle matrix from bundles/
         id: bundles
@@ -84,6 +86,10 @@ jobs:
     name: "Publish ${{ matrix.bundle.name }}"
     needs: discover
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
     if: needs.discover.outputs.matrix != '[]'
     strategy:
       fail-fast: false
@@ -103,6 +109,8 @@ jobs:
           fi
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Restore last published content hash
         id: last_bundle_hash
@@ -151,11 +159,12 @@ jobs:
           DEST_NS: ${{ inputs.dest_namespace || 'complytime' }}
         run: |
           set -euo pipefail
-          r='${{ github.repository }}'
           repo_name="policies-${BUNDLE_NAME}"
-          echo "ghcr_repo=${r,,}/${repo_name}" >> "$GITHUB_OUTPUT"
-          echo "dest_repo=${DEST_NS}/${repo_name}" >> "$GITHUB_OUTPUT"
-          echo "bundle_tag=latest" >> "$GITHUB_OUTPUT"
+          {
+            echo "ghcr_repo=${GITHUB_REPOSITORY,,}/${repo_name}"
+            echo "dest_repo=${DEST_NS}/${repo_name}"
+            echo "bundle_tag=latest"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Publish bundle, sign, verify, and promote
         id: publish
@@ -186,11 +195,16 @@ jobs:
 
       - name: Print release refs
         if: steps.gate.outputs.proceed == 'true'
+        env:
+          BUNDLE_NAME: ${{ matrix.bundle.name }}
+          SOURCE_REF: ${{ steps.publish.outputs.source_ref }}
+          DESTINATION_REF: ${{ steps.publish.outputs.destination_ref }}
+          VERIFIED_DEST: ${{ steps.publish.outputs.verified_destination }}
         run: |
-          echo "bundle=${{ matrix.bundle.name }}"
-          echo "source_ref=${{ steps.publish.outputs.source_ref }}"
-          echo "destination_ref=${{ steps.publish.outputs.destination_ref }}"
-          echo "verified_destination=${{ steps.publish.outputs.verified_destination }}"
+          echo "bundle=${BUNDLE_NAME}"
+          echo "source_ref=${SOURCE_REF}"
+          echo "destination_ref=${DESTINATION_REF}"
+          echo "verified_destination=${VERIFIED_DEST}"
 
       - name: Install ORAS
         if: steps.gate.outputs.proceed == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
           fi
 
       - name: Checkout code
+        # zizmor: ignore[artipacked] -- persist-credentials required for git push of tags
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0

--- a/.github/workflows/release_notes_preview.yml
+++ b/.github/workflows/release_notes_preview.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Draft release notes (dry run)
         id: drafter


### PR DESCRIPTION
## Summary

Resolves all lint failures reported by the `Standardized CI / Run linters` job
(zizmor, actionlint/shellcheck, yamllint) across four workflow files.

## Changes

### `publish-policy-oci.yml` (5 fixes)

| Finding | Severity | Fix |
|---------|----------|-----|
| `excessive-permissions` | HIGH | Move `id-token: write` and `packages: write` from workflow-level to `publish` job permissions |
| `artipacked` | MEDIUM | Add `persist-credentials: false` to both checkout steps |
| `template-injection` | INFO | Move step outputs from \${{ }} templates in `run:` blocks to `env:` vars |
| template in `run:` | best practice | Replace `\${{ github.repository }}` with default `GITHUB_REPOSITORY` env var |
| `SC2129` | style | Group consecutive `>> "\$GITHUB_OUTPUT"` redirects |

### `cue-validate.yml` (1 fix)

| Finding | Severity | Fix |
|---------|----------|-----|
| `SC2129` | style | Group consecutive `>> "\$GITHUB_STEP_SUMMARY"` redirects |

### `release_notes_preview.yml` (1 fix)

| Finding | Severity | Fix |
|---------|----------|-----|
| `artipacked` | MEDIUM | Add `persist-credentials: false` to checkout (no git push in this workflow) |

### `release.yml` (1 fix -- comment only)

| Finding | Severity | Fix |
|---------|----------|-----|
| `artipacked` | MEDIUM | Inline `zizmor: ignore[artipacked]` -- this workflow requires persisted credentials for `git push` of tags. A full rework to use `persist-credentials: false` with an alternative push mechanism is planned for a separate session. |

## Verification

All three linters pass cleanly across all 8 workflow files after these changes:

```
zizmor:     No findings to report. Good job! (1 ignored, 28 suppressed) — exit 0
actionlint: (no output) — exit 0
yamllint:   (no output) — exit 0
```

## References

- CI failure: https://github.com/complytime/complytime-policies/actions/runs/34219501860/job/102039022661
- [zizmor artipacked docs](https://docs.zizmor.sh/audits/#artipacked)
- [zizmor excessive-permissions docs](https://docs.zizmor.sh/audits/#excessive-permissions)
- [zizmor template-injection docs](https://docs.zizmor.sh/audits/#template-injection)
- [shellcheck SC2129](https://www.shellcheck.net/wiki/SC2129)
- Related PRs
  - https://github.com/complytime/complytime-policies/pull/57
  - https://github.com/complytime/complytime-policies/pull/58
  - https://github.com/complytime/complytime-policies/pull/59
  - https://github.com/complytime/complytime-policies/pull/60
  - https://github.com/complytime/complytime-policies/pull/61